### PR TITLE
fix(#mcp): improve daemon error handling in MCP server

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -884,25 +884,22 @@ program
   .description("Start MCP server for AI tool integration")
   .option("-s, --session <id>", "Target session (auto-detected from CWD)")
   .action(async (opts: { session?: string }) => {
-    if (!isDaemonRunning()) {
-      process.stderr.write("Daemon not running. Start with `zaps daemon start`.\n");
-      process.exit(1);
-    }
     const sock = socketPath();
-    const res = await ipcRequest(sock, "session.list");
-    if (res.error) {
-      process.stderr.write(`Error: ${res.error}\n`);
-      process.exit(1);
+    let sessionId = "";
+    try {
+      const res = await ipcRequest(sock, "session.list");
+      if (!res.error) {
+        // eslint-disable-next-line no-unsafe-type-assertion -- IPC boundary
+        const sessions = res.result as SessionInfo[];
+        if (sessions.length > 0) {
+          sessionId = resolveTargetSession(sessions, opts.session).id;
+        }
+      }
+    } catch {
+      // Daemon not running — MCP server will report errors per-tool call
     }
-    // eslint-disable-next-line no-unsafe-type-assertion -- IPC boundary
-    const sessions = res.result as SessionInfo[];
-    if (sessions.length === 0) {
-      process.stderr.write("No active sessions.\n");
-      process.exit(1);
-    }
-    const target = resolveTargetSession(sessions, opts.session);
     const { startMcpServer } = await import("./mcp/server.js");
-    await startMcpServer(sock, target.id);
+    await startMcpServer(sock, sessionId);
   });
 
 if (process.argv.length === 2) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -885,21 +885,21 @@ program
   .option("-s, --session <id>", "Target session (auto-detected from CWD)")
   .action(async (opts: { session?: string }) => {
     const sock = socketPath();
-    let sessionId = "";
+    let targetSessionId = "";
     try {
       const res = await ipcRequest(sock, "session.list");
       if (!res.error) {
         // eslint-disable-next-line no-unsafe-type-assertion -- IPC boundary
         const sessions = res.result as SessionInfo[];
         if (sessions.length > 0) {
-          sessionId = resolveTargetSession(sessions, opts.session).id;
+          targetSessionId = resolveTargetSession(sessions, opts.session).id;
         }
       }
     } catch {
       // Daemon not running — MCP server will report errors per-tool call
     }
     const { startMcpServer } = await import("./mcp/server.js");
-    await startMcpServer(sock, sessionId);
+    await startMcpServer(sock, targetSessionId);
   });
 
 if (process.argv.length === 2) {

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -700,7 +700,9 @@ export class ServiceManager extends EventEmitter {
   }
 
   private async chainRename(title: string): Promise<void> {
-    await this.pendingRename.catch(() => { /* Ignored */ });
+    await this.pendingRename.catch(() => {
+      /* Ignored */
+    });
     await this.deps.renameWindow(this.paneMap["@tui"], title);
   }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,15 +13,17 @@ async function startMcpServer(socketPath: string, sessionId: string): Promise<vo
   );
 
   async function request(method: string, params?: unknown): Promise<unknown> {
-    let res;
+    let res: Awaited<ReturnType<typeof ipcRequest>> | undefined = undefined;
     try {
       res = await ipcRequest(socketPath, method, params, 30_000, sessionId);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
+    } catch (error) {
+      const { code } = error as NodeJS.ErrnoException;
       if (code === "ENOENT" || code === "ECONNREFUSED") {
-        throw new Error("Daemon not running. Start with `zaps up` or `zaps daemon start`.");
+        throw new Error("Daemon not running. Start with `zaps up` or `zaps daemon start`.", {
+          cause: error,
+        });
       }
-      throw err;
+      throw error;
     }
     if (res.error) {
       throw new Error(res.error);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,7 +13,16 @@ async function startMcpServer(socketPath: string, sessionId: string): Promise<vo
   );
 
   async function request(method: string, params?: unknown): Promise<unknown> {
-    const res = await ipcRequest(socketPath, method, params, 30_000, sessionId);
+    let res;
+    try {
+      res = await ipcRequest(socketPath, method, params, 30_000, sessionId);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ECONNREFUSED") {
+        throw new Error("Daemon not running. Start with `zaps up` or `zaps daemon start`.");
+      }
+      throw err;
+    }
     if (res.error) {
       throw new Error(res.error);
     }

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -530,6 +530,32 @@ describe("startMcpServer", () => {
   // --- Error propagation ---
 
   describe("error propagation", () => {
+    it("request() catches ECONNREFUSED and returns friendly message", async () => {
+      const err = new Error("connect ECONNREFUSED") as NodeJS.ErrnoException;
+      err.code = "ECONNREFUSED";
+      mockIpcRequest.mockRejectedValue(err);
+
+      await expect(registeredTools.get("services_list")!.cb({})).rejects.toThrow(
+        "Daemon not running. Start with `zaps up` or `zaps daemon start`.",
+      );
+    });
+
+    it("request() catches ENOENT and returns friendly message", async () => {
+      const err = new Error("connect ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      mockIpcRequest.mockRejectedValue(err);
+
+      await expect(registeredTools.get("services_list")!.cb({})).rejects.toThrow(
+        "Daemon not running. Start with `zaps up` or `zaps daemon start`.",
+      );
+    });
+
+    it("request() re-throws unknown errors", async () => {
+      mockIpcRequest.mockRejectedValue(new Error("unexpected"));
+
+      await expect(registeredTools.get("services_list")!.cb({})).rejects.toThrow("unexpected");
+    });
+
     it("request() helper throws on IPC error", async () => {
       mockIpcRequest.mockResolvedValue({ id: "r1", error: "Session expired" });
 


### PR DESCRIPTION
Handle ENOENT and ECONNREFUSED errors gracefully when daemon is not running. Provide user-friendly messages and update tests to cover new error cases.