### PR TITLE
feat(mcp): add MCP server integration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,56 @@ services: {
 }
 ```
 
+## MCP Server
+
+ZAPS exposes an [MCP](https://modelcontextprotocol.io/) server that lets AI agents manage services, run tasks, and read logs.
+
+```bash
+zaps mcp                   # auto-detects session from CWD
+zaps mcp --session my-app  # target specific session
+```
+
+### Available Tools
+
+| Tool                   | Description                          |
+| ---------------------- | ------------------------------------ |
+| `services_list`        | List all services and their statuses |
+| `services_details`     | Get details for a specific service   |
+| `services_start`       | Start a service                      |
+| `services_stop`        | Stop a service                       |
+| `services_restart`     | Restart a service                    |
+| `services_start_all`   | Start all (or specific) services     |
+| `services_stop_all`    | Stop all (or specific) services      |
+| `services_restart_all` | Restart all (or specific) services   |
+| `logs_snapshot`        | Get recent log lines for a service   |
+| `tasks_list`           | List available tasks                 |
+| `tasks_run`            | Run a task and return its output     |
+
+### Resources
+
+| URI                         | Description                    |
+| --------------------------- | ------------------------------ |
+| `zaps://logs/{serviceName}` | Live log output (subscribable) |
+
+### Claude Code Setup
+
+```bash
+claude mcp add zaps -- zaps mcp
+```
+
+Or manually add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "zaps": {
+      "command": "zaps",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "build": "tsx scripts/build.ts",
     "build:native": "bun run scripts/build-native.ts",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run -c test/integration/vitest.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "oxfmt --check; oxlint --type-aware --deny-warnings",
     "lint:fix": "oxfmt --write; oxlint --fix --fix-suggestions --fix-dangerously --deny-warnings --type-aware",
-    "check": "pnpm typecheck && pnpm lint:fix && pnpm build && pnpm test"
+    "check": "pnpm typecheck && pnpm lint:fix && pnpm build && pnpm build:native && pnpm test:coverage"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/node": "^25.2.3",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -430,6 +433,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -453,6 +462,16 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.31.0':
     resolution: {integrity: sha512-2A7s+TmsY7xF3yM0VWXq2YJ82Z7Rd7AOKraotyp58Fbk7q9cFZKczW6Zrz/iaMaJYfR/UHDxF3kMR11vayflug==}
@@ -946,6 +965,21 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -1052,6 +1086,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -1077,9 +1115,21 @@ packages:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1131,12 +1181,32 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -1183,6 +1253,10 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   docker-compose@1.3.1:
     resolution: {integrity: sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w==}
     engines: {node: '>= 6.0.0'}
@@ -1195,8 +1269,15 @@ packages:
     resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
     engines: {node: '>= 8.0'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1207,6 +1288,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -1214,8 +1299,20 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
@@ -1234,12 +1331,19 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -1252,12 +1356,36 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1268,9 +1396,21 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1280,6 +1420,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1288,9 +1431,17 @@ packages:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -1300,6 +1451,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1307,8 +1462,28 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.3:
+    resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1342,6 +1517,14 @@ packages:
       react-devtools-core:
         optional: true
 
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1368,6 +1551,9 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -1402,11 +1588,20 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -1436,6 +1631,26 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1472,9 +1687,25 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1509,6 +1740,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1520,6 +1755,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1534,6 +1772,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1561,8 +1803,24 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-devtools-core@7.0.1:
     resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
@@ -1595,6 +1853,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1610,6 +1872,10 @@ packages:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -1632,6 +1898,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1642,6 +1919,22 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1678,6 +1971,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1783,6 +2080,10 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1794,6 +2095,10 @@ packages:
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1810,12 +2115,20 @@ packages:
     resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
     engines: {node: '>=20.18.1'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1970,6 +2283,11 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2178,6 +2496,10 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.9(hono@4.12.3)':
+    dependencies:
+      hono: 4.12.3
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2204,6 +2526,28 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.3)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.3
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@oxfmt/binding-android-arm-eabi@0.31.0':
     optional: true
@@ -2548,6 +2892,22 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -2656,6 +3016,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -2681,7 +3055,19 @@ snapshots:
 
   byline@5.0.0: {}
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -2734,9 +3120,22 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-to-spaces@2.0.1: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -2774,6 +3173,8 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  depd@2.0.0: {}
+
   docker-compose@1.3.1:
     dependencies:
       yaml: 2.8.2
@@ -2799,7 +3200,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2807,13 +3216,23 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
   environment@1.1.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   es-toolkit@1.44.0: {}
 
@@ -2877,11 +3296,15 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@2.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
 
@@ -2893,29 +3316,112 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-port@7.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -2930,11 +3436,33 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.3: {}
+
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2981,6 +3509,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ip-address@10.0.1: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-docker@3.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2996,6 +3528,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -3034,9 +3568,15 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@6.1.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -3066,6 +3606,18 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-fn@2.1.0: {}
 
   minimatch@5.1.6:
@@ -3089,7 +3641,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -3166,6 +3728,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parseurl@1.3.3: {}
+
   patch-console@2.0.0: {}
 
   path-key@3.1.1: {}
@@ -3175,6 +3739,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-to-regexp@8.3.0: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -3182,6 +3748,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.6:
     dependencies:
@@ -3220,10 +3788,28 @@ snapshots:
       '@types/node': 25.2.3
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-devtools-core@7.0.1:
     dependencies:
@@ -3270,6 +3856,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@4.0.0:
@@ -3310,6 +3898,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   safe-buffer@5.1.2: {}
@@ -3322,6 +3920,33 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -3329,6 +3954,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3363,6 +4016,8 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -3516,6 +4171,8 @@ snapshots:
 
   tmp@0.2.5: {}
 
+  toidentifier@1.0.1: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.3
@@ -3529,6 +4186,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@5.26.5: {}
@@ -3537,9 +4200,13 @@ snapshots:
 
   undici@7.21.0: {}
 
+  unpipe@1.0.0: {}
+
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -3682,5 +4349,9 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -884,6 +884,32 @@ daemonCmd
     process.stdout.write(`${res.result as string}\n`);
   });
 
+program
+  .command("mcp")
+  .description("Start MCP server for AI tool integration")
+  .option("-s, --session <id>", "Target session (auto-detected from CWD)")
+  .action(async (opts: { session?: string }) => {
+    if (!isDaemonRunning()) {
+      process.stderr.write("Daemon not running. Start with `zaps daemon start`.\n");
+      process.exit(1);
+    }
+    const sock = socketPath();
+    const res = await ipcRequest(sock, "session.list");
+    if (res.error) {
+      process.stderr.write(`Error: ${res.error}\n`);
+      process.exit(1);
+    }
+    // eslint-disable-next-line no-unsafe-type-assertion -- IPC boundary
+    const sessions = res.result as SessionInfo[];
+    if (sessions.length === 0) {
+      process.stderr.write("No active sessions.\n");
+      process.exit(1);
+    }
+    const target = resolveTargetSession(sessions, opts.session);
+    const { startMcpServer } = await import("./mcp/server.js");
+    await startMcpServer(sock, target.id);
+  });
+
 if (process.argv.length === 2) {
   process.argv.push("up");
 }

--- a/src/daemon/log-monitor.ts
+++ b/src/daemon/log-monitor.ts
@@ -56,6 +56,8 @@ export class LogMonitor {
             }
             this.listener?.(serviceName, newLines);
           }
+        } catch {
+          /* Pane may have been destroyed during shutdown — ignore */
         } finally {
           fetching = false;
         }

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -4,9 +4,14 @@ import path from "node:path";
 
 import { getEnv } from "./env.js";
 
+function socketArgs(): string[] {
+  const socket = getEnv("ZAPS_TMUX_SOCKET");
+  return socket ? ["-L", socket] : [];
+}
+
 async function run(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn("tmux", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
     proc.stdout.on("data", (d: Buffer) => (stdout += d));
@@ -197,7 +202,7 @@ export async function displayPopup(opts: DisplayPopupOptions): Promise<void> {
     }
     args.push("--", opts.command);
 
-    const proc = spawn("tmux", args, { stdio: "ignore" });
+    const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: "ignore" });
     proc.on("close", (code: number | null) => {
       if (code === 0) {
         resolve();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,268 @@
+import { ipcRequest, ipcStream, ipcSubscribe } from "#src/lib/ipc/client.js";
+import type { DaemonEvent } from "#src/lib/ipc/protocol.js";
+import type { ServiceStatus } from "#src/lib/service/types.js";
+/* eslint-disable no-unsafe-type-assertion -- IPC boundary */
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+async function startMcpServer(socketPath: string, sessionId: string): Promise<void> {
+  const server = new McpServer(
+    { name: "zaps", version: "0.1.0" },
+    { capabilities: { resources: { subscribe: true, listChanged: true } } },
+  );
+
+  async function request(method: string, params?: unknown): Promise<unknown> {
+    const res = await ipcRequest(socketPath, method, params, 30_000, sessionId);
+    if (res.error) {
+      throw new Error(res.error);
+    }
+    return res.result;
+  }
+
+  // --- Tools ---
+
+  server.registerTool(
+    "services_list",
+    {
+      description: "List all services and their statuses",
+      annotations: { readOnlyHint: true },
+    },
+    async () => ({
+      content: [
+        { type: "text" as const, text: JSON.stringify(await request("services.list"), null, 2) },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_details",
+    {
+      description: "Get details for a specific service",
+      inputSchema: { name: z.string().describe("Service name") },
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(await request("services.details", { name: args.name }), null, 2),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_start",
+    {
+      description: "Start a service",
+      inputSchema: { name: z.string().describe("Service name") },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(await request("services.start", { name: args.name })),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_stop",
+    {
+      description: "Stop a service",
+      inputSchema: { name: z.string().describe("Service name") },
+      annotations: { destructiveHint: true },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(await request("services.stop", { name: args.name })),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_restart",
+    {
+      description: "Restart a service",
+      inputSchema: { name: z.string().describe("Service name") },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(await request("services.restart", { name: args.name })),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_start_all",
+    {
+      description: "Start all services, or specific ones by name",
+      inputSchema: {
+        names: z.array(z.string()).optional().describe("Service names (omit for all)"),
+      },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            await request("services.startAll", args.names ? { names: args.names } : undefined),
+          ),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_stop_all",
+    {
+      description: "Stop all services, or specific ones by name",
+      inputSchema: {
+        names: z.array(z.string()).optional().describe("Service names (omit for all)"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            await request("services.stopAll", args.names ? { names: args.names } : undefined),
+          ),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "services_restart_all",
+    {
+      description: "Restart all services, or specific ones by name",
+      inputSchema: {
+        names: z.array(z.string()).optional().describe("Service names (omit for all)"),
+      },
+    },
+    async (args) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            await request("services.restartAll", args.names ? { names: args.names } : undefined),
+          ),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "logs_snapshot",
+    {
+      description: "Get recent log lines for a service",
+      inputSchema: { service: z.string().describe("Service name") },
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      const lines = (await request("logs.snapshot", { service: args.service })) as string[];
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    },
+  );
+
+  server.registerTool(
+    "tasks_list",
+    {
+      description: "List available tasks",
+      annotations: { readOnlyHint: true },
+    },
+    async () => ({
+      content: [
+        { type: "text" as const, text: JSON.stringify(await request("tasks.list"), null, 2) },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "tasks_run",
+    {
+      description: "Run a task and return its output",
+      inputSchema: { key: z.string().describe("Task key") },
+    },
+    async (args) => {
+      const lines: string[] = [];
+      const res = await ipcStream(
+        socketPath,
+        "tasks.run",
+        { key: args.key },
+        (event, data) => {
+          if (event === "line") {
+            lines.push(data as string);
+          }
+        },
+        120_000,
+        sessionId,
+      );
+      if (res.error) {
+        return { content: [{ type: "text" as const, text: `Error: ${res.error}` }], isError: true };
+      }
+      const result = res.result as { success: boolean };
+      const output = lines.join("\n");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: output || (result.success ? "Task completed." : "Task failed."),
+          },
+        ],
+        isError: !result.success,
+      };
+    },
+  );
+
+  // --- Resources: live log streaming ---
+
+  server.registerResource(
+    "service-logs",
+    new ResourceTemplate("zaps://logs/{serviceName}", {
+      list: async () => {
+        const statuses = (await request("services.list")) as ServiceStatus[];
+        return {
+          resources: statuses.map((s) => ({
+            uri: `zaps://logs/${s.name}`,
+            name: `${s.name} logs`,
+            description: `Log output for ${s.name}`,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+    }),
+    { description: "Live log output for a service", mimeType: "text/plain" },
+    async (uri, variables) => {
+      const serviceName = variables.serviceName as string;
+      const lines = (await request("logs.snapshot", { service: serviceName })) as string[];
+      return {
+        contents: [{ uri: uri.href, text: lines.join("\n"), mimeType: "text/plain" }],
+      };
+    },
+  );
+
+  // Subscribe to daemon log events → push resource update notifications
+  ipcSubscribe(socketPath, sessionId, ["log.lines"], (event: DaemonEvent) => {
+    if (event.event === "log.lines") {
+      const data = event.data as { service: string };
+      // eslint-disable-next-line no-void -- Fire-and-forget notification
+      void server.server.sendResourceUpdated({ uri: `zaps://logs/${data.service}` });
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+export { startMcpServer };

--- a/test/integration/daemon/cli-helpers.test.ts
+++ b/test/integration/daemon/cli-helpers.test.ts
@@ -1,0 +1,76 @@
+import { CliError, formatTable, resolveTargetSession } from "#src/cli/helpers.js";
+import type { SessionInfo } from "#src/cli/helpers.js";
+import { describe, expect, it } from "vitest";
+
+const sessions: SessionInfo[] = [
+  { id: "abc123def456", name: "my-app", projectDir: "/projects/my-app" },
+  { id: "xyz789ghi012", name: "api-server", projectDir: "/projects/api-server" },
+  { id: "abc999zzz000", name: "other", projectDir: "/projects/other" },
+];
+
+describe("resolveTargetSession", () => {
+  it("matches exact id", () => {
+    const result = resolveTargetSession(sessions, "abc123def456");
+    expect(result.id).toBe("abc123def456");
+    expect(result.name).toBe("my-app");
+  });
+
+  it("matches exact name", () => {
+    const result = resolveTargetSession(sessions, "api-server");
+    expect(result.id).toBe("xyz789ghi012");
+  });
+
+  it("matches id prefix (unique)", () => {
+    const result = resolveTargetSession(sessions, "xyz");
+    expect(result.id).toBe("xyz789ghi012");
+  });
+
+  it("matches name prefix (unique)", () => {
+    const result = resolveTargetSession(sessions, "api-");
+    expect(result.id).toBe("xyz789ghi012");
+  });
+
+  it("throws CliError on ambiguous prefix", () => {
+    // "abc" matches both abc123def456 and abc999zzz000
+    expect(() => resolveTargetSession(sessions, "abc")).toThrow(CliError);
+    expect(() => resolveTargetSession(sessions, "abc")).toThrow(/Ambiguous session/);
+  });
+
+  it("throws CliError when not found", () => {
+    expect(() => resolveTargetSession(sessions, "zzz-no-match")).toThrow(CliError);
+    expect(() => resolveTargetSession(sessions, "zzz-no-match")).toThrow(/Session not found/);
+  });
+
+  it("auto-selects when no arg and single session", () => {
+    const single = [sessions[0]];
+    const result = resolveTargetSession(single);
+    expect(result.id).toBe("abc123def456");
+  });
+
+  it("throws CliError when no arg and multiple sessions", () => {
+    expect(() => resolveTargetSession(sessions)).toThrow(CliError);
+    expect(() => resolveTargetSession(sessions)).toThrow(/Multiple sessions/);
+  });
+});
+
+describe("formatTable", () => {
+  it("pads columns correctly", () => {
+    const rows = [
+      ["id", "name", "dir"],
+      ["abc123", "my-app", "/projects/a"],
+      ["x", "b", "/p"],
+    ];
+    const result = formatTable(rows);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3);
+    // All lines should have same column alignment
+    // "id" padded to 6 (length of "abc123"), "name" padded to 6 (length of "my-app")
+    expect(lines[0]).toBe("id      name    dir        ");
+    expect(lines[1]).toBe("abc123  my-app  /projects/a");
+    expect(lines[2]).toBe("x       b       /p         ");
+  });
+
+  it("returns empty string for empty rows", () => {
+    expect(formatTable([])).toBe("");
+  });
+});

--- a/test/integration/daemon/client.test.ts
+++ b/test/integration/daemon/client.test.ts
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { DaemonClient } from "#src/client/daemon-client.js";
+import { ipcRequest } from "#src/lib/ipc/client.js";
+import type { ServiceStatus } from "#src/lib/service/types.js";
+import type { TestDaemon } from "../helpers/daemon.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createTestDaemon,
+  waitForAllServices,
+  waitForServiceState,
+  writeMultiServiceConfig,
+} from "../helpers/daemon.js";
+import { getFreePort } from "../helpers/port.js";
+import { hasTmux } from "../helpers/skip.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+describe.skipIf(!hasTmux())("DaemonClient integration", () => {
+  let daemon: TestDaemon;
+  let tmux: TestSession;
+  let tmpDir: string;
+  let sid: string;
+  let client: DaemonClient;
+  let port1: number;
+  let port2: number;
+
+  beforeAll(async () => {
+    daemon = await createTestDaemon();
+    tmux = await createTestSession();
+    port1 = await getFreePort();
+    port2 = await getFreePort();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-client-"));
+    writeMultiServiceConfig(tmpDir, port1, port2);
+
+    const configPath = path.join(tmpDir, ".zaps.mjs");
+    const res = await ipcRequest(daemon.socketPath, "session.create", {
+      configPath,
+      projectDir: tmpDir,
+      tmuxSession: tmux.name,
+      originPane: tmux.initialPaneId,
+    });
+    sid = (res.result as { id: string }).id;
+
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "ready");
+
+    client = new DaemonClient(daemon.socketPath, sid);
+  });
+
+  afterAll(async () => {
+    try {
+      client.disconnect();
+    } catch {
+      /* Best-effort */
+    }
+    try {
+      await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+    } catch {
+      /* Best-effort cleanup */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await daemon.cleanup();
+    await tmux.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Connection ─────────────────────────────────────────────────────
+
+  it("connect() sets connected to true", async () => {
+    client.connect();
+    // Allow subscription to establish
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(client.connected).toBe(true);
+  });
+
+  it("session getter returns session id", () => {
+    expect(client.session).toBe(sid);
+  });
+
+  // ── Session operations ─────────────────────────────────────────────
+
+  it("attach() returns valid SessionSnapshot", async () => {
+    const snap = await client.attach();
+    expect(snap.id).toBe(sid);
+    expect(snap.name).toBe("test-multi");
+    expect(snap.paneMap).toBeDefined();
+    expect(snap.statuses.length).toBeGreaterThan(0);
+    expect(snap.servicesMeta.length).toBeGreaterThan(0);
+  });
+
+  // ── Service operations ─────────────────────────────────────────────
+
+  it("listServices() returns service statuses", async () => {
+    const statuses = await client.listServices();
+    expect(statuses).toHaveLength(2);
+    const names = statuses.map((s) => s.name).toSorted();
+    expect(names).toEqual(["api", "web"]);
+  });
+
+  it("stopService() transitions service to stopped", async () => {
+    await client.stopService("api");
+    await waitForServiceState(daemon.socketPath, sid, "api", "stopped");
+
+    const statuses = await client.listServices();
+    const api = statuses.find((s) => s.name === "api");
+    expect(api?.state).toBe("stopped");
+  });
+
+  it("startService() transitions service to ready", async () => {
+    await client.startService("api");
+    await waitForServiceState(daemon.socketPath, sid, "api", "ready");
+
+    const statuses = await client.listServices();
+    const api = statuses.find((s) => s.name === "api");
+    expect(api?.state).toBe("ready");
+  });
+
+  it("restartService() cycles service back to ready", async () => {
+    await client.restartService("web");
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+    const statuses = await client.listServices();
+    const web = statuses.find((s) => s.name === "web");
+    expect(web?.state).toBe("ready");
+  });
+
+  it("restartAll() cycles all services", async () => {
+    await client.restartAll();
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "ready");
+
+    const statuses = await client.listServices();
+    for (const s of statuses) {
+      expect(s.state).toBe("ready");
+    }
+  });
+
+  // ── Logs ───────────────────────────────────────────────────────────
+
+  it("getLogSnapshot() returns lines for a service", async () => {
+    // Let LogMonitor capture at least one cycle
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    const lines = await client.getLogSnapshot("api");
+    expect(lines.length).toBeGreaterThan(0);
+  });
+
+  // ── Events ─────────────────────────────────────────────────────────
+
+  it("emits service.stateChange on stop/start", async () => {
+    const events: { name: string; status: ServiceStatus }[] = [];
+    client.on("service.stateChange", (name: string, status: ServiceStatus) => {
+      events.push({ name, status });
+    });
+
+    await client.stopService("api");
+    await waitForServiceState(daemon.socketPath, sid, "api", "stopped");
+    // Allow events to propagate
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const apiEvents = events.filter((e) => e.name === "api");
+    expect(apiEvents.length).toBeGreaterThan(0);
+
+    client.removeAllListeners("service.stateChange");
+
+    // Restart for subsequent tests
+    await client.startService("api");
+    await waitForServiceState(daemon.socketPath, sid, "api", "ready");
+  });
+
+  it("emits log.lines events", async () => {
+    const logEvents: { service: string; lines: string[] }[] = [];
+    client.on("log.lines", (service: string, lines: string[]) => {
+      logEvents.push({ service, lines });
+    });
+
+    // Restart a service to generate fresh log output
+    await client.restartService("web");
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+    // Allow LogMonitor to capture new output
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    client.removeAllListeners("log.lines");
+
+    expect(logEvents.length).toBeGreaterThan(0);
+  });
+
+  // ── Disconnect ─────────────────────────────────────────────────────
+
+  it("disconnect() sets connected to false", () => {
+    client.disconnect();
+    expect(client.connected).toBe(false);
+  });
+});

--- a/test/integration/daemon/e2e.test.ts
+++ b/test/integration/daemon/e2e.test.ts
@@ -1,0 +1,329 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { sessionId } from "#src/daemon/session.js";
+import { ipcRequest, ipcSubscribe } from "#src/lib/ipc/client.js";
+import type { DaemonEvent } from "#src/lib/ipc/protocol.js";
+import type { TestDaemon } from "../helpers/daemon.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createTestDaemon, waitForServiceState, writeTestConfig } from "../helpers/daemon.js";
+import { getFreePort } from "../helpers/port.js";
+import { hasTmux } from "../helpers/skip.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+describe.skipIf(!hasTmux())("daemon e2e", () => {
+  // ── Daemon-level handlers ─────────────────────────────────────────────
+
+  describe("daemon-level handlers", () => {
+    let daemon: TestDaemon;
+
+    beforeEach(async () => {
+      daemon = await createTestDaemon();
+    });
+
+    afterEach(async () => {
+      await daemon.cleanup();
+    });
+
+    it("daemon.ping returns pong", async () => {
+      const res = await ipcRequest(daemon.socketPath, "daemon.ping");
+      expect(res.error).toBeUndefined();
+      expect(res.result).toBe("pong");
+    });
+
+    it("daemon.status returns pid and empty sessions", async () => {
+      const res = await ipcRequest(daemon.socketPath, "daemon.status");
+      expect(res.error).toBeUndefined();
+      const status = res.result as { pid: number; sessions: unknown[] };
+      expect(status.pid).toBe(process.pid);
+      expect(status.sessions).toEqual([]);
+    });
+
+    it("session.list returns empty array initially", async () => {
+      const res = await ipcRequest(daemon.socketPath, "session.list");
+      expect(res.error).toBeUndefined();
+      expect(res.result).toEqual([]);
+    });
+
+    it("unknown method returns error", async () => {
+      const res = await ipcRequest(daemon.socketPath, "nonexistent.method");
+      expect(res.error).toContain("Unknown method");
+    });
+
+    it("session-scoped method without session returns error", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list");
+      expect(res.error).toContain("Session required");
+    });
+  });
+
+  // ── Session lifecycle ─────────────────────────────────────────────────
+
+  describe("session lifecycle", () => {
+    let daemon: TestDaemon;
+    let tmux: TestSession;
+    let tmpDir: string;
+    let createdSessionId: string | undefined;
+
+    beforeEach(async () => {
+      daemon = await createTestDaemon();
+      tmux = await createTestSession();
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-e2e-"));
+      createdSessionId = undefined;
+    });
+
+    afterEach(async () => {
+      // Destroy session first to stop LogMonitor before killing tmux panes
+      if (createdSessionId) {
+        try {
+          await ipcRequest(
+            daemon.socketPath,
+            "session.destroy",
+            undefined,
+            10_000,
+            createdSessionId,
+          );
+        } catch {
+          /* Best-effort cleanup */
+        }
+      }
+      // Let in-flight LogMonitor capturePane calls settle
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await daemon.cleanup();
+      await tmux.cleanup();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("session.create returns id, name, and paneMap", async () => {
+      const port = await getFreePort();
+      const configPath = writeTestConfig(tmpDir, port);
+
+      const res = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath,
+        projectDir: tmpDir,
+        tmuxSession: tmux.name,
+        originPane: tmux.initialPaneId,
+      });
+      expect(res.error).toBeUndefined();
+
+      const data = res.result as { id: string; name: string; paneMap: Record<string, string> };
+      createdSessionId = data.id;
+      expect(data.id).toBe(sessionId(configPath));
+      expect(data.name).toBe("test-daemon");
+      expect(data.paneMap["@tui"]).toBe(tmux.initialPaneId);
+      expect(data.paneMap.web).toBeDefined();
+
+      // Verify it appears in session.list
+      const listRes = await ipcRequest(daemon.socketPath, "session.list");
+      const sessions = listRes.result as { id: string }[];
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].id).toBe(data.id);
+    });
+
+    it("session.destroy removes session", async () => {
+      const port = await getFreePort();
+      const configPath = writeTestConfig(tmpDir, port);
+
+      const createRes = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath,
+        projectDir: tmpDir,
+        tmuxSession: tmux.name,
+        originPane: tmux.initialPaneId,
+      });
+      const sid = (createRes.result as { id: string }).id;
+
+      const destroyRes = await ipcRequest(
+        daemon.socketPath,
+        "session.destroy",
+        undefined,
+        10_000,
+        sid,
+      );
+      expect(destroyRes.error).toBeUndefined();
+      expect((destroyRes.result as { destroyed: string }).destroyed).toBe(sid);
+
+      // Session already destroyed — skip afterEach destroy
+      createdSessionId = undefined;
+
+      const listRes = await ipcRequest(daemon.socketPath, "session.list");
+      expect(listRes.result).toEqual([]);
+    });
+  });
+
+  // ── Session-scoped operations (shared session, ordered tests) ─────────
+
+  describe("session operations", () => {
+    let daemon: TestDaemon;
+    let tmux: TestSession;
+    let tmpDir: string;
+    let sid: string;
+    let port: number;
+    let configPath: string;
+
+    beforeAll(async () => {
+      daemon = await createTestDaemon();
+      tmux = await createTestSession();
+      port = await getFreePort();
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-e2e-"));
+      configPath = writeTestConfig(tmpDir, port);
+
+      const res = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath,
+        projectDir: tmpDir,
+        tmuxSession: tmux.name,
+        originPane: tmux.initialPaneId,
+      });
+      sid = (res.result as { id: string }).id;
+
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+    });
+
+    afterAll(async () => {
+      try {
+        await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+      } catch {
+        /* Best-effort cleanup */
+      }
+      // Let in-flight LogMonitor capturePane calls settle
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await daemon.cleanup();
+      await tmux.cleanup();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("services.list returns service statuses", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0].name).toBe("web");
+      expect(statuses[0].state).toBe("ready");
+    });
+
+    it("services.details returns info with deps", async () => {
+      const res = await ipcRequest(
+        daemon.socketPath,
+        "services.details",
+        { name: "web" },
+        5000,
+        sid,
+      );
+      expect(res.error).toBeUndefined();
+      const details = res.result as {
+        name: string;
+        state: string;
+        dependsOn: string[];
+        hasDocker: boolean;
+      };
+      expect(details.name).toBe("web");
+      expect(details.state).toBe("ready");
+      expect(details.dependsOn).toEqual([]);
+      expect(details.hasDocker).toBe(false);
+    });
+
+    it("session.attach returns full snapshot", async () => {
+      const res = await ipcRequest(daemon.socketPath, "session.attach", undefined, 5000, sid);
+      expect(res.error).toBeUndefined();
+      const snap = res.result as {
+        id: string;
+        name: string;
+        paneMap: Record<string, string>;
+        statuses: { name: string; state: string }[];
+        configPath: string;
+        projectDir: string;
+        tasks: unknown[];
+        servicesMeta: { name: string }[];
+      };
+      expect(snap.id).toBe(sid);
+      expect(snap.name).toBe("test-daemon");
+      expect(snap.configPath).toBe(configPath);
+      expect(snap.projectDir).toBe(tmpDir);
+      expect(snap.statuses).toHaveLength(1);
+      expect(snap.servicesMeta).toHaveLength(1);
+      expect(snap.servicesMeta[0].name).toBe("web");
+    });
+
+    it("logs.snapshot returns captured pane output", async () => {
+      // Wait for LogMonitor to capture at least one cycle (polls every 500ms)
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const res = await ipcRequest(
+        daemon.socketPath,
+        "logs.snapshot",
+        { service: "web" },
+        5000,
+        sid,
+      );
+      expect(res.error).toBeUndefined();
+      const lines = res.result as string[];
+      expect(lines.length).toBeGreaterThan(0);
+    });
+
+    it("logs.snapshot for unknown service returns error", async () => {
+      const res = await ipcRequest(
+        daemon.socketPath,
+        "logs.snapshot",
+        { service: "nope" },
+        5000,
+        sid,
+      );
+      expect(res.error).toContain("Unknown service");
+    });
+
+    it("subscribe receives stateChange events on stop", async () => {
+      const events: DaemonEvent[] = [];
+      const sub = ipcSubscribe(daemon.socketPath, sid, ["service.stateChange"], (event) =>
+        events.push(event),
+      );
+
+      // Wait for subscription to be established
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // Stop the service — triggers stateChange events
+      await ipcRequest(daemon.socketPath, "services.stop", { name: "web" }, 10_000, sid);
+
+      // Allow time for events to propagate
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      sub.close();
+
+      const stateEvents = events.filter((e) => e.event === "service.stateChange");
+      expect(stateEvents.length).toBeGreaterThan(0);
+
+      const webEvents = stateEvents.filter((e) => {
+        const data = e.data as { name: string };
+        return data.name === "web";
+      });
+      expect(webEvents.length).toBeGreaterThan(0);
+    });
+
+    it("services.start transitions stopped service back to ready", async () => {
+      // Service was stopped by previous test
+      const res = await ipcRequest(
+        daemon.socketPath,
+        "services.start",
+        { name: "web" },
+        15_000,
+        sid,
+      );
+      expect(res.error).toBeUndefined();
+
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+    });
+
+    it("services.restart cycles the service back to ready", async () => {
+      const res = await ipcRequest(
+        daemon.socketPath,
+        "services.restart",
+        { name: "web" },
+        15_000,
+        sid,
+      );
+      expect(res.error).toBeUndefined();
+
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+    });
+  });
+});

--- a/test/integration/daemon/lifecycle.test.ts
+++ b/test/integration/daemon/lifecycle.test.ts
@@ -1,0 +1,215 @@
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  IdleTimer,
+  daemonDir,
+  isDaemonRunning,
+  logPath,
+  pidPath,
+  readPid,
+  removePid,
+  removeSocket,
+  socketPath,
+  writePid,
+} from "#src/daemon/lifecycle.js";
+import type { TestDaemon } from "../helpers/daemon.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDaemon } from "../helpers/daemon.js";
+
+describe("lifecycle helpers", () => {
+  let originalXdg: string | undefined;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    originalXdg = process.env["XDG_RUNTIME_DIR"];
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-lifecycle-"));
+    process.env["XDG_RUNTIME_DIR"] = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env["XDG_RUNTIME_DIR"];
+    } else {
+      process.env["XDG_RUNTIME_DIR"] = originalXdg;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Path helpers ───────────────────────────────────────────────────
+
+  it("daemonDir() creates dir and returns path", () => {
+    const dir = daemonDir();
+    expect(dir).toBe(path.join(tmpDir, "zaps"));
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+
+  it("socketPath() returns correct path under daemonDir", () => {
+    const sock = socketPath();
+    expect(sock).toBe(path.join(tmpDir, "zaps", "daemon.sock"));
+  });
+
+  it("pidPath() returns correct path under daemonDir", () => {
+    const pid = pidPath();
+    expect(pid).toBe(path.join(tmpDir, "zaps", "daemon.pid"));
+  });
+
+  it("logPath() returns correct path under daemonDir", () => {
+    const log = logPath();
+    expect(log).toBe(path.join(tmpDir, "zaps", "daemon.log"));
+  });
+
+  // ── PID management ─────────────────────────────────────────────────
+
+  it("writePid() creates file containing process.pid", () => {
+    daemonDir(); // Ensure dir
+    writePid();
+    const contents = fs.readFileSync(pidPath(), "utf8").trim();
+    expect(Number.parseInt(contents, 10)).toBe(process.pid);
+  });
+
+  it("readPid() returns written PID", () => {
+    daemonDir();
+    writePid();
+    expect(readPid()).toBe(process.pid);
+  });
+
+  it("readPid() returns null on missing file", () => {
+    daemonDir();
+    expect(readPid()).toBeNull();
+  });
+
+  it("removePid() removes the pid file", () => {
+    daemonDir();
+    writePid();
+    expect(fs.existsSync(pidPath())).toBe(true);
+    removePid();
+    expect(fs.existsSync(pidPath())).toBe(false);
+  });
+
+  it("removePid() is no-op if file missing", () => {
+    daemonDir();
+    expect(() => removePid()).not.toThrow();
+  });
+
+  // ── isDaemonRunning ────────────────────────────────────────────────
+
+  it("isDaemonRunning() returns true for current PID", () => {
+    daemonDir();
+    writePid();
+    expect(isDaemonRunning()).toBe(true);
+  });
+
+  it("isDaemonRunning() returns false for stale PID", () => {
+    daemonDir();
+    // Write a PID that definitely doesn't exist
+    fs.writeFileSync(pidPath(), "999999999", "utf8");
+    expect(isDaemonRunning()).toBe(false);
+    // Should also clean up stale files
+    expect(fs.existsSync(pidPath())).toBe(false);
+  });
+
+  it("isDaemonRunning() returns false when no pid file", () => {
+    daemonDir();
+    expect(isDaemonRunning()).toBe(false);
+  });
+
+  // ── removeSocket ───────────────────────────────────────────────────
+
+  it("removeSocket() removes socket file", () => {
+    daemonDir();
+    const sock = socketPath();
+    fs.writeFileSync(sock, "");
+    expect(fs.existsSync(sock)).toBe(true);
+    removeSocket();
+    expect(fs.existsSync(sock)).toBe(false);
+  });
+
+  it("removeSocket() is no-op if file missing", () => {
+    daemonDir();
+    expect(() => removeSocket()).not.toThrow();
+  });
+
+  // ── IdleTimer ──────────────────────────────────────────────────────
+
+  it("IdleTimer fires callback after timeout", async () => {
+    const callback = vi.fn();
+    const timer = new IdleTimer(100, callback);
+    timer.reset();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("IdleTimer.reset() restarts countdown", async () => {
+    const callback = vi.fn();
+    const timer = new IdleTimer(150, callback);
+    timer.reset();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(callback).not.toHaveBeenCalled();
+
+    timer.reset(); // Restart
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(callback).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("IdleTimer.cancel() prevents callback", async () => {
+    const callback = vi.fn();
+    const timer = new IdleTimer(100, callback);
+    timer.reset();
+    timer.cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  // ── pingSocket (via real DaemonServer) ─────────────────────────────
+
+  describe("socket connectivity", () => {
+    let testDaemon: TestDaemon;
+
+    it("connecting to real DaemonServer succeeds", async () => {
+      testDaemon = await createTestDaemon();
+      const alive = await pingTestSocket(testDaemon.socketPath);
+      expect(alive).toBe(true);
+      await testDaemon.cleanup();
+    });
+
+    it("connecting to nonexistent socket fails", async () => {
+      const fakeSock = path.join(tmpDir, "nonexistent.sock");
+      const alive = await pingTestSocket(fakeSock);
+      expect(alive).toBe(false);
+    });
+  });
+});
+
+/**
+ * Minimal ping implementation matching daemon's pingSocket behavior.
+ */
+async function pingTestSocket(sock: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const client = net.createConnection(sock);
+    client.on("connect", () => {
+      const req = JSON.stringify({ id: "ping0", method: "daemon.ping" });
+      client.write(`${req}\n`);
+    });
+    client.on("data", () => {
+      client.destroy();
+      resolve(true);
+    });
+    client.on("error", () => {
+      resolve(false);
+    });
+    setTimeout(() => {
+      client.destroy();
+      resolve(false);
+    }, 500);
+  });
+}

--- a/test/integration/daemon/multi-service.test.ts
+++ b/test/integration/daemon/multi-service.test.ts
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ipcRequest, ipcStream, ipcSubscribe } from "#src/lib/ipc/client.js";
+import type { DaemonEvent } from "#src/lib/ipc/protocol.js";
+import type { TestDaemon } from "../helpers/daemon.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createTestDaemon,
+  waitForAllServices,
+  waitForServiceState,
+  writeMultiServiceConfig,
+} from "../helpers/daemon.js";
+import { getFreePort } from "../helpers/port.js";
+import { hasTmux } from "../helpers/skip.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+describe.skipIf(!hasTmux())("multi-service operations", () => {
+  let daemon: TestDaemon;
+  let tmux: TestSession;
+  let tmpDir: string;
+  let sid: string;
+  let port1: number;
+  let port2: number;
+
+  beforeAll(async () => {
+    daemon = await createTestDaemon();
+    tmux = await createTestSession();
+    port1 = await getFreePort();
+    port2 = await getFreePort();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-"));
+    writeMultiServiceConfig(tmpDir, port1, port2);
+
+    const configPath = path.join(tmpDir, ".zaps.mjs");
+    const res = await ipcRequest(daemon.socketPath, "session.create", {
+      configPath,
+      projectDir: tmpDir,
+      tmuxSession: tmux.name,
+      originPane: tmux.initialPaneId,
+    });
+    sid = (res.result as { id: string }).id;
+
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "ready");
+  });
+
+  afterAll(async () => {
+    try {
+      await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+    } catch {
+      /* Best-effort cleanup */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await daemon.cleanup();
+    await tmux.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Bulk operations ────────────────────────────────────────────────
+
+  it("services.list returns both services as ready", async () => {
+    const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid);
+    expect(res.error).toBeUndefined();
+    const statuses = res.result as { name: string; state: string }[];
+    expect(statuses).toHaveLength(2);
+    const names = statuses.map((s) => s.name).toSorted();
+    expect(names).toEqual(["api", "web"]);
+    for (const s of statuses) {
+      expect(s.state).toBe("ready");
+    }
+  });
+
+  it("services.stopAll stops both services", async () => {
+    const res = await ipcRequest(daemon.socketPath, "services.stopAll", undefined, 15_000, sid);
+    expect(res.error).toBeUndefined();
+    expect((res.result as { stopped: string }).stopped).toBe("all");
+
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "stopped");
+  });
+
+  it("services.startAll starts both services back", async () => {
+    const res = await ipcRequest(daemon.socketPath, "services.startAll", undefined, 15_000, sid);
+    expect(res.error).toBeUndefined();
+    expect((res.result as { started: string }).started).toBe("all");
+
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "ready");
+  });
+
+  // ── Named subset operations ────────────────────────────────────────
+
+  it("services.stopAll with names stops only named service", async () => {
+    const res = await ipcRequest(
+      daemon.socketPath,
+      "services.stopAll",
+      { names: ["api"] },
+      15_000,
+      sid,
+    );
+    expect(res.error).toBeUndefined();
+    expect((res.result as { stopped: string[] }).stopped).toEqual(["api"]);
+
+    await waitForServiceState(daemon.socketPath, sid, "api", "stopped");
+
+    // Web should still be ready
+    const list = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid);
+    const statuses = list.result as { name: string; state: string }[];
+    const web = statuses.find((s) => s.name === "web");
+    expect(web?.state).toBe("ready");
+  });
+
+  it("services.startAll with names starts only named service", async () => {
+    // Api was stopped by previous test
+    const res = await ipcRequest(
+      daemon.socketPath,
+      "services.startAll",
+      { names: ["api"] },
+      15_000,
+      sid,
+    );
+    expect(res.error).toBeUndefined();
+    expect((res.result as { started: string[] }).started).toEqual(["api"]);
+
+    await waitForServiceState(daemon.socketPath, sid, "api", "ready");
+  });
+
+  it("services.restartAll cycles both services", async () => {
+    const res = await ipcRequest(daemon.socketPath, "services.restartAll", undefined, 20_000, sid);
+    expect(res.error).toBeUndefined();
+    expect((res.result as { restarted: string }).restarted).toBe("all");
+
+    await waitForAllServices(daemon.socketPath, sid, ["api", "web"], "ready");
+  });
+
+  it("services.restartAll with names restarts only named service", async () => {
+    const res = await ipcRequest(
+      daemon.socketPath,
+      "services.restartAll",
+      { names: ["web"] },
+      15_000,
+      sid,
+    );
+    expect(res.error).toBeUndefined();
+    expect((res.result as { restarted: string[] }).restarted).toEqual(["web"]);
+
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+  });
+
+  // ── Tasks ──────────────────────────────────────────────────────────
+
+  it("tasks.list returns configured tasks", async () => {
+    const res = await ipcRequest(daemon.socketPath, "tasks.list", undefined, 5000, sid);
+    expect(res.error).toBeUndefined();
+    const tasks = res.result as { key: string; name: string; description: string | null }[];
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].key).toBe("build");
+    expect(tasks[0].name).toBe("Build");
+  });
+
+  it("tasks.run streams line events and returns success", async () => {
+    const lines: string[] = [];
+    const res = await ipcStream(
+      daemon.socketPath,
+      "tasks.run",
+      { key: "build" },
+      (event, data) => {
+        if (event === "line") {
+          lines.push(data as string);
+        }
+      },
+      30_000,
+      sid,
+    );
+    expect(res.error).toBeUndefined();
+    expect((res.result as { success: boolean }).success).toBe(true);
+    expect(lines.some((l) => l.includes("build-ok"))).toBe(true);
+  });
+
+  it("tasks.run with unknown task returns error", async () => {
+    const res = await ipcStream(
+      daemon.socketPath,
+      "tasks.run",
+      { key: "nonexistent" },
+      () => {
+        /* No-op */
+      },
+      5000,
+      sid,
+    );
+    expect(res.error).toContain("Unknown task");
+  });
+
+  // ── Log event subscription ─────────────────────────────────────────
+
+  it("subscribe receives log.lines events for a service", async () => {
+    const logEvents: DaemonEvent[] = [];
+    const sub = ipcSubscribe(daemon.socketPath, sid, ["log.lines"], (event) =>
+      logEvents.push(event),
+    );
+
+    // Wait for subscription to establish
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Restart a service to generate fresh log output
+    await ipcRequest(daemon.socketPath, "services.restart", { name: "api" }, 15_000, sid);
+    await waitForServiceState(daemon.socketPath, sid, "api", "ready");
+
+    // Allow LogMonitor to capture new output
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    sub.close();
+
+    const serviceLogs = logEvents.filter((e) => {
+      const data = e.data as { service: string };
+      return data.service === "api" || data.service === "web";
+    });
+    expect(serviceLogs.length).toBeGreaterThan(0);
+  });
+});

--- a/test/integration/global-setup.ts
+++ b/test/integration/global-setup.ts
@@ -1,0 +1,11 @@
+import { execFileSync } from "node:child_process";
+
+export default function setup() {
+  return () => {
+    try {
+      execFileSync("tmux", ["-L", "zaps-test", "kill-server"], { stdio: "ignore" });
+    } catch {
+      /* Server may already be gone */
+    }
+  };
+}

--- a/test/integration/helpers/daemon.ts
+++ b/test/integration/helpers/daemon.ts
@@ -1,0 +1,156 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { DaemonServer } from "#src/daemon/server.js";
+import { ipcRequest } from "#src/lib/ipc/client.js";
+
+export interface TestDaemon {
+  socketPath: string;
+  server: DaemonServer;
+  cleanup: () => Promise<void>;
+}
+
+export async function createTestDaemon(): Promise<TestDaemon> {
+  const socketPath = path.join(os.tmpdir(), `zaps-test-${randomUUID().slice(0, 8)}.sock`);
+  const server = new DaemonServer();
+  await server.start(socketPath);
+  return {
+    socketPath,
+    server,
+    async cleanup() {
+      server.stop();
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        /* Socket may already be cleaned up */
+      }
+    },
+  };
+}
+
+/**
+ * Write a minimal .zaps.mjs config that defines a single HTTP service.
+ * Returns the absolute config path.
+ */
+export function writeTestConfig(dir: string, port: number): string {
+  const configPath = path.join(dir, ".zaps.mjs");
+  const cmd = `node -e "require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port},()=>console.log('ready on port ${port}'))"`;
+  fs.writeFileSync(
+    configPath,
+    [
+      "export function config(lib) {",
+      "  return lib.defineProject({",
+      '    name: "test-daemon",',
+      "    services: {",
+      "      web: {",
+      `        start: ${JSON.stringify(cmd)},`,
+      `        ready: { port: ${port} },`,
+      "      },",
+      "    },",
+      "  });",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  return configPath;
+}
+
+/**
+ * Write a .zaps.mjs config with two HTTP services (api + web) and a build task.
+ */
+export function writeMultiServiceConfig(dir: string, port1: number, port2: number): string {
+  const configPath = path.join(dir, ".zaps.mjs");
+  const apiCmd = `node -e "require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port1},()=>console.log('ready on port ${port1}'))"`;
+  const webCmd = `node -e "require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port2},()=>console.log('ready on port ${port2}'))"`;
+  fs.writeFileSync(
+    configPath,
+    [
+      "export function config(lib) {",
+      "  return lib.defineProject({",
+      '    name: "test-multi",',
+      "    services: {",
+      "      api: {",
+      `        start: ${JSON.stringify(apiCmd)},`,
+      `        ready: { port: ${port1} },`,
+      "      },",
+      "      web: {",
+      `        start: ${JSON.stringify(webCmd)},`,
+      `        ready: { port: ${port2} },`,
+      "      },",
+      "    },",
+      "    tasks: {",
+      "      build: {",
+      '        name: "Build",',
+      "        popup: true,",
+      '        commands: "echo build-ok",',
+      "      },",
+      "    },",
+      "  });",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  return configPath;
+}
+
+/**
+ * Poll services.list until a service reaches the target state.
+ */
+export async function waitForServiceState(
+  socketPath: string,
+  session: string,
+  service: string,
+  targetState: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- Polling loop */
+  while (Date.now() - start < timeoutMs) {
+    const res = await ipcRequest(socketPath, "services.list", undefined, 5000, session);
+    if (!res.error) {
+      const statuses = res.result as { name: string; state: string }[];
+      const svc = statuses.find((s) => s.name === service);
+      if (svc?.state === targetState) {
+        return;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  /* eslint-enable no-await-in-loop */
+  throw new Error(`Service '${service}' did not reach '${targetState}' within ${timeoutMs}ms`);
+}
+
+/**
+ * Wait for all named services to reach a target state.
+ */
+export async function waitForAllServices(
+  socketPath: string,
+  session: string,
+  services: string[],
+  targetState: string,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- Polling loop */
+  while (Date.now() - start < timeoutMs) {
+    const res = await ipcRequest(socketPath, "services.list", undefined, 5000, session);
+    if (!res.error) {
+      const statuses = res.result as { name: string; state: string }[];
+      const allReady = services.every((name) => {
+        const svc = statuses.find((s) => s.name === name);
+        return svc?.state === targetState;
+      });
+      if (allReady) {
+        return;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  /* eslint-enable no-await-in-loop */
+  throw new Error(
+    `Services [${services.join(", ")}] did not all reach '${targetState}' within ${timeoutMs}ms`,
+  );
+}

--- a/test/integration/vitest.config.ts
+++ b/test/integration/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     hookTimeout: 30_000,
     pool: "forks",
     fileParallelism: false,
+    env: { ZAPS_TMUX_SOCKET: "zaps-test" },
+    globalSetup: "./test/integration/global-setup.ts",
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary", "json"],

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -1,0 +1,552 @@
+/* eslint-disable class-methods-use-this -- Mock classes mimic SDK interface */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- IPC mocks (same pattern as daemon-client tests) ---
+
+const mockIpcRequest = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockIpcStream = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockIpcSubscribe = vi.fn();
+
+vi.mock("../../src/lib/ipc/client.js", () => ({
+  ipcRequest: async (...args: unknown[]) => mockIpcRequest(...args),
+  ipcStream: async (...args: unknown[]) => mockIpcStream(...args),
+  ipcSubscribe: (...args: unknown[]) => mockIpcSubscribe(...args),
+}));
+
+// --- MCP SDK mocks ---
+
+type ToolCb = (args: Record<string, unknown>) => Promise<unknown>;
+type ResourceReadCb = (
+  uri: { href: string },
+  variables: Record<string, unknown>,
+) => Promise<unknown>;
+interface TemplateConfig {
+  list: () => Promise<unknown>;
+}
+
+const registeredTools = new Map<string, { meta: unknown; cb: ToolCb }>();
+const registeredResources = new Map<
+  string,
+  { template: { pattern: string; config: TemplateConfig }; meta: unknown; cb: ResourceReadCb }
+>();
+
+const mockSendResourceUpdated = vi.fn();
+const mockConnect = vi.fn();
+let mcpServerCtorArgs: unknown[] = [];
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
+  class MockMcpServer {
+    server = { sendResourceUpdated: mockSendResourceUpdated };
+
+    constructor(...args: unknown[]) {
+      mcpServerCtorArgs = args;
+    }
+
+    registerTool(name: string, meta: unknown, handler: ToolCb) {
+      registeredTools.set(name, { meta, cb: handler });
+    }
+
+    registerResource(
+      name: string,
+      template: { pattern: string; config: TemplateConfig },
+      meta: unknown,
+      handler: ResourceReadCb,
+    ) {
+      registeredResources.set(name, { template, meta, cb: handler });
+    }
+
+    async connect(...args: unknown[]) {
+      mockConnect(...args);
+    }
+  }
+
+  class MockResourceTemplate {
+    pattern: string;
+    config: TemplateConfig;
+
+    constructor(pattern: string, config: TemplateConfig) {
+      this.pattern = pattern;
+      this.config = config;
+    }
+  }
+
+  return { McpServer: MockMcpServer, ResourceTemplate: MockResourceTemplate };
+});
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: vi.fn(),
+}));
+
+// --- Import under test ---
+
+const { startMcpServer } = await import("../../src/mcp/server.js");
+
+const SOCK = "/test.sock";
+const SESSION = "sess1";
+
+describe("startMcpServer", () => {
+  beforeEach(async () => {
+    mockIpcRequest.mockReset();
+    mockIpcStream.mockReset();
+    mockIpcSubscribe.mockReset();
+    mockConnect.mockClear();
+    mockSendResourceUpdated.mockClear();
+    mcpServerCtorArgs = [];
+    registeredTools.clear();
+    registeredResources.clear();
+    await startMcpServer(SOCK, SESSION);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- Setup ---
+
+  describe("setup", () => {
+    it("creates McpServer with correct name/version/capabilities", () => {
+      expect(mcpServerCtorArgs).toEqual([
+        { name: "zaps", version: "0.1.0" },
+        { capabilities: { resources: { subscribe: true, listChanged: true } } },
+      ]);
+    });
+
+    it("registers all 11 tools", () => {
+      expect(registeredTools.size).toBe(11);
+      const expected = [
+        "services_list",
+        "services_details",
+        "services_start",
+        "services_stop",
+        "services_restart",
+        "services_start_all",
+        "services_stop_all",
+        "services_restart_all",
+        "logs_snapshot",
+        "tasks_list",
+        "tasks_run",
+      ];
+      for (const name of expected) {
+        expect(registeredTools.has(name)).toBe(true);
+      }
+    });
+
+    it("connects StdioServerTransport", () => {
+      expect(mockConnect).toHaveBeenCalledOnce();
+    });
+  });
+
+  // --- Read-only tool forwarding ---
+
+  describe("read-only tools", () => {
+    it("services_list forwards to ipcRequest and returns JSON", async () => {
+      const statuses = [{ name: "api", state: "ready" }];
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: statuses });
+
+      const result = await registeredTools.get("services_list")!.cb({});
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.list",
+        undefined,
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify(statuses, null, 2) }],
+      });
+    });
+
+    it("services_details forwards { name } param", async () => {
+      const details = { name: "api", state: "ready", pid: 123 };
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: details });
+
+      const result = await registeredTools.get("services_details")!.cb({ name: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.details",
+        { name: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
+      });
+    });
+
+    it("logs_snapshot forwards { service } and joins lines", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: ["line1", "line2", "line3"] });
+
+      const result = await registeredTools.get("logs_snapshot")!.cb({ service: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "logs.snapshot",
+        { service: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: "line1\nline2\nline3" }],
+      });
+    });
+
+    it("tasks_list forwards to ipcRequest", async () => {
+      const tasks = [{ key: "build", name: "Build" }];
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: tasks });
+
+      const result = await registeredTools.get("tasks_list")!.cb({});
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(SOCK, "tasks.list", undefined, 30_000, SESSION);
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify(tasks, null, 2) }],
+      });
+    });
+
+    it("tool throws on IPC error response", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", error: "Not found" });
+
+      await expect(registeredTools.get("services_list")!.cb({})).rejects.toThrow("Not found");
+    });
+  });
+
+  // --- Mutation tool forwarding ---
+
+  describe("mutation tools", () => {
+    it("services_start forwards { name } and returns JSON", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { started: "api" } });
+
+      const result = await registeredTools.get("services_start")!.cb({ name: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.start",
+        { name: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ started: "api" }) }],
+      });
+    });
+
+    it("services_stop forwards { name }", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { stopped: "api" } });
+
+      const result = await registeredTools.get("services_stop")!.cb({ name: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.stop",
+        { name: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ stopped: "api" }) }],
+      });
+    });
+
+    it("services_restart forwards { name }", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { restarted: "api" } });
+
+      const result = await registeredTools.get("services_restart")!.cb({ name: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.restart",
+        { name: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ restarted: "api" }) }],
+      });
+    });
+  });
+
+  // --- Batch mutation tools ---
+
+  describe("batch mutation tools", () => {
+    it("services_start_all forwards without params when names omitted", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { started: ["api", "web"] } });
+
+      const result = await registeredTools.get("services_start_all")!.cb({});
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.startAll",
+        undefined,
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ started: ["api", "web"] }) }],
+      });
+    });
+
+    it("services_start_all forwards { names } when provided", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { started: ["api"] } });
+
+      const result = await registeredTools.get("services_start_all")!.cb({ names: ["api"] });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.startAll",
+        { names: ["api"] },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ started: ["api"] }) }],
+      });
+    });
+
+    it("services_start_all throws on IPC error", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", error: "Daemon unavailable" });
+
+      await expect(registeredTools.get("services_start_all")!.cb({})).rejects.toThrow(
+        "Daemon unavailable",
+      );
+    });
+
+    it("services_stop_all forwards without params when names omitted", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { stopped: ["api", "web"] } });
+
+      const result = await registeredTools.get("services_stop_all")!.cb({});
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.stopAll",
+        undefined,
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ stopped: ["api", "web"] }) }],
+      });
+    });
+
+    it("services_stop_all forwards { names } when provided", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { stopped: ["web"] } });
+
+      const result = await registeredTools.get("services_stop_all")!.cb({ names: ["web"] });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.stopAll",
+        { names: ["web"] },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ stopped: ["web"] }) }],
+      });
+    });
+
+    it("services_stop_all has destructiveHint annotation", () => {
+      const meta = registeredTools.get("services_stop_all")!.meta as {
+        annotations?: { destructiveHint?: boolean };
+      };
+      expect(meta.annotations?.destructiveHint).toBe(true);
+    });
+
+    it("services_restart_all forwards without params when names omitted", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { restarted: ["api", "web"] } });
+
+      const result = await registeredTools.get("services_restart_all")!.cb({});
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.restartAll",
+        undefined,
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ restarted: ["api", "web"] }) }],
+      });
+    });
+
+    it("services_restart_all forwards { names } when provided", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: { restarted: ["api"] } });
+
+      const result = await registeredTools.get("services_restart_all")!.cb({ names: ["api"] });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "services.restartAll",
+        { names: ["api"] },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ restarted: ["api"] }) }],
+      });
+    });
+
+    it("services_restart_all throws on IPC error", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", error: "Timeout" });
+
+      await expect(registeredTools.get("services_restart_all")!.cb({})).rejects.toThrow("Timeout");
+    });
+  });
+
+  // --- tasks_run streaming ---
+
+  describe("tasks_run", () => {
+    it("collects line events and returns joined output", async () => {
+      mockIpcStream.mockImplementation(
+        async (_sock: unknown, _method: unknown, _params: unknown, onEvent: unknown) => {
+          const emit = onEvent as (event: string, data: unknown) => void;
+          emit("line", "output1");
+          emit("line", "output2");
+          return { id: "r1", result: { success: true } };
+        },
+      );
+
+      const result = await registeredTools.get("tasks_run")!.cb({ key: "build" });
+
+      expect(mockIpcStream).toHaveBeenCalledWith(
+        SOCK,
+        "tasks.run",
+        { key: "build" },
+        expect.any(Function),
+        120_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: "output1\noutput2" }],
+        isError: false,
+      });
+    });
+
+    it("returns isError: true on IPC error", async () => {
+      mockIpcStream.mockResolvedValue({ id: "r1", error: "task failed" });
+
+      const result = await registeredTools.get("tasks_run")!.cb({ key: "bad" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Error: task failed" }],
+        isError: true,
+      });
+    });
+
+    it("returns fallback text on success with no output", async () => {
+      mockIpcStream.mockResolvedValue({ id: "r1", result: { success: true } });
+
+      const result = await registeredTools.get("tasks_run")!.cb({ key: "empty" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Task completed." }],
+        isError: false,
+      });
+    });
+
+    it("returns fallback failure text on failure with no output", async () => {
+      mockIpcStream.mockResolvedValue({ id: "r1", result: { success: false } });
+
+      const result = await registeredTools.get("tasks_run")!.cb({ key: "fail" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Task failed." }],
+        isError: true,
+      });
+    });
+  });
+
+  // --- Resources ---
+
+  describe("resources", () => {
+    it("list callback returns URI per service", async () => {
+      const statuses = [
+        { name: "api", state: "ready" },
+        { name: "web", state: "stopped" },
+      ];
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: statuses });
+
+      const resource = registeredResources.get("service-logs")!;
+      const result = await resource.template.config.list();
+
+      expect(result).toEqual({
+        resources: [
+          {
+            uri: "zaps://logs/api",
+            name: "api logs",
+            description: "Log output for api",
+            mimeType: "text/plain",
+          },
+          {
+            uri: "zaps://logs/web",
+            name: "web logs",
+            description: "Log output for web",
+            mimeType: "text/plain",
+          },
+        ],
+      });
+    });
+
+    it("read callback returns log text content", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", result: ["log1", "log2"] });
+
+      const resource = registeredResources.get("service-logs")!;
+      const result = await resource.cb({ href: "zaps://logs/api" }, { serviceName: "api" });
+
+      expect(mockIpcRequest).toHaveBeenCalledWith(
+        SOCK,
+        "logs.snapshot",
+        { service: "api" },
+        30_000,
+        SESSION,
+      );
+      expect(result).toEqual({
+        contents: [{ uri: "zaps://logs/api", text: "log1\nlog2", mimeType: "text/plain" }],
+      });
+    });
+
+    it("ipcSubscribe log.lines event triggers sendResourceUpdated", () => {
+      expect(mockIpcSubscribe).toHaveBeenCalledWith(
+        SOCK,
+        SESSION,
+        ["log.lines"],
+        expect.any(Function),
+      );
+
+      const eventHandler = mockIpcSubscribe.mock.calls[0][3] as (event: unknown) => void;
+      eventHandler({ event: "log.lines", data: { service: "api" } });
+
+      expect(mockSendResourceUpdated).toHaveBeenCalledWith({ uri: "zaps://logs/api" });
+    });
+
+    it("ipcSubscribe ignores non-log.lines events", () => {
+      const eventHandler = mockIpcSubscribe.mock.calls[0][3] as (event: unknown) => void;
+      eventHandler({ event: "service.stateChange", data: { name: "api" } });
+
+      expect(mockSendResourceUpdated).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Error propagation ---
+
+  describe("error propagation", () => {
+    it("request() helper throws on IPC error", async () => {
+      mockIpcRequest.mockResolvedValue({ id: "r1", error: "Session expired" });
+
+      await expect(registeredTools.get("services_details")!.cb({ name: "api" })).rejects.toThrow(
+        "Session expired",
+      );
+    });
+
+    it("tasks_run stream error returns isError: true", async () => {
+      mockIpcStream.mockResolvedValue({ id: "r1", error: "Stream broke" });
+
+      const result = await registeredTools.get("tasks_run")!.cb({ key: "x" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Error: Stream broke" }],
+        isError: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Introduce MCP server for AI tool integration, exposing service management and log streaming via Model Context Protocol. Add integration and unit tests for daemon lifecycle, multi-service, and MCP server functionality. Update dependencies and CLI.