### PR TITLE
feat(#add): prime agent context for AI integration

### DIFF
--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -8,6 +8,10 @@ description: Use when interacting with local dev sessions/services - start/stop/
 
 Activate when user asks to start/stop/manage local development sessions, run tasks, view logs, or interact with running services (not config authoring).
 
+## First Action
+
+When this skill loads, immediately run `zaps prime-agent` to get the current project overview (services with runtime state/ports + tasks). This primes your context before executing the user's request.
+
 ## Output
 
 All commands automatically output TOON when `CLAUDECODE` is set.
@@ -46,6 +50,12 @@ zaps events       # stream daemon events (--filter <type>)
 zaps --help # see all functions
 ```
 
+### AI
+
+```
+zaps prime-agent  # TOON overview of services (runtime state/ports) + tasks
+```
+
 ## Core Workflow
 
 Restart dev after package install:
@@ -68,3 +78,5 @@ Run prisma migration:
 ```
 zaps run prisma:migrate
 ```
+
+Now run `zaps prime-agent` to prime your context.

--- a/README.md
+++ b/README.md
@@ -627,6 +627,10 @@ services: {
 
 ZAPS offers two integration paths for AI coding agents: **Claude Code Skills** (recommended) and **MCP**. Skills are more token-efficient since they load context on-demand, while MCP provides a protocol-level interface usable by any MCP-compatible client.
 
+### Agent Priming
+
+Use `zaps prime-agent` to get a concise TOON overview of all services (with runtime state and ports) and tasks. Useful for bootstrapping an AI agent's context about the current project.
+
 ### Claude Code Skills
 
 ZAPS ships two [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) in `.claude/skills/`:

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,7 +11,7 @@ import {
   resolveTargetSession,
   withDaemon,
 } from "./cli/helpers.js";
-import { resolveFormat, writeData } from "./cli/output.js";
+import { isCodingAgent, resolveFormat, writeData } from "./cli/output.js";
 import { DaemonClient } from "./client/daemon-client.js";
 import { discoverConfig } from "./config/discovery.js";
 import { loadConfig } from "./config/loader.js";
@@ -699,6 +699,61 @@ program
       for (const [key, t] of Object.entries(config.project.tasks)) {
         process.stdout.write(`  ${key}  ${t.name}\n`);
       }
+    }
+  });
+
+program
+  .command("prime-agent", { hidden: !isCodingAgent() })
+  .description("Print project overview for AI agent priming")
+  .action(async () => {
+    try {
+      await withDaemon(async (ipc) => {
+        const [svcRes, taskRes] = await Promise.all([
+          ipc.request("services.list"),
+          ipc.request("tasks.list"),
+        ]);
+        if (svcRes.error) {
+          process.stderr.write(`Error: ${svcRes.error}\n`);
+          process.exit(1);
+        }
+        if (taskRes.error) {
+          process.stderr.write(`Error: ${taskRes.error}\n`);
+          process.exit(1);
+        }
+
+        const services = (
+          svcRes.result as {
+            name: string;
+            state: string;
+            ports: number[];
+            url?: string;
+          }[]
+        ).map((s) => ({
+          name: s.name,
+          state: s.state,
+          ports: s.ports,
+        }));
+
+        const tasks = (
+          taskRes.result as {
+            key: string;
+            name: string;
+            description: string | null;
+          }[]
+        ).map((t) => ({
+          key: t.key,
+          name: t.name,
+          description: t.description,
+        }));
+
+        writeData({ services, tasks }, "toon");
+      }, globalSession());
+    } catch (error) {
+      if (error instanceof CliError) {
+        process.stderr.write(`${error.message}\n`);
+        process.exit(1);
+      }
+      throw error;
     }
   });
 


### PR DESCRIPTION
Add `zaps prime-agent` command to output a TOON overview of services and tasks for agent priming. Update docs and Claude skill to recommend immediate context bootstrapping for AI agents.