### PR TITLE
fix(#fix): ensure service start uses correct cwd

### DIFF
--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: zaps-config
 description: Use when working on ZAPS config files (.zaps.mts/.zaps.ts/local.zaps.ts) - provides service definitions, ready detection, docker integration, tasks, layout, hooks, dependencies, and environment configuration.
 ---
 

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: zaps-usage
 description: Use when interacting with local dev sessions/services - start/stop/inspect services, run tasks, view logs via CLI
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -150,5 +150,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
 
+!CLAUDE.md
 !.claude/skills/
 !.claude/skills/**
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+## Commands
+
+```bash
+pnpm check                    # full CI: typecheck + lint:fix + build + build:native + test:coverage
+pnpm test                     # unit tests (vitest)
+pnpm test -- path/to/file     # single test file
+pnpm test:integration         # integration tests (sequential, 60s timeout, needs tmux)
+pnpm test:coverage            # unit tests with coverage (85% lines/functions/statements, 89% branches)
+pnpm typecheck                # tsc --noEmit
+pnpm lint                     # oxfmt --check + oxlint (type-aware, deny-warnings)
+pnpm lint:fix                 # oxfmt --write + oxlint --fix
+pnpm build                    # esbuild bundle → dist/cli.mjs + tsc declarations
+pnpm build:native             # bun native binary → dist/zaps
+```
+
+**Always run `pnpm check` before finishing your task.**
+
+## Architecture
+
+**ZAPS** (Zero Ass Pain Setup) — tmux session manager that orchestrates dev services with a React/Ink TUI.
+
+### Core layers
+
+- **CLI** (`src/cli.tsx`) — Commander.js commands, entry point
+- **Daemon** (`src/daemon/`) — background Unix socket IPC server managing sessions
+- **Service Manager** (`src/lib/service/manager.ts`) — lifecycle, dependency graph, ready detection, crash recovery
+- **TUI** (`src/components/`) — React/Ink terminal UI with Dashboard, LogView, TasksView
+- **Config** (`src/config/`) — discovery, Zod validation, builder API for `.zaps.mts` files
+- **MCP** (`src/mcp/server.ts`) — Model Context Protocol server for AI agents
+- **Client** (`src/client/daemon-client.ts`) — TUI↔daemon EventEmitter bridge
+
+### Key patterns
+
+- Path alias: `#src/*` → `./src/*`
+- IPC: JSON over Unix sockets (ndjson for log streaming)
+- JSX runtime: `react-jsx` (React 19 + Ink 6)
+- Config discovery walks up from CWD for `.zaps.mts`/`.zaps.ts`/`local.zaps.ts` variants
+
+## Skills & README
+
+**Always update these when changing user-facing behavior:**
+
+- `README.md` — CLI commands, config options, usage docs
+- `.claude/skills/zaps-config/` — config authoring skill + reference docs
+- `.claude/skills/zaps-usage/` — CLI usage skill
+
+## Tech
+
+- TypeScript (ES2023, strict, ESM)
+- React 19 + Ink 6 (TUI)
+- Zod 4 (config validation)
+- Commander 14 (CLI)
+- Vitest 4 (testing), oxlint/oxfmt (lint/format)
+- esbuild (bundle), bun (native binary)

--- a/README.md
+++ b/README.md
@@ -631,9 +631,9 @@ ZAPS offers two integration paths for AI coding agents: **Claude Code Skills** (
 
 ZAPS ships two [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) in `.claude/skills/`:
 
-| Skill | Description |
-| --- | --- |
-| `zaps-usage` | Interact with dev sessions — start/stop services, run tasks, view logs |
+| Skill         | Description                                                                  |
+| ------------- | ---------------------------------------------------------------------------- |
+| `zaps-usage`  | Interact with dev sessions — start/stop services, run tasks, view logs       |
 | `zaps-config` | Author and edit ZAPS config files (`.zaps.mts`, `.zaps.ts`, `local.zaps.ts`) |
 
 Skills are **recommended over MCP** because they load reference docs on-demand rather than occupying persistent context, resulting in significantly lower token usage.

--- a/src/client/daemon-client.ts
+++ b/src/client/daemon-client.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 
+import type { DockerConfig } from "#src/config/types.js";
 import type { SessionSnapshot } from "#src/daemon/session.js";
 import type { IpcSubscription } from "#src/lib/ipc/client.js";
 import { ipcRequest, ipcStream, ipcSubscribe } from "#src/lib/ipc/client.js";
@@ -104,6 +105,13 @@ export class DaemonClient extends EventEmitter {
 
   async restartService(name: string): Promise<void> {
     const res = await this.request("services.restart", { name });
+    if (res.error) {
+      throw new Error(res.error);
+    }
+  }
+
+  async rebuildDocker(name: string, overrides: Partial<DockerConfig>): Promise<void> {
+    const res = await this.request("services.rebuild", { name, overrides });
     if (res.error) {
       throw new Error(res.error);
     }

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -1,6 +1,6 @@
 import type { Socket } from "node:net";
 
-import type { ResolvedConfig } from "#src/config/types.js";
+import type { DockerConfig, ResolvedConfig } from "#src/config/types.js";
 import type { SessionStore } from "#src/daemon/server.js";
 import type { Session } from "#src/daemon/session.js";
 import { execCommand } from "#src/lib/exec.js";
@@ -158,6 +158,20 @@ export const sessionHandlers: Record<
     try {
       await session.manager.restartService(name);
       return ipcOk(req.id, { restarted: name });
+    } catch (error) {
+      return ipcErr(req.id, error instanceof Error ? error.message : String(error));
+    }
+  },
+
+  async "services.rebuild"(req, store) {
+    const session = getSession(req, store);
+    if (!session) {
+      return ipcErr(req.id, "Unknown session");
+    }
+    const { name, overrides } = req.params as { name: string; overrides: Partial<DockerConfig> };
+    try {
+      await session.manager.restartWithDockerOverrides(name, overrides);
+      return ipcOk(req.id, { rebuilt: name });
     } catch (error) {
       return ipcErr(req.id, error instanceof Error ? error.message : String(error));
     }

--- a/src/hooks/useServiceActions.ts
+++ b/src/hooks/useServiceActions.ts
@@ -1,12 +1,11 @@
 import type { DaemonClient } from "#src/client/daemon-client.js";
 import type { DockerConfig } from "#src/config/types.js";
 
-// Docker rebuild not yet supported via daemon — stub
-async function rebuildDocker(_name: string, _overrides: Partial<DockerConfig>) {
-  // TODO: Add docker rebuild support to daemon protocol
-}
-
 export function useServiceActions(client: DaemonClient) {
+  async function rebuildDocker(name: string, overrides: Partial<DockerConfig>) {
+    await client.rebuildDocker(name, overrides);
+  }
+
   async function restart(name: string) {
     await client.restartService(name);
   }

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -320,7 +320,9 @@ export class ServiceManager extends EventEmitter {
     // Build command
     const resolvedCommand = resolveCommand(serviceConfig);
     const envPrefix = formatEnvForShell(env);
-    const command = envPrefix ? `${envPrefix} ${resolvedCommand}` : resolvedCommand;
+    const cwd = serviceConfig.cwd ?? this.config.projectDir;
+    const cmdWithEnv = envPrefix ? `${envPrefix} ${resolvedCommand}` : resolvedCommand;
+    const command = `cd ${JSON.stringify(cwd)} && ${cmdWithEnv}`;
 
     // Send to pane
     await this.deps.sendKeys(paneTarget, command);

--- a/test/hooks/useServiceActions.test.tsx
+++ b/test/hooks/useServiceActions.test.tsx
@@ -27,6 +27,7 @@ function createMockClient(statuses: ServiceStatus[] = []): DaemonClient {
     stopService: vi.fn().mockResolvedValue(undefined),
     restartService: vi.fn().mockResolvedValue(undefined),
     restartAll: vi.fn().mockResolvedValue(undefined),
+    rebuildDocker: vi.fn().mockResolvedValue(undefined),
     getLogSnapshot: vi.fn().mockResolvedValue([]),
   });
   return client as unknown as DaemonClient;

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -345,7 +345,7 @@ describe("startService", () => {
     await vi.advanceTimersByTimeAsync(2000);
     await promise;
 
-    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", "PORT='3000' npm run dev");
+    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", "cd \"/test\" && PORT='3000' npm run dev");
   });
 
   it("transitions through stopped -> starting -> ready and emits stateChange", async () => {
@@ -441,7 +441,7 @@ describe("startService", () => {
     await vi.advanceTimersByTimeAsync(2000);
     await promise;
 
-    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", "dynamic-cmd");
+    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", 'cd "/test" && dynamic-cmd');
   });
 
   it("guards against double-start when already starting", async () => {
@@ -499,7 +499,23 @@ describe("startService", () => {
     await vi.advanceTimersByTimeAsync(2000);
     await promise;
 
-    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", "run-cmd");
+    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", 'cd "/test" && run-cmd');
+  });
+
+  it("uses service-level cwd instead of projectDir when set", async () => {
+    const config = makeConfig({
+      svc: { start: "start-svc", cwd: "/custom/path" },
+    });
+    const paneMap = makePaneMap(["svc"]);
+    const deps = createMockDeps();
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+    const promise = mgr.startService("svc");
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(deps.sendKeys).toHaveBeenCalledWith("%svc", 'cd "/custom/path" && start-svc');
   });
 });
 
@@ -1162,7 +1178,7 @@ describe("docker config", () => {
 
     expect(deps.sendKeys).toHaveBeenCalledWith(
       "%db",
-      "docker compose -f local.docker-compose.yml up --build --force-recreate -V postgres",
+      'cd "/test" && docker compose -f local.docker-compose.yml up --build --force-recreate -V postgres',
     );
     expect(mgr.getStatus("db").state).toBe("ready");
     expect(mgr.getStatus("db").ports).toEqual([5432]);
@@ -1191,7 +1207,7 @@ describe("docker config", () => {
     await vi.advanceTimersByTimeAsync(2000);
     await promise;
 
-    expect(deps.sendKeys).toHaveBeenCalledWith("%db", "custom-start");
+    expect(deps.sendKeys).toHaveBeenCalledWith("%db", 'cd "/test" && custom-start');
 
     spy.mockRestore();
   });


### PR DESCRIPTION
Update service manager to prepend 'cd <cwd>' to start commands, using service-level cwd when set. Add Docker rebuild support to daemon protocol and client. Adjust tests for new command format.