### PR TITLE
feat(docker): add expand option for combined docker services

### DIFF
--- a/.claude/skills/zaps-config/references/04-docker.md
+++ b/.claude/skills/zaps-config/references/04-docker.md
@@ -177,6 +177,22 @@ Creates 3 individual services (`postgres`, `redis`, `mailpit`) that:
 
 Layout references use the group name: `{ pane: "infra" }`.
 
+Use `expand: { ... }` for per-child overrides:
+
+```ts
+infra: {
+  docker: {
+    service: ["caddy", "postgres", "bugsink"],
+    expand: {
+      postgres: { onReady: () => runTask("prisma:deploy") },
+      bugsink: { ready: { http: "http://localhost:8000/health" } },
+    },
+  },
+}
+```
+
+Children without overrides inherit parent config. Overrides can set `ready`, `env`, hooks, `url`, `flags`, `restart`, etc.
+
 ### Docker with Dependencies
 
 ```ts

--- a/.claude/skills/zaps-config/references/04-docker.md
+++ b/.claude/skills/zaps-config/references/04-docker.md
@@ -14,6 +14,7 @@ ZAPS integrates with `docker compose` via the `docker` property on services.
 | `removeOrphans` | `boolean`                          | `false`      | Remove orphan containers (`--remove-orphans`) |
 | `pull`          | `"always" \| "missing" \| "never"` | `undefined`  | Image pull policy (`--pull`)                  |
 | `noDeps`        | `boolean`                          | `false`      | Skip dependency services (`--no-deps`)        |
+| `expand`        | `boolean`                          | `false`      | Expand array services into individual entries |
 
 ## Command Generation
 
@@ -146,6 +147,35 @@ services: {
   },
 }
 ```
+
+### Expanded Docker Services
+
+Use `expand: true` with `service: string[]` to create individually addressable services sharing one pane:
+
+```ts
+services: {
+  infra: {
+    docker: {
+      service: ["postgres", "redis", "mailpit"],
+      expand: true,
+    },
+  },
+  api: {
+    start: "pnpm dev",
+    dependsOn: ["postgres"],  // reference expanded child
+  },
+}
+```
+
+Creates 3 individual services (`postgres`, `redis`, `mailpit`) that:
+
+- Share a single pane (one `docker compose up` command)
+- Have independent status, ready detection, lifecycle
+- Can be started/stopped/restarted individually
+- Can be referenced individually in `dependsOn`
+- Appear grouped under "infra" in the TUI
+
+Layout references use the group name: `{ pane: "infra" }`.
 
 ### Docker with Dependencies
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,28 @@ This creates three individual services (`postgres`, `redis`, `mailpit`) that:
 
 Layout references use the group name: `{ pane: "infra" }`.
 
+Use `expand: { ... }` instead of `expand: true` to provide per-child overrides:
+
+```typescript
+services: {
+  infra: {
+    docker: {
+      service: ["caddy", "postgres", "mailpit", "bugsink"],
+      expand: {
+        postgres: {
+          onReady: () => runTask("prisma:deploy"),
+        },
+        bugsink: {
+          ready: { http: "http://localhost:8000/health/ready" },
+        },
+      },
+    },
+  },
+}
+```
+
+Children without overrides inherit the parent config. Overrides can set `ready`, `env`, `onReady`, `onStop`, `onBeforeStart`, `url`, `flags`, `restart`, etc.
+
 ### Dependencies
 
 Services start in topological order. Services at the same level start in parallel:

--- a/README.md
+++ b/README.md
@@ -340,16 +340,47 @@ When a service has `docker` config and no `start`/`run`, ZAPS auto-generates a `
 
 If no `ready` config is provided, ZAPS defaults to checking the docker container state (running + healthy).
 
-| Option          | Type                               | Default | Description                               |
-| --------------- | ---------------------------------- | ------- | ----------------------------------------- |
-| `service`       | `string \| string[]`               | —       | Docker Compose service name(s) (required) |
-| `file`          | `string`                           | —       | Path to compose file                      |
-| `build`         | `boolean`                          | —       | `--build` flag                            |
-| `forceRecreate` | `boolean`                          | —       | `--force-recreate` flag                   |
-| `renewVolumes`  | `boolean`                          | —       | `-V` flag (recreate volumes)              |
-| `removeOrphans` | `boolean`                          | —       | `--remove-orphans` flag                   |
-| `pull`          | `"always" \| "missing" \| "never"` | —       | `--pull` strategy                         |
-| `noDeps`        | `boolean`                          | —       | `--no-deps` flag                          |
+| Option          | Type                               | Default | Description                                 |
+| --------------- | ---------------------------------- | ------- | ------------------------------------------- |
+| `service`       | `string \| string[]`               | —       | Docker Compose service name(s) (required)   |
+| `file`          | `string`                           | —       | Path to compose file                        |
+| `build`         | `boolean`                          | —       | `--build` flag                              |
+| `forceRecreate` | `boolean`                          | —       | `--force-recreate` flag                     |
+| `renewVolumes`  | `boolean`                          | —       | `-V` flag (recreate volumes)                |
+| `removeOrphans` | `boolean`                          | —       | `--remove-orphans` flag                     |
+| `pull`          | `"always" \| "missing" \| "never"` | —       | `--pull` strategy                           |
+| `noDeps`        | `boolean`                          | —       | `--no-deps` flag                            |
+| `expand`        | `boolean`                          | —       | Expand into individual services (see below) |
+
+### Expanded Docker Services
+
+When you have multiple Docker Compose services that can share a single tmux pane, use `expand: true` to split them into individually addressable services:
+
+```typescript
+services: {
+  infra: {
+    docker: {
+      service: ["postgres", "redis", "mailpit"],
+      expand: true,
+    },
+    restart: { maxRetries: 3 },
+  },
+  api: {
+    start: "npm run dev",
+    dependsOn: ["postgres"],  // reference individual expanded service
+  },
+}
+```
+
+This creates three individual services (`postgres`, `redis`, `mailpit`) that:
+
+- Share a single tmux pane (one `docker compose up` command)
+- Each have independent status, ready detection, and lifecycle
+- Can be started/stopped/restarted individually
+- Can be referenced individually in `dependsOn`
+- Appear as grouped rows in the TUI dashboard
+
+Layout references use the group name: `{ pane: "infra" }`.
 
 ### Dependencies
 

--- a/src/components/ServiceList.tsx
+++ b/src/components/ServiceList.tsx
@@ -18,15 +18,55 @@ function computeScrollOffset(selectedIndex: number, total: number, maxRows: numb
   return Math.max(0, Math.min(selectedIndex - half, total - maxRows));
 }
 
+/**
+ * Track which groups have been seen to render group headers.
+ * Returns the group name if this service is the first in its group, else undefined.
+ */
+function getGroupHeader(
+  status: ServiceStatus,
+  index: number,
+  statuses: ServiceStatus[],
+): string | undefined {
+  if (!status.group) {
+    return undefined;
+  }
+  // Show header if this is the first service in this group
+  if (index === 0 || statuses[index - 1].group !== status.group) {
+    return status.group;
+  }
+  return undefined;
+}
+
+function renderRow(
+  s: ServiceStatus,
+  i: number,
+  statuses: ServiceStatus[],
+  selectedIndex: number,
+  cols: number,
+) {
+  const groupHeader = getGroupHeader(s, i, statuses);
+  const isGrouped = Boolean(s.group);
+
+  return (
+    <Box key={s.name} flexDirection="column">
+      {groupHeader && (
+        <Text dimColor>
+          {"  "}
+          {groupHeader}
+        </Text>
+      )}
+      <ServiceRow status={s} isSelected={i === selectedIndex} cols={cols} indent={isGrouped} />
+    </Box>
+  );
+}
+
 export function ServiceList({ statuses, selectedIndex, maxRows, cols }: ServiceListProps) {
   const total = statuses.length;
 
   if (maxRows === undefined || maxRows <= 0 || total <= maxRows) {
     return (
       <Box flexDirection="column">
-        {statuses.map((s, i) => (
-          <ServiceRow key={s.name} status={s} isSelected={i === selectedIndex} cols={cols} />
-        ))}
+        {statuses.map((s, i) => renderRow(s, i, statuses, selectedIndex, cols))}
       </Box>
     );
   }
@@ -51,14 +91,7 @@ export function ServiceList({ statuses, selectedIndex, maxRows, cols }: ServiceL
           {"  "}↑ {above} more
         </Text>
       )}
-      {visible.map((s, i) => (
-        <ServiceRow
-          key={s.name}
-          status={s}
-          isSelected={i + adjOffset === selectedIndex}
-          cols={cols}
-        />
-      ))}
+      {visible.map((s, i) => renderRow(s, i + adjOffset, statuses, i + adjOffset, cols))}
       {below > 0 && (
         <Text dimColor>
           {"  "}↓ {below} more

--- a/src/components/ServiceRow.tsx
+++ b/src/components/ServiceRow.tsx
@@ -8,6 +8,7 @@ interface ServiceRowProps {
   status: ServiceStatus;
   isSelected: boolean;
   cols: number;
+  indent?: boolean;
 }
 
 function formatPorts(ports: number[]): string {
@@ -42,20 +43,24 @@ function stateLabel(status: ServiceStatus): string {
 
 // 4 chars: selector(2) + status(1) + space(1)
 const PREFIX_WIDTH = 4;
+const INDENT_WIDTH = 2;
 
-export function ServiceRow({ status, isSelected, cols }: ServiceRowProps) {
+export function ServiceRow({ status, isSelected, cols, indent }: ServiceRowProps) {
   const portsStr = formatPorts(status.ports);
-  const available = cols - PREFIX_WIDTH;
+  const indentStr = indent ? "  " : "";
+  const effectiveCols = indent ? cols - INDENT_WIDTH : cols;
+  const available = effectiveCols - PREFIX_WIDTH;
 
   // Cols >= 80: NAME(24) STATUS(10) PORTS(24) URL(rest)
   // Cols >= 50: NAME(20) STATUS(10) PORTS(rest)
   // Cols >= 30: NAME(rest) STATUS(8)
   // Cols < 30:  NAME only (truncated)
 
-  if (cols >= 80) {
+  if (effectiveCols >= 80) {
     return (
       <Box flexDirection="column">
         <Box>
+          <Text>{indentStr}</Text>
           <Text>{isSelected ? "> " : "  "}</Text>
           <StatusCell status={status} />
           <Text> </Text>
@@ -73,12 +78,13 @@ export function ServiceRow({ status, isSelected, cols }: ServiceRowProps) {
     );
   }
 
-  if (cols >= 50) {
+  if (effectiveCols >= 50) {
     const nameWidth = 20;
     const statusWidth = 10;
     return (
       <Box flexDirection="column">
         <Box>
+          <Text>{indentStr}</Text>
           <Text>{isSelected ? "> " : "  "}</Text>
           <StatusCell status={status} />
           <Text> </Text>
@@ -93,12 +99,13 @@ export function ServiceRow({ status, isSelected, cols }: ServiceRowProps) {
     );
   }
 
-  if (cols >= 30) {
+  if (effectiveCols >= 30) {
     const statusWidth = 8;
     const nameWidth = Math.max(4, available - statusWidth);
     return (
       <Box flexDirection="column">
         <Box>
+          <Text>{indentStr}</Text>
           <Text>{isSelected ? "> " : "  "}</Text>
           <StatusCell status={status} />
           <Text> </Text>
@@ -115,6 +122,7 @@ export function ServiceRow({ status, isSelected, cols }: ServiceRowProps) {
   return (
     <Box flexDirection="column">
       <Box>
+        <Text>{indentStr}</Text>
         <Text>{isSelected ? "> " : "  "}</Text>
         <StatusCell status={status} />
         <Text> </Text>

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -16,6 +16,28 @@ function collectPaneNames(node: LayoutNode): string[] {
   return [];
 }
 
+function validateExpandNames(
+  groupName: string,
+  childNames: string[],
+  overrides: Record<string, unknown>,
+  services: Record<string, unknown>,
+): void {
+  for (const childName of childNames) {
+    if (childName !== groupName && services[childName]) {
+      throw new Error(
+        `Docker expand collision: '${groupName}' expands '${childName}' which already exists as a service`,
+      );
+    }
+  }
+  for (const key of Object.keys(overrides)) {
+    if (!childNames.includes(key)) {
+      throw new Error(
+        `Docker expand override '${key}' in '${groupName}' is not a valid service name. Valid: ${childNames.join(", ")}`,
+      );
+    }
+  }
+}
+
 /**
  * Expand docker services with `expand: true` into individual child services.
  * Each child shares a pane but has independent lifecycle and status.
@@ -37,21 +59,11 @@ function expandDockerServices(project: ProjectConfig): Map<string, string[]> {
       // eslint-disable-next-line no-continue -- guarded by filter above
       continue;
     }
-    const { expand: _, service: svcNames, ...dockerFlags } = parentDocker;
+    const { expand: expandVal, service: svcNames, ...dockerFlags } = parentDocker;
     const childNames = Array.isArray(svcNames) ? svcNames : [svcNames];
+    const overrides = typeof expandVal === "object" ? expandVal : {};
 
-    // Validate no naming collisions
-    for (const childName of childNames) {
-      if (childName === groupName) {
-        // eslint-disable-next-line no-continue -- skip self-reference
-        continue;
-      }
-      if (project.services[childName]) {
-        throw new Error(
-          `Docker expand collision: '${groupName}' expands '${childName}' which already exists as a service`,
-        );
-      }
-    }
+    validateExpandNames(groupName, childNames, overrides, project.services);
 
     // Remove parent service
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing expanded parent
@@ -69,9 +81,15 @@ function expandDockerServices(project: ProjectConfig): Map<string, string[]> {
       // Non-owners implicitly depend on the owner (must wait for docker compose up)
       const childDeps = i === 0 ? inherited.dependsOn : [...(inherited.dependsOn ?? []), ownerName];
 
+      // Merge per-child overrides (ready, hooks, env, etc.)
+      const childOverride = overrides[childName] ?? {};
+
       project.services[childName] = {
         ...inherited,
-        dependsOn: childDeps,
+        ...childOverride,
+        dependsOn: childOverride.dependsOn
+          ? [...(childDeps ?? []), ...childOverride.dependsOn]
+          : childDeps,
         docker: { ...dockerFlags, service: childName },
         _combined: combined,
       };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -57,6 +57,7 @@ function expandDockerServices(project: ProjectConfig): Map<string, string[]> {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing expanded parent
     delete project.services[groupName];
 
+    const [ownerName] = childNames;
     for (let i = 0; i < childNames.length; i += 1) {
       const childName = childNames[i];
       const combined: CombinedServiceMeta = {
@@ -65,8 +66,12 @@ function expandDockerServices(project: ProjectConfig): Map<string, string[]> {
         isOwner: i === 0,
       };
 
+      // Non-owners implicitly depend on the owner (must wait for docker compose up)
+      const childDeps = i === 0 ? inherited.dependsOn : [...(inherited.dependsOn ?? []), ownerName];
+
       project.services[childName] = {
         ...inherited,
+        dependsOn: childDeps,
         docker: { ...dockerFlags, service: childName },
         _combined: combined,
       };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { detectCycles } from "#src/lib/service/graph.js";
 
 import { createZapsLib } from "./builder.js";
-import type { LayoutNode, ProjectConfig, ResolvedConfig } from "./types.js";
+import type { CombinedServiceMeta, LayoutNode, ProjectConfig, ResolvedConfig } from "./types.js";
 import { isLayoutLeaf, isLayoutSplit } from "./types.js";
 
 function collectPaneNames(node: LayoutNode): string[] {
@@ -14,6 +14,78 @@ function collectPaneNames(node: LayoutNode): string[] {
     return node.children.flatMap(collectPaneNames);
   }
   return [];
+}
+
+/**
+ * Expand docker services with `expand: true` into individual child services.
+ * Each child shares a pane but has independent lifecycle and status.
+ */
+function expandDockerServices(project: ProjectConfig): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  const toExpand: [string, (typeof project.services)[string]][] = [];
+
+  for (const [name, svc] of Object.entries(project.services)) {
+    if (svc.docker?.expand && Array.isArray(svc.docker.service)) {
+      toExpand.push([name, svc]);
+    }
+  }
+
+  for (const [groupName, svc] of toExpand) {
+    // Create child services — destructure parent to inherit non-docker props
+    const { docker: parentDocker, ...inherited } = svc;
+    if (!parentDocker) {
+      // eslint-disable-next-line no-continue -- guarded by filter above
+      continue;
+    }
+    const { expand: _, service: svcNames, ...dockerFlags } = parentDocker;
+    const childNames = Array.isArray(svcNames) ? svcNames : [svcNames];
+
+    // Validate no naming collisions
+    for (const childName of childNames) {
+      if (childName === groupName) {
+        // eslint-disable-next-line no-continue -- skip self-reference
+        continue;
+      }
+      if (project.services[childName]) {
+        throw new Error(
+          `Docker expand collision: '${groupName}' expands '${childName}' which already exists as a service`,
+        );
+      }
+    }
+
+    // Remove parent service
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing expanded parent
+    delete project.services[groupName];
+
+    for (let i = 0; i < childNames.length; i += 1) {
+      const childName = childNames[i];
+      const combined: CombinedServiceMeta = {
+        group: groupName,
+        allServices: [...childNames],
+        isOwner: i === 0,
+      };
+
+      project.services[childName] = {
+        ...inherited,
+        docker: { ...dockerFlags, service: childName },
+        _combined: combined,
+      };
+    }
+
+    groups.set(groupName, [...childNames]);
+  }
+
+  // Rewrite dependsOn/restartWith: expand group name refs to all children
+  for (const svc of Object.values(project.services)) {
+    if (svc.dependsOn) {
+      svc.dependsOn = svc.dependsOn.flatMap((dep) => groups.get(dep) ?? [dep]);
+    }
+    if (svc.restartWith) {
+      svc.restartWith = svc.restartWith.flatMap((dep) => groups.get(dep) ?? [dep]);
+    }
+  }
+
+  return groups;
 }
 
 function validateServiceDeps(project: ProjectConfig): void {
@@ -37,7 +109,7 @@ function validateServiceDeps(project: ProjectConfig): void {
   }
 }
 
-function validateSemantics(project: ProjectConfig): void {
+function validateSemantics(project: ProjectConfig, groups: Map<string, string[]>): void {
   validateServiceDeps(project);
 
   // Validate task dependsOn refs
@@ -53,12 +125,12 @@ function validateSemantics(project: ProjectConfig): void {
     }
   }
 
-  // Validate layout pane refs
+  // Validate layout pane refs (accept group names as valid pane refs)
   if (project.layout) {
     const paneNames = collectPaneNames(project.layout);
 
     for (const pane of paneNames) {
-      if (pane !== "@tui" && !project.services[pane]) {
+      if (pane !== "@tui" && !project.services[pane] && !groups.has(pane)) {
         throw new Error(`Layout references unknown pane '${pane}'`);
       }
     }
@@ -107,15 +179,19 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
 
   const projectDir = resolveProjectDir(project.cwd, configDir, resolvedInvokeDir);
 
+  // Expand docker services with expand: true before validation
+  const groups = expandDockerServices(project);
+
   const name = project.name || path.basename(projectDir);
   const resolved = { ...project, name };
 
-  validateSemantics(resolved);
+  validateSemantics(resolved, groups);
 
   return {
     project: resolved,
     configPath,
     projectDir,
     bindActions,
+    groups,
   };
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -56,6 +56,7 @@ const dockerConfigSchema = z.object({
   removeOrphans: z.optional(z.boolean()),
   pull: z.optional(z.enum(["always", "missing", "never"])),
   noDeps: z.optional(z.boolean()),
+  expand: z.optional(z.boolean()),
 });
 
 // === Env Config ===

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -56,7 +56,9 @@ const dockerConfigSchema = z.object({
   removeOrphans: z.optional(z.boolean()),
   pull: z.optional(z.enum(["always", "missing", "never"])),
   noDeps: z.optional(z.boolean()),
-  expand: z.optional(z.boolean()),
+  expand: z.optional(
+    z.union([z.boolean(), z.record(z.string(), z.record(z.string(), z.unknown()))]),
+  ),
 });
 
 // === Env Config ===

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -31,6 +31,14 @@ export interface DockerConfig {
   removeOrphans?: boolean;
   pull?: "always" | "missing" | "never";
   noDeps?: boolean;
+  expand?: boolean;
+}
+
+// === Combined Service Metadata ===
+export interface CombinedServiceMeta {
+  group: string;
+  allServices: string[];
+  isOwner: boolean;
 }
 
 // === Service Context ===
@@ -74,6 +82,8 @@ export interface ServiceConfig {
   onReady?: () => void | Promise<void>;
   onStop?: () => void | Promise<void>;
   onOutput?: (line: string) => void | Promise<void>;
+  /** @internal Set by loader for expanded docker services */
+  _combined?: CombinedServiceMeta;
 }
 
 // === Task Run Context ===
@@ -167,6 +177,8 @@ export interface ResolvedConfig {
   configPath: string;
   projectDir: string;
   bindActions?: (actions: LibraryActions) => void;
+  /** Maps group name → expanded child service names (from docker expand) */
+  groups: Map<string, string[]>;
 }
 
 // === Type Guards ===

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -31,8 +31,14 @@ export interface DockerConfig {
   removeOrphans?: boolean;
   pull?: "always" | "missing" | "never";
   noDeps?: boolean;
-  expand?: boolean;
+  expand?: boolean | Record<string, ExpandChildOverrides>;
 }
+
+/** Per-child overrides for expanded docker services */
+export type ExpandChildOverrides = Omit<
+  Partial<ServiceConfig>,
+  "docker" | "start" | "run" | "_combined"
+>;
 
 // === Combined Service Metadata ===
 export interface CombinedServiceMeta {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
+import { promisify } from "node:util";
 
 import { loadConfig } from "#src/config/loader.js";
 import { ipcErr, ipcOk } from "#src/lib/ipc/protocol.js";
@@ -23,6 +25,8 @@ import { daemonHandlers } from "./handlers/daemon.js";
 import { sessionHandlers } from "./handlers/session.js";
 import type { SessionCreateParams } from "./session.js";
 import { Session, sessionId } from "./session.js";
+
+const execFileAsync = promisify(execFile);
 
 interface SessionStore {
   list(): Session[];
@@ -129,6 +133,7 @@ class DaemonServer implements SessionStore {
       params.originPane,
       config.project.layout,
       config.project.services,
+      config.groups,
     );
     await selectPane(focusPane);
 
@@ -144,6 +149,9 @@ class DaemonServer implements SessionStore {
       getWindowName,
       getWindowOption,
       setWindowOption,
+      exec: async (cmd: string, args: string[], cwd?: string) => {
+        await execFileAsync(cmd, args, cwd ? { cwd } : {});
+      },
     };
 
     // Create ServiceManager

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -29,6 +29,7 @@ export interface ServiceMeta {
   name: string;
   dependsOn: string[];
   hasDocker: boolean;
+  group?: string;
   dockerDefaults: {
     build: boolean;
     forceRecreate: boolean;
@@ -160,10 +161,29 @@ export class Session {
   async startAll(): Promise<void> {
     await this.manager.startAll();
 
-    // Start log monitoring for each service pane
+    // Start log monitoring for each service pane.
+    // For combined groups, start one monitor per shared pane and route to all children.
+    const monitoredPanes = new Set<string>();
     for (const [svcName, paneId] of Object.entries(this.paneMap)) {
-      if (svcName !== "@tui") {
+      if (svcName !== "@tui" && !monitoredPanes.has(paneId)) {
+        monitoredPanes.add(paneId);
         this.logMonitor.start(svcName, paneId);
+      }
+    }
+
+    // For combined children that share a pane, create buffer aliases
+    // So logs requested by child name return the shared pane's output
+    for (const [svcName] of Object.entries(this.paneMap)) {
+      if (svcName !== "@tui" && !this.logBuffers.has(svcName)) {
+        // Find which service's buffer covers this pane
+        const paneId = this.paneMap[svcName];
+        for (const [existingName, existingPaneId] of Object.entries(this.paneMap)) {
+          const existingBuffer = this.logBuffers.get(existingName);
+          if (existingPaneId === paneId && existingBuffer) {
+            this.logBuffers.set(svcName, existingBuffer);
+            break;
+          }
+        }
       }
     }
   }
@@ -197,6 +217,7 @@ export class Session {
       tuiPaneId,
       newConfig.project.layout,
       newConfig.project.services,
+      newConfig.groups,
     );
 
     // 6. Create new ServiceManager
@@ -288,6 +309,7 @@ export class Session {
         name: svcName,
         dependsOn: svc.dependsOn ?? [],
         hasDocker: Boolean(svc.docker),
+        group: svc._combined?.group,
         dockerDefaults: {
           build: svc.docker?.build ?? false,
           forceRecreate: svc.docker?.forceRecreate ?? false,

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -47,6 +47,14 @@ async function sleep(ms: number): Promise<void> {
 
 function resolveCommand(config: ServiceConfig): string {
   if (config.docker && !config.start && !config.run) {
+    // For combined owner: build command with ALL services in the group
+    if (config._combined?.isOwner) {
+      const groupDocker: DockerConfig = {
+        ...config.docker,
+        service: config._combined.allServices,
+      };
+      return buildDockerCommand(groupDocker);
+    }
     return buildDockerCommand(config.docker);
   }
   const cmd = config.start ?? config.run;
@@ -54,6 +62,22 @@ function resolveCommand(config: ServiceConfig): string {
     return cmd();
   }
   return cmd ?? "";
+}
+
+/**
+ * Build docker compose args for operating on a single service in a combined group.
+ */
+function buildDockerComposeArgs(
+  action: "stop" | "start" | "restart",
+  serviceName: string,
+  composeFile?: string,
+): string[] {
+  const args = ["compose"];
+  if (composeFile) {
+    args.push("-f", composeFile);
+  }
+  args.push(action, serviceName);
+  return args;
 }
 
 function resolveReadyConfig(config: ServiceConfig): ReadyConfig | undefined {
@@ -153,6 +177,9 @@ export class ServiceManager extends EventEmitter {
       const status = createServiceStatus(name);
       if (svc.docker) {
         status.isDocker = true;
+      }
+      if (svc._combined) {
+        status.group = svc._combined.group;
       }
       this.statuses.set(name, status);
     }
@@ -317,19 +344,7 @@ export class ServiceManager extends EventEmitter {
       this.emit("stateChange", name, status);
     }
 
-    // Resolve env
-    const ctx = buildServiceContext(this.statuses, this.config.projectDir);
-    const env = resolveEnv(serviceConfig.env, ctx);
-
-    // Build command
-    const resolvedCommand = resolveCommand(serviceConfig);
-    const envPrefix = formatEnvForShell(env);
-    const cwd = serviceConfig.cwd ?? this.config.projectDir;
-    const cmdWithEnv = envPrefix ? `${envPrefix} ${resolvedCommand}` : resolvedCommand;
-    const command = `cd ${JSON.stringify(cwd)} && ${cmdWithEnv}`;
-
-    // Send to pane
-    await this.deps.sendKeys(paneTarget, command);
+    await this.sendStartCommand(name, serviceConfig, paneTarget);
 
     // Wait for ready
     try {
@@ -349,6 +364,7 @@ export class ServiceManager extends EventEmitter {
       status.ports = ports;
       status.readySince = Date.now();
 
+      const ctx = buildServiceContext(this.statuses, this.config.projectDir);
       await this.onServiceReady(name, serviceConfig, status, ports, ctx);
     } catch (error) {
       // If aborted during stop, don't transition to error
@@ -360,6 +376,42 @@ export class ServiceManager extends EventEmitter {
       delete status.readySince;
       this.emit("stateChange", name, status);
     }
+  }
+
+  /**
+   * Send the start command for a service — handles combined vs regular.
+   */
+  private async sendStartCommand(
+    name: string,
+    serviceConfig: ServiceConfig,
+    paneTarget: string,
+  ): Promise<void> {
+    const combined = serviceConfig._combined;
+
+    if (combined && !combined.isOwner) {
+      // Combined non-owner: start individual container via docker compose
+      const [ownerName] = combined.allServices;
+      const ownerStatus = this.statuses.get(ownerName);
+      if (ownerStatus && (ownerStatus.state === "ready" || ownerStatus.state === "starting")) {
+        await this.deps.exec(
+          "docker",
+          buildDockerComposeArgs("start", name, serviceConfig.docker?.file),
+          serviceConfig.cwd ?? this.config.projectDir,
+        );
+      }
+      // If owner not running, skip — the owner will start all containers
+      return;
+    }
+
+    // Regular or combined owner: send command to pane
+    const ctx = buildServiceContext(this.statuses, this.config.projectDir);
+    const env = resolveEnv(serviceConfig.env, ctx);
+    const resolvedCommand = resolveCommand(serviceConfig);
+    const envPrefix = formatEnvForShell(env);
+    const cwd = serviceConfig.cwd ?? this.config.projectDir;
+    const cmdWithEnv = envPrefix ? `${envPrefix} ${resolvedCommand}` : resolvedCommand;
+    const command = `cd ${JSON.stringify(cwd)} && ${cmdWithEnv}`;
+    await this.deps.sendKeys(paneTarget, command);
   }
 
   private async onServiceReady(
@@ -417,43 +469,39 @@ export class ServiceManager extends EventEmitter {
     status.state = transition(status.state, "stopping");
     this.emit("stateChange", name, status);
 
-    // Send Ctrl-C
-    await this.deps.sendCtrlC(paneTarget);
-
     // Abort any pending ready poll
     const controller = this.abortControllers.get(name);
     if (controller) {
       controller.abort();
     }
 
-    // Poll for process exit with 5s timeout
-    const stopStart = Date.now();
-    const STOP_TIMEOUT = 5000;
-    let exited = false;
+    const combined = serviceConfig._combined;
 
-    while (Date.now() - stopStart < STOP_TIMEOUT) {
-      const rootPid = await this.deps.panePid(paneTarget);
-      const descendants = await this.deps.getDescendantPids(rootPid);
-      if (descendants.length <= 1) {
-        exited = true;
-        break;
-      }
-      await sleep(200);
-    }
+    if (combined) {
+      // Combined service: stop individual container via docker compose stop
+      await this.deps.exec(
+        "docker",
+        buildDockerComposeArgs("stop", name, serviceConfig.docker?.file),
+        serviceConfig.cwd ?? this.config.projectDir,
+      );
 
-    // Force kill if not exited
-    if (!exited) {
-      const rootPid = await this.deps.panePid(paneTarget);
-      const pids = await this.deps.getDescendantPids(rootPid);
-      for (const pid of pids) {
-        if (pid !== rootPid) {
-          try {
-            process.kill(pid, "SIGKILL");
-          } catch {
-            // Process may have already exited
-          }
+      // If ALL siblings are now stopped, Ctrl-C the pane to clean up docker compose up
+      const allStopped = combined.allServices.every((sib) => {
+        if (sib === name) {
+          return true;
         }
+        const sibStatus = this.statuses.get(sib);
+        return !sibStatus || sibStatus.state === "stopped" || sibStatus.state === "error";
+      });
+
+      if (allStopped) {
+        await this.deps.sendCtrlC(paneTarget);
+        await this.waitForPaneExit(paneTarget);
       }
+    } else {
+      // Regular service: Ctrl-C and wait for exit
+      await this.deps.sendCtrlC(paneTarget);
+      await this.waitForPaneExit(paneTarget);
     }
 
     // Transition: stopping -> stopped
@@ -472,6 +520,39 @@ export class ServiceManager extends EventEmitter {
   }
 
   /**
+   * Wait for pane process to exit with 5s timeout, force kill if needed.
+   */
+  private async waitForPaneExit(paneTarget: string): Promise<void> {
+    const stopStart = Date.now();
+    const STOP_TIMEOUT = 5000;
+    let exited = false;
+
+    while (Date.now() - stopStart < STOP_TIMEOUT) {
+      const rootPid = await this.deps.panePid(paneTarget);
+      const descendants = await this.deps.getDescendantPids(rootPid);
+      if (descendants.length <= 1) {
+        exited = true;
+        break;
+      }
+      await sleep(200);
+    }
+
+    if (!exited) {
+      const rootPid = await this.deps.panePid(paneTarget);
+      const pids = await this.deps.getDescendantPids(rootPid);
+      for (const pid of pids) {
+        if (pid !== rootPid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // Process may have already exited
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Restart a single service.
    */
   async restartService(name: string): Promise<void> {
@@ -480,16 +561,49 @@ export class ServiceManager extends EventEmitter {
       throw new Error(`Unknown service: ${name}`);
     }
 
-    // Stop if running
-    if (status.state === "ready" || status.state === "starting") {
-      await this.stopService(name);
+    const serviceConfig = this.config.project.services[name];
+    const combined = serviceConfig?._combined;
+
+    // For combined non-owner: use docker compose restart directly
+    if (
+      combined &&
+      !combined.isOwner &&
+      (status.state === "ready" || status.state === "starting")
+    ) {
+      // Abort any pending ready poll
+      const controller = this.abortControllers.get(name);
+      if (controller) {
+        controller.abort();
+      }
+
+      status.state = transition(status.state, "stopping");
+      this.emit("stateChange", name, status);
+
+      await this.deps.exec(
+        "docker",
+        buildDockerComposeArgs("restart", name, serviceConfig.docker?.file),
+        serviceConfig.cwd ?? this.config.projectDir,
+      );
+
+      status.state = transition(status.state, "stopped");
+      delete status.readySince;
+      delete status.url;
+      this.emit("stateChange", name, status);
+
+      status.retryCount = 0;
+      await this.startService(name);
+    } else {
+      // Stop if running
+      if (status.state === "ready" || status.state === "starting") {
+        await this.stopService(name);
+      }
+
+      // Reset retry count
+      status.retryCount = 0;
+
+      // Start
+      await this.startService(name);
     }
-
-    // Reset retry count
-    status.retryCount = 0;
-
-    // Start
-    await this.startService(name);
 
     // Cascade restart dependents
     if (!this.cascadingTriggers.has(name)) {
@@ -569,8 +683,9 @@ export class ServiceManager extends EventEmitter {
       return;
     }
     const config = this.config.project.services[name];
+    const combined = config._combined;
 
-    // Poll every 2s: check if process still alive
+    // Poll every 2s: check if process/container still alive
     while (status.state === "ready") {
       await sleep(2000);
       // Re-check state after sleep (stopService may have changed it)
@@ -578,11 +693,24 @@ export class ServiceManager extends EventEmitter {
         return;
       }
 
-      const rootPid = await this.deps.panePid(this.paneMap[name]);
-      const descendants = await this.deps.getDescendantPids(rootPid);
+      let crashed = false;
 
-      // If only shell PID left (no child), service has crashed
-      if (descendants.length <= 1) {
+      if (combined) {
+        // Combined docker service: check container status
+        const info = await getContainerInfo(
+          name,
+          config.cwd ?? this.config.projectDir,
+          config.docker?.file,
+        );
+        crashed = !info || info.state !== "running";
+      } else {
+        const rootPid = await this.deps.panePid(this.paneMap[name]);
+        const descendants = await this.deps.getDescendantPids(rootPid);
+        // If only shell PID left (no child), service has crashed
+        crashed = descendants.length <= 1;
+      }
+
+      if (crashed) {
         const restartConfig = config.restart;
         if (restartConfig && status.retryCount < (restartConfig.maxRetries ?? 3)) {
           status.state = transition(status.state, "restarting");
@@ -729,6 +857,7 @@ export interface ServiceManagerDeps {
   getWindowName: (target: string) => Promise<string>;
   getWindowOption: (target: string, option: string) => Promise<string>;
   setWindowOption: (target: string, option: string, value: string) => Promise<void>;
+  exec: (cmd: string, args: string[], cwd?: string) => Promise<void>;
 }
 
 export { diffOutput };

--- a/src/lib/service/types.ts
+++ b/src/lib/service/types.ts
@@ -27,6 +27,8 @@ export interface ServiceStatus {
   lastError?: string;
   readySince?: number;
   isDocker?: boolean;
+  /** Group name for expanded docker services */
+  group?: string;
 }
 
 // === Dependency injection interfaces ===

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -87,12 +87,31 @@ function collectFocusedPanes(node: LayoutNode): string[] {
   return [];
 }
 
-export function validateLayout(layout: LayoutNode, serviceNames: string[]): void {
+/**
+ * After layout walk, expand group pane mappings so each child service
+ * in an expanded docker group shares the same tmux pane as the group.
+ */
+function expandGroupPanes(paneMap: PaneMap, groups: Map<string, string[]>): void {
+  for (const [groupName, children] of groups) {
+    const groupPaneId = paneMap[groupName];
+    if (groupPaneId) {
+      for (const child of children) {
+        paneMap[child] = groupPaneId;
+      }
+    }
+  }
+}
+
+export function validateLayout(
+  layout: LayoutNode,
+  serviceNames: string[],
+  groups?: Map<string, string[]>,
+): void {
   const paneNames = collectPaneNames(layout);
   const seen = new Set<string>();
 
   for (const pane of paneNames) {
-    if (pane !== "@tui" && !serviceNames.includes(pane)) {
+    if (pane !== "@tui" && !serviceNames.includes(pane) && !groups?.has(pane)) {
       throw new Error(`Layout references unknown pane '${pane}'`);
     }
     if (seen.has(pane)) {
@@ -119,16 +138,37 @@ export async function createLayout(
   startPaneId: string,
   layout: LayoutNode | undefined,
   services: Record<string, ServiceConfig>,
+  groups?: Map<string, string[]>,
 ): Promise<{ paneMap: PaneMap; focusPane: string }> {
   const paneMap: PaneMap = {};
   const serviceNames = Object.keys(services);
+  // Collect all child names from groups that are already individual services
+  const groupChildNames = new Set<string>();
+  if (groups) {
+    for (const children of groups.values()) {
+      for (const child of children) {
+        groupChildNames.add(child);
+      }
+    }
+  }
 
   if (!layout) {
     // Case 1: No layout — @tui gets start pane, each service gets a split pane
     paneMap["@tui"] = startPaneId;
 
+    // Create one pane per group (shared by all children)
+    if (groups) {
+      for (const [groupName, children] of groups) {
+        const paneId = await splitPane(startPaneId, "v");
+        paneMap[groupName] = paneId;
+        for (const child of children) {
+          paneMap[child] = paneId;
+        }
+      }
+    }
+
     for (const name of serviceNames) {
-      if (!services[name].detached) {
+      if (!services[name].detached && !(name in paneMap)) {
         const paneId = await splitPane(startPaneId, "v");
         paneMap[name] = paneId;
       }
@@ -140,7 +180,12 @@ export async function createLayout(
   // Case 2: Layout tree provided
   const focusName = await walkLayout(layout, startPaneId, paneMap);
 
-  // Services not in layout get split panes (skip detached)
+  // Expand group panes: map child services to their group's pane
+  if (groups) {
+    expandGroupPanes(paneMap, groups);
+  }
+
+  // Services not in layout get split panes (skip detached and group children already mapped)
   for (const name of serviceNames) {
     if (!services[name].detached && !(name in paneMap)) {
       const paneId = await splitPane(startPaneId, "v");

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 // Mock tmux functions to prevent real tmux commands
@@ -30,16 +31,6 @@ import type { DaemonClient } from "../src/client/daemon-client.js";
 import { App } from "../src/components/App.js";
 import type { ServiceMeta, TaskInfo } from "../src/daemon/session.js";
 import type { ServiceStatus } from "../src/lib/service/types.js";
-
-// Flush React/Ink reconciler
-async function act(fn?: () => void): Promise<void> {
-  if (fn) {
-    fn();
-  }
-  return new Promise((resolve) => {
-    setTimeout(resolve, 150);
-  });
-}
 
 // ANSI escape sequences for special keys
 const ARROW_UP = "\x1B[A";
@@ -134,7 +125,7 @@ describe("Keyboard routing — Dashboard", () => {
     const { lastFrame, stdin } = renderApp({ statuses });
 
     // Move down — api should be selected
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
     const frame = lastFrame() ?? "";
@@ -151,10 +142,12 @@ describe("Keyboard routing — Dashboard", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("r");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.restartService)).toHaveBeenCalledWith("db");
   });
@@ -166,10 +159,12 @@ describe("Keyboard routing — Dashboard", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("s");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     // Toggle tries stopService first (succeeds for running service)
     expect(vi.mocked(client.stopService)).toHaveBeenCalledWith("db");
@@ -182,10 +177,12 @@ describe("Keyboard routing — Dashboard", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("a");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.restartAll)).toHaveBeenCalledTimes(1);
   });
@@ -197,10 +194,12 @@ describe("Keyboard routing — Dashboard", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("q");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
@@ -212,10 +211,12 @@ describe("Keyboard routing — Dashboard", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("d");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.destroySession)).toHaveBeenCalled();
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
@@ -229,7 +230,7 @@ describe("Keyboard routing — Dashboard", () => {
     const { stdin, lastFrame } = renderApp({ statuses });
 
     // Should not throw
-    await act(() => {
+    act(() => {
       stdin.write("o");
     });
     expect(lastFrame()).toContain("db");
@@ -247,7 +248,7 @@ describe("Keyboard routing — View switching", () => {
 
     const { lastFrame, stdin } = renderApp({ statuses, tasks, projectName: "test" });
 
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
 
@@ -267,13 +268,13 @@ describe("Keyboard routing — View switching", () => {
 
     const { lastFrame, stdin } = renderApp({ statuses, tasks, projectName: "test" });
 
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
     expect(lastFrame()).toContain("[enter] run");
 
     // Go back
-    await act(() => {
+    await act(async () => {
       stdin.write(ESCAPE);
     });
     expect(lastFrame()).toContain("[t]asks");
@@ -291,10 +292,10 @@ describe("Keyboard routing — View switching", () => {
     });
 
     // Select api (index 1) then press l
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
-    await act(() => {
+    act(() => {
       stdin.write("l");
     });
 
@@ -315,13 +316,13 @@ describe("Keyboard routing — View switching", () => {
     });
 
     // Go to logs
-    await act(() => {
+    act(() => {
       stdin.write("l");
     });
     expect(lastFrame()).toContain("[esc] back");
 
     // Go back
-    await act(() => {
+    await act(async () => {
       stdin.write(ESCAPE);
     });
     expect(lastFrame()).toContain("[t]asks");
@@ -333,10 +334,10 @@ describe("Keyboard routing — Edge cases", () => {
     const { lastFrame, stdin } = renderApp({});
 
     // Should not throw
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_UP);
     });
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
     expect(lastFrame()).toContain("zaps");
@@ -345,13 +346,15 @@ describe("Keyboard routing — Edge cases", () => {
   it("r/s with no services is a no-op", async () => {
     const { stdin, client } = renderApp({});
 
-    await act(() => {
+    act(() => {
       stdin.write("r");
     });
-    await act(() => {
+    act(() => {
       stdin.write("s");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.restartService)).not.toHaveBeenCalled();
     expect(vi.mocked(client.stopService)).not.toHaveBeenCalled();
@@ -375,10 +378,10 @@ describe("Keyboard routing — Edge cases", () => {
     const { stdin } = renderApp({ statuses, client });
 
     // Press r twice rapidly
-    await act(() => {
+    act(() => {
       stdin.write("r");
     });
-    await act(() => {
+    act(() => {
       stdin.write("r");
     });
 
@@ -387,7 +390,9 @@ describe("Keyboard routing — Edge cases", () => {
 
     // Resolve to clean up
     resolveRestart();
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
   });
 });
 
@@ -399,10 +404,12 @@ describe("Keyboard routing — ctrl keys", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("\x03"); // Ctrl+c
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
@@ -414,10 +421,12 @@ describe("Keyboard routing — ctrl keys", () => {
 
     const { stdin, client } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("\x04"); // Ctrl+d
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.destroySession)).toHaveBeenCalled();
   });
@@ -431,14 +440,16 @@ describe("Keyboard routing — ctrl keys", () => {
     const { stdin, client } = renderApp({ statuses, tasks });
 
     // Switch to tasks view
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
     // Then ctrl+d
-    await act(() => {
+    act(() => {
       stdin.write("\x04");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.destroySession)).toHaveBeenCalled();
   });
@@ -450,13 +461,15 @@ describe("Keyboard routing — ctrl keys", () => {
 
     const { stdin, client } = renderApp({ statuses, paneMap: { db: "%0" } });
 
-    await act(() => {
+    act(() => {
       stdin.write("l");
     });
-    await act(() => {
+    act(() => {
       stdin.write("\x03");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
@@ -471,13 +484,15 @@ describe("Keyboard routing — Tasks view", () => {
 
     const { stdin, client } = renderApp({ statuses, tasks });
 
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
-    await act(() => {
+    act(() => {
       stdin.write("\r"); // Enter
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.runTask)).toHaveBeenCalled();
   });
@@ -493,14 +508,16 @@ describe("Keyboard routing — Tasks view", () => {
 
     const { stdin, client } = renderApp({ statuses, tasks });
 
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
     // Press shortcut for second task
-    await act(() => {
+    act(() => {
       stdin.write("x");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     expect(vi.mocked(client.runTask)).toHaveBeenCalled();
   });
@@ -516,10 +533,10 @@ describe("Keyboard routing — Tasks view", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses, tasks });
 
-    await act(() => {
+    act(() => {
       stdin.write("t");
     });
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
 
@@ -550,7 +567,7 @@ describe("Keyboard routing — Docker rebuild", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses, servicesMeta });
 
-    await act(() => {
+    act(() => {
       stdin.write("R");
     });
 
@@ -566,7 +583,7 @@ describe("Keyboard routing — Docker rebuild", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("R");
     });
 
@@ -596,22 +613,24 @@ describe("Keyboard routing — Docker rebuild", () => {
     const { stdin, lastFrame } = renderApp({ statuses, servicesMeta });
 
     // Open docker rebuild
-    await act(() => {
+    act(() => {
       stdin.write("R");
     });
     // Toggle first flag (build)
-    await act(() => {
+    act(() => {
       stdin.write(" ");
     });
     // Move down to next flag
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
     // Press enter to submit
-    await act(() => {
+    act(() => {
       stdin.write("\r");
     });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     // After enter, view returns to dashboard
     expect(lastFrame()).toContain("[t]asks");
@@ -638,10 +657,10 @@ describe("Keyboard routing — Docker rebuild", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses, servicesMeta });
 
-    await act(() => {
+    act(() => {
       stdin.write("R");
     });
-    await act(() => {
+    act(() => {
       stdin.write(ESCAPE);
     });
 
@@ -670,16 +689,16 @@ describe("Keyboard routing — Docker rebuild", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses, servicesMeta });
 
-    await act(() => {
+    act(() => {
       stdin.write("R");
     });
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_UP);
     });
 
@@ -696,24 +715,24 @@ describe("Keyboard routing — Logs scroll", () => {
     const { lastFrame, stdin } = renderApp({ statuses, paneMap: { db: "%0" } });
 
     // Go to logs
-    await act(() => {
+    act(() => {
       stdin.write("l");
     });
     expect(lastFrame()).toContain("[esc] back");
 
     // Scroll up
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_UP);
     });
     // Scroll down
-    await act(() => {
+    act(() => {
       stdin.write(ARROW_DOWN);
     });
     // K/j also scroll
-    await act(() => {
+    act(() => {
       stdin.write("k");
     });
-    await act(() => {
+    act(() => {
       stdin.write("j");
     });
 
@@ -731,7 +750,7 @@ describe("Keyboard routing — Dashboard special keys", () => {
 
     const { stdin } = renderApp({ statuses });
 
-    await act(() => {
+    act(() => {
       stdin.write("o");
     });
     expect(vi.mocked(openInBrowser)).toHaveBeenCalledWith("http://localhost:3000");
@@ -745,7 +764,7 @@ describe("Keyboard routing — Dashboard special keys", () => {
 
     const { stdin } = renderApp({ statuses, paneMap: { api: "%1" } });
 
-    await act(() => {
+    act(() => {
       stdin.write("z");
     });
     expect(vi.mocked(zoomPane)).toHaveBeenCalledWith("%1");
@@ -759,7 +778,7 @@ describe("Keyboard routing — Dashboard special keys", () => {
 
     const { stdin, lastFrame } = renderApp({ statuses, paneMap: { api: "%1" } });
 
-    await act(() => {
+    act(() => {
       stdin.write("E");
     });
     expect(vi.mocked(editPaneCapture)).toHaveBeenCalledWith("%1", "api");
@@ -775,15 +794,21 @@ describe("Router — task event handling", () => {
     const client = createMockClient(statuses);
 
     const { lastFrame } = renderApp({ statuses, client });
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     // Simulate daemon task.start event
     (client as unknown as EventEmitter).emit("task.start", "build", "Build");
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     // Simulate daemon task.complete event
     (client as unknown as EventEmitter).emit("task.complete", "build", "Build", "success");
-    await act();
+    await act(async () => {
+      /* Flush */
+    });
 
     // Dashboard should reflect task history
     expect(lastFrame()).toBeDefined();

--- a/test/components/ColumnHeaders.test.tsx
+++ b/test/components/ColumnHeaders.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { ColumnHeaders } from "../../src/components/ColumnHeaders.js";
+
+describe("ColumnHeaders", () => {
+  it("renders wide layout (cols >= 80) with NAME STATUS PORTS URL", () => {
+    const { lastFrame } = render(<ColumnHeaders cols={80} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("NAME");
+    expect(frame).toContain("STATUS");
+    expect(frame).toContain("PORTS");
+    expect(frame).toContain("URL");
+  });
+
+  it("renders medium layout (cols >= 50 < 80) with NAME STATUS PORTS", () => {
+    const { lastFrame } = render(<ColumnHeaders cols={60} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("NAME");
+    expect(frame).toContain("STATUS");
+    expect(frame).toContain("PORTS");
+    expect(frame).not.toContain("URL");
+  });
+
+  it("renders narrow layout (cols >= 30 < 50) with NAME STATUS", () => {
+    const { lastFrame } = render(<ColumnHeaders cols={40} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("NAME");
+    expect(frame).toContain("STATUS");
+    expect(frame).not.toContain("PORTS");
+  });
+
+  it("renders tiny layout (cols < 30) with NAME only", () => {
+    const { lastFrame } = render(<ColumnHeaders cols={20} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("NAME");
+    expect(frame).not.toContain("STATUS");
+  });
+});

--- a/test/components/HelpBar.test.tsx
+++ b/test/components/HelpBar.test.tsx
@@ -2,7 +2,12 @@ import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
 
 import { HelpBar } from "../../src/components/HelpBar.js";
+import type { ServiceStatus } from "../../src/lib/service/types.js";
 import { getTaskShortcuts } from "../../src/lib/taskShortcuts.js";
+
+function makeStatus(overrides: Partial<ServiceStatus> = {}): ServiceStatus {
+  return { name: "api", state: "ready", ports: [], retryCount: 0, ...overrides };
+}
 
 describe("HelpBar", () => {
   it("renders global shortcut hints only", () => {
@@ -19,6 +24,21 @@ describe("HelpBar", () => {
     expect(frame).not.toContain("[r]estart");
     expect(frame).not.toContain("[l]ogs");
     expect(frame).not.toContain("[o]pen");
+  });
+
+  it("renders compact mode with status: shows restart/stop hints", () => {
+    const { lastFrame } = render(<HelpBar compact status={makeStatus()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[r]estart");
+    expect(frame).toContain("[s]top");
+    expect(frame).toContain("[q]uit");
+  });
+
+  it("renders default mode when compact=true but no status", () => {
+    const { lastFrame } = render(<HelpBar compact />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[t]asks");
+    expect(frame).not.toContain("[r]estart");
   });
 });
 

--- a/test/components/Router.test.tsx
+++ b/test/components/Router.test.tsx
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DaemonClient } from "../../src/client/daemon-client.js";
@@ -26,9 +27,6 @@ const { openInBrowser } = await import("../../src/lib/open.js");
 const { zoomPane, editPaneCapture } = await import("../../src/lib/tmux.js");
 
 // ── helpers ────────────────────────────────────────────────────────────
-
-/** Let ink's React reconciler flush state updates */
-const tick = async () => new Promise<void>((resolve) => setTimeout(resolve, 100));
 
 function createMockClient(): DaemonClient {
   const emitter = new EventEmitter();
@@ -134,7 +132,9 @@ describe("Router", () => {
     const statuses = [makeStatus({ name: "web" }), makeStatus({ name: "api" })];
     const { stdin, lastFrame } = renderRouter({ statuses });
     stdin.write("j");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("api");
   });
@@ -144,7 +144,9 @@ describe("Router", () => {
     const { stdin, lastFrame } = renderRouter({ statuses });
     stdin.write("j");
     stdin.write("k");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("web");
   });
@@ -193,7 +195,9 @@ describe("Router", () => {
   it("navigates to log view with l key", async () => {
     const { stdin, lastFrame } = renderRouter();
     stdin.write("l");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("web");
   });
@@ -234,13 +238,17 @@ describe("Router", () => {
     ];
     const { stdin, lastFrame } = renderRouter({ statuses, servicesMeta });
     stdin.write("R");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     // Dashboard still renders underneath popup
     expect(frame).toContain("web");
     // Pressing escape proves we were in docker rebuild view
     stdin.write("\x1B");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toContain("web");
   });
 
@@ -291,7 +299,9 @@ describe("Router", () => {
     const tasks: TaskInfo[] = [{ key: "migrate", name: "Run migrations", description: null }];
     const { stdin, lastFrame } = renderRouter({ tasks });
     stdin.write("t");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("[enter] run");
   });
@@ -328,9 +338,13 @@ describe("Router", () => {
   it("returns to dashboard from logs on escape", async () => {
     const { stdin, lastFrame } = renderRouter();
     stdin.write("l");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write("\x1B");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("zaps");
   });
@@ -341,10 +355,14 @@ describe("Router", () => {
     const tasks: TaskInfo[] = [{ key: "migrate", name: "Run migrations", description: null }];
     const { stdin, lastFrame } = renderRouter({ tasks });
     stdin.write("t");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toContain("[enter] run");
     stdin.write("\x1B");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toContain("zaps");
   });
 
@@ -352,9 +370,13 @@ describe("Router", () => {
     const tasks: TaskInfo[] = [{ key: "migrate", name: "Run migrations", description: null }];
     const { stdin, lastFrame } = renderRouter({ tasks });
     stdin.write("t");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write("\r");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("[enter] run");
   });
@@ -366,9 +388,13 @@ describe("Router", () => {
     ];
     const { stdin, lastFrame } = renderRouter({ tasks });
     stdin.write("t");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write("s");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("[enter] run");
   });
@@ -380,10 +406,14 @@ describe("Router", () => {
     ];
     const { stdin, lastFrame } = renderRouter({ tasks });
     stdin.write("t");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write("j");
     stdin.write("k");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     const frame = lastFrame() ?? "";
     expect(frame).toContain("Run migrations");
   });
@@ -415,60 +445,88 @@ describe("Router", () => {
 
     it("exits with escape", async () => {
       const { stdin, lastFrame } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("\x1B");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       const frame = lastFrame() ?? "";
       expect(frame).toContain("zaps");
     });
 
     it("toggles flag with space without crashing", async () => {
       const { stdin, lastFrame } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write(" ");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       expect(lastFrame()).toBeDefined();
     });
 
     it("navigates flags with j/k without crashing", async () => {
       const { stdin, lastFrame } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("j");
       stdin.write("k");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       expect(lastFrame()).toBeDefined();
     });
 
     it("clamps flag index at boundaries", async () => {
       const { stdin, lastFrame } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("k");
       stdin.write("k");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       expect(lastFrame()).toBeDefined();
       for (let i = 0; i < DOCKER_REBUILD_FLAGS.length + 2; i += 1) {
         stdin.write("j");
       }
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       expect(lastFrame()).toBeDefined();
     });
 
     it("rebuilds on enter and returns to dashboard", async () => {
       const { stdin, lastFrame } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("\r");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       const frame = lastFrame() ?? "";
       expect(frame).toContain("zaps");
     });
 
     it("ignores enter when busy", async () => {
       const { stdin, client } = enterDockerRebuild();
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("\r");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       stdin.write("R");
-      await tick();
+      await act(async () => {
+        /* Flush */
+      });
       expect(client.disconnect).not.toHaveBeenCalled();
     });
   });
@@ -495,13 +553,19 @@ describe("Router", () => {
     const { stdin } = renderRouter({ statuses, servicesMeta, client });
 
     stdin.write("R");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write(" ");
     stdin.write("j");
     stdin.write(" ");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     stdin.write("\r");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(client.disconnect).not.toHaveBeenCalled();
   });
 
@@ -511,7 +575,9 @@ describe("Router", () => {
     const client = createMockClient();
     const { lastFrame } = renderRouter({ client });
     client.emit("task.start", "migrate", "Run migrations");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toBeDefined();
   });
 
@@ -519,9 +585,13 @@ describe("Router", () => {
     const client = createMockClient();
     const { lastFrame } = renderRouter({ client });
     client.emit("task.start", "migrate", "Run migrations");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     client.emit("task.complete", "migrate", "Run migrations", "success");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toBeDefined();
   });
 
@@ -529,7 +599,9 @@ describe("Router", () => {
     const client = createMockClient();
     const { lastFrame } = renderRouter({ client });
     client.emit("task.complete", "seed", "Seed DB", "error");
-    await tick();
+    await act(async () => {
+      /* Flush */
+    });
     expect(lastFrame()).toBeDefined();
   });
 

--- a/test/components/ServiceList.test.tsx
+++ b/test/components/ServiceList.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { ServiceList } from "../../src/components/ServiceList.js";
+import type { ServiceStatus } from "../../src/lib/service/types.js";
+
+function makeStatus(overrides: Partial<ServiceStatus> = {}): ServiceStatus {
+  return {
+    name: "api",
+    state: "ready",
+    ports: [],
+    retryCount: 0,
+    ...overrides,
+  };
+}
+
+describe("ServiceList", () => {
+  it("renders all services without maxRows", () => {
+    const statuses = [makeStatus({ name: "api" }), makeStatus({ name: "db" })];
+    const { lastFrame } = render(<ServiceList statuses={statuses} selectedIndex={0} cols={80} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+    expect(frame).toContain("db");
+  });
+
+  it("renders group header for first service in group", () => {
+    const statuses = [
+      makeStatus({ name: "api", group: "backend" }),
+      makeStatus({ name: "worker", group: "backend" }),
+    ];
+    const { lastFrame } = render(<ServiceList statuses={statuses} selectedIndex={0} cols={80} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("backend");
+  });
+
+  it("does not repeat group header for subsequent services in same group", () => {
+    const statuses = [
+      makeStatus({ name: "api", group: "backend" }),
+      makeStatus({ name: "worker", group: "backend" }),
+    ];
+    const { lastFrame } = render(<ServiceList statuses={statuses} selectedIndex={0} cols={80} />);
+    const frame = lastFrame() ?? "";
+    // "backend" should appear only once as a header
+    expect(frame.indexOf("backend")).toBe(frame.lastIndexOf("backend"));
+  });
+
+  it("shows separate group headers for different groups", () => {
+    const statuses = [
+      makeStatus({ name: "api", group: "backend" }),
+      makeStatus({ name: "web", group: "frontend" }),
+    ];
+    const { lastFrame } = render(<ServiceList statuses={statuses} selectedIndex={0} cols={80} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("backend");
+    expect(frame).toContain("frontend");
+  });
+
+  it("no group header for ungrouped services", () => {
+    const statuses = [makeStatus({ name: "api" }), makeStatus({ name: "db" })];
+    const { lastFrame } = render(<ServiceList statuses={statuses} selectedIndex={0} cols={80} />);
+    const frame = lastFrame() ?? "";
+    // No group label should appear
+    expect(frame).not.toMatch(/^\s+backend/m);
+  });
+
+  it("renders scroll down indicator when maxRows < total", () => {
+    const statuses = Array.from({ length: 10 }, (_, i) => makeStatus({ name: `svc${i}` }));
+    const { lastFrame } = render(
+      <ServiceList statuses={statuses} selectedIndex={0} maxRows={4} cols={80} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("↓");
+  });
+
+  it("renders scroll up indicator when scrolled down", () => {
+    const statuses = Array.from({ length: 10 }, (_, i) => makeStatus({ name: `svc${i}` }));
+    const { lastFrame } = render(
+      <ServiceList statuses={statuses} selectedIndex={9} maxRows={4} cols={80} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("↑");
+  });
+
+  it("no scroll indicators when total fits in maxRows", () => {
+    const statuses = [makeStatus({ name: "api" }), makeStatus({ name: "db" })];
+    const { lastFrame } = render(
+      <ServiceList statuses={statuses} selectedIndex={0} maxRows={10} cols={80} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("↑");
+    expect(frame).not.toContain("↓");
+  });
+
+  it("renders with maxRows=0 (no limit path)", () => {
+    const statuses = [makeStatus({ name: "api" }), makeStatus({ name: "db" })];
+    const { lastFrame } = render(
+      <ServiceList statuses={statuses} selectedIndex={0} maxRows={0} cols={80} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+    expect(frame).toContain("db");
+  });
+});

--- a/test/components/ServiceRow.test.tsx
+++ b/test/components/ServiceRow.test.tsx
@@ -115,4 +115,71 @@ describe("ServiceRow", () => {
     const { lastFrame } = render(<ServiceRow status={status} cols={100} isSelected={false} />);
     expect(lastFrame()).toBeTruthy();
   });
+
+  it("renders medium layout (cols >= 50 < 80) with name and status", () => {
+    const status = makeStatus({ name: "api", ports: [3000] });
+    const { lastFrame } = render(<ServiceRow status={status} cols={60} isSelected={false} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+    expect(frame).toContain(":3000");
+  });
+
+  it("renders medium layout selected with lastError", () => {
+    const status = makeStatus({ state: "error", lastError: "connection refused" });
+    const { lastFrame } = render(<ServiceRow status={status} cols={60} isSelected />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("│ Error: connection refused");
+  });
+
+  it("renders narrow layout (cols >= 30 < 50) with name and status", () => {
+    const status = makeStatus({ name: "api" });
+    const { lastFrame } = render(<ServiceRow status={status} cols={40} isSelected={false} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+  });
+
+  it("renders narrow layout selected with lastError", () => {
+    const status = makeStatus({ state: "error", lastError: "timeout" });
+    const { lastFrame } = render(<ServiceRow status={status} cols={40} isSelected />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("│ Error: timeout");
+  });
+
+  it("renders tiny layout (cols < 30) with name only", () => {
+    const status = makeStatus({ name: "api" });
+    const { lastFrame } = render(<ServiceRow status={status} cols={20} isSelected={false} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+  });
+
+  it("renders tiny layout selected", () => {
+    const status = makeStatus({ name: "api" });
+    const { lastFrame } = render(<ServiceRow status={status} cols={20} isSelected />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain(">");
+  });
+
+  it("applies indent in wide layout", () => {
+    const status = makeStatus({ name: "api" });
+    const { lastFrame } = render(
+      <ServiceRow status={status} cols={100} isSelected={false} indent />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+  });
+
+  it("applies indent in medium layout", () => {
+    const status = makeStatus({ name: "api" });
+    const { lastFrame } = render(
+      <ServiceRow status={status} cols={60} isSelected={false} indent />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("api");
+  });
+
+  it("shows retry count in medium layout", () => {
+    const status = makeStatus({ state: "starting", retryCount: 3 });
+    const { lastFrame } = render(<ServiceRow status={status} cols={60} isSelected={false} />);
+    expect(lastFrame()).toBeTruthy();
+  });
 });

--- a/test/components/TasksView.test.tsx
+++ b/test/components/TasksView.test.tsx
@@ -7,7 +7,22 @@ import { describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "../../src/client/daemon-client.js";
 import { TasksView } from "../../src/components/TasksView.js";
 import type { TaskInfo } from "../../src/daemon/session.js";
+import type { Dimensions } from "../../src/hooks/useDimensions.js";
 import { AppProvider } from "../../src/hooks/useZaps.js";
+
+vi.mock("../../src/hooks/useDimensions.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/hooks/useDimensions.js")>();
+  return {
+    ...original,
+    useDimensions: vi.fn().mockReturnValue({
+      cols: 100,
+      rows: 24,
+      compact: false,
+      narrow: false,
+      medium: true,
+    } satisfies Dimensions),
+  };
+});
 
 function createMockClient(overrides?: Partial<Record<string, unknown>>): DaemonClient {
   const emitter = new EventEmitter();
@@ -271,6 +286,40 @@ describe("TasksView", () => {
     // The task result status should be reflected in the rendered output
     const frame = lastFrame() ?? "";
     // TaskListPanel renders task results — just verify no crash and task is shown
+    expect(frame).toContain("Run migrations");
+  });
+});
+
+describe("TasksView layout branches", () => {
+  it("renders wide layout (showHeader=true) when not medium", async () => {
+    const { useDimensions } = await import("../../src/hooks/useDimensions.js");
+    vi.mocked(useDimensions).mockReturnValue({
+      cols: 130,
+      rows: 24,
+      compact: false,
+      narrow: false,
+      medium: false,
+    });
+
+    const tasks: TaskInfo[] = [{ key: "migrate", name: "Run migrations", description: null }];
+    const { lastFrame } = renderTasksView({ tasks });
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Run migrations");
+  });
+
+  it("renders compact layout (compact=true, medium=true) without header", async () => {
+    const { useDimensions } = await import("../../src/hooks/useDimensions.js");
+    vi.mocked(useDimensions).mockReturnValue({
+      cols: 100,
+      rows: 8,
+      compact: true,
+      narrow: false,
+      medium: true,
+    });
+
+    const tasks: TaskInfo[] = [{ key: "migrate", name: "Run migrations", description: null }];
+    const { lastFrame } = renderTasksView({ tasks });
+    const frame = lastFrame() ?? "";
     expect(frame).toContain("Run migrations");
   });
 });

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -387,3 +387,135 @@ describe("loadConfig", () => {
     );
   });
 });
+
+describe("docker expand", () => {
+  it("expands docker services with expand: true", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: { service: ["postgres", "redis"], expand: true },
+              restart: { maxRetries: 3 },
+            },
+          },
+        });
+      }
+    `,
+    );
+
+    const result = await loadConfig(configPath);
+
+    // Parent "infra" should be removed
+    expect(result.project.services.infra).toBeUndefined();
+    // Children should exist
+    expect(result.project.services.postgres).toBeDefined();
+    expect(result.project.services.redis).toBeDefined();
+    // Children inherit restart config
+    expect(result.project.services.postgres.restart?.maxRetries).toBe(3);
+    // Children have _combined metadata
+    expect(result.project.services.postgres._combined?.group).toBe("infra");
+    expect(result.project.services.postgres._combined?.isOwner).toBe(true);
+    expect(result.project.services.redis._combined?.isOwner).toBe(false);
+    expect(result.project.services.redis._combined?.allServices).toEqual(["postgres", "redis"]);
+    // Non-owner implicitly depends on owner
+    expect(result.project.services.redis.dependsOn).toContain("postgres");
+    // Groups map
+    expect(result.groups.get("infra")).toEqual(["postgres", "redis"]);
+  });
+
+  it("rewrites dependsOn referencing group name", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: { service: ["postgres", "redis"], expand: true },
+            },
+            api: {
+              start: "node server.js",
+              dependsOn: ["infra"],
+            },
+          },
+        });
+      }
+    `,
+    );
+
+    const result = await loadConfig(configPath);
+    // DependsOn: ["infra"] should expand to ["postgres", "redis"]
+    expect(result.project.services.api.dependsOn).toEqual(["postgres", "redis"]);
+  });
+
+  it("throws on naming collision", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: { service: ["api"], expand: true },
+            },
+            api: {
+              start: "node server.js",
+            },
+          },
+        });
+      }
+    `,
+    );
+
+    await expect(loadConfig(configPath)).rejects.toThrow("Docker expand collision");
+  });
+
+  it("layout accepts group name as valid pane", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: { service: ["postgres", "redis"], expand: true },
+            },
+          },
+          layout: {
+            direction: "columns",
+            children: [
+              { pane: "@tui", size: "30" },
+              { pane: "infra", size: "70" },
+            ],
+          },
+        });
+      }
+    `,
+    );
+
+    // Should not throw — "infra" is a valid group name in layout
+    const result = await loadConfig(configPath);
+    expect(result.groups.get("infra")).toEqual(["postgres", "redis"]);
+  });
+
+  it("returns empty groups when no expand used", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            api: { start: "node server.js" },
+          },
+        });
+      }
+    `,
+    );
+
+    const result = await loadConfig(configPath);
+    expect(result.groups.size).toBe(0);
+  });
+});

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -501,6 +501,72 @@ describe("docker expand", () => {
     expect(result.groups.get("infra")).toEqual(["postgres", "redis"]);
   });
 
+  it("expand with per-child overrides merges onto children", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: {
+                service: ["caddy", "postgres", "bugsink"],
+                expand: {
+                  postgres: {
+                    onReady: () => console.log("migrated"),
+                  },
+                  bugsink: {
+                    ready: { http: "http://localhost:8000/health" },
+                  },
+                },
+              },
+              restart: { maxRetries: 3 },
+            },
+          },
+        });
+      }
+    `,
+    );
+
+    const result = await loadConfig(configPath);
+    // All children exist
+    expect(result.project.services.caddy).toBeDefined();
+    expect(result.project.services.postgres).toBeDefined();
+    expect(result.project.services.bugsink).toBeDefined();
+    // Caddy has no overrides — inherits parent restart
+    expect(result.project.services.caddy.restart?.maxRetries).toBe(3);
+    expect(result.project.services.caddy.onReady).toBeUndefined();
+    // Postgres has onReady override
+    expect(result.project.services.postgres.onReady).toBeTypeOf("function");
+    expect(result.project.services.postgres.restart?.maxRetries).toBe(3);
+    // Bugsink has ready override
+    expect(result.project.services.bugsink.ready).toEqual({ http: "http://localhost:8000/health" });
+  });
+
+  it("expand override for unknown child throws", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(lib) {
+        return lib.defineProject({
+          services: {
+            infra: {
+              docker: {
+                service: ["caddy"],
+                expand: {
+                  unknown: { ready: { port: 3000 } },
+                },
+              },
+            },
+          },
+        });
+      }
+    `,
+    );
+
+    await expect(loadConfig(configPath)).rejects.toThrow("Docker expand override 'unknown'");
+  });
+
   it("returns empty groups when no expand used", async () => {
     const configPath = writeConfig(
       ".zaps.ts",

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -34,6 +34,7 @@ function createSessionParams(overrides?: Partial<SessionCreateParams>): SessionC
       },
       configPath: "/test/.zaps.mts",
       projectDir: "/test",
+      groups: new Map(),
     } as SessionCreateParams["config"],
     paneMap: { "@tui": "%0", api: "%1" },
     tmuxSession: "main",
@@ -218,6 +219,7 @@ describe("Session", () => {
           },
           configPath: "/test/.zaps.mts",
           projectDir: "/test",
+          groups: new Map(),
         } as SessionCreateParams["config"],
       });
 

--- a/test/hooks/useLogs.test.tsx
+++ b/test/hooks/useLogs.test.tsx
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 
 import { Text } from "ink";
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DaemonClient } from "../../src/client/daemon-client.js";
@@ -28,14 +29,6 @@ function createMockClient(): DaemonClient {
     getLogSnapshot: vi.fn().mockResolvedValue([]),
   });
   return client as unknown as DaemonClient;
-}
-
-// Flush React/Ink reconciler
-async function act(fn: () => void): Promise<void> {
-  fn();
-  return new Promise((resolve) => {
-    setTimeout(resolve, 50);
-  });
 }
 
 describe("useLogs", () => {
@@ -69,13 +62,13 @@ describe("useLogs", () => {
     expect(lastFrame()).toContain("autoScroll:true");
     expect(lastFrame()).toContain("offset:0");
 
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
     expect(lastFrame()).toContain("autoScroll:false");
     expect(lastFrame()).toContain("offset:1");
 
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
     expect(lastFrame()).toContain("offset:2");
@@ -98,24 +91,24 @@ describe("useLogs", () => {
     const { lastFrame } = render(<Wrapper />);
 
     // Scroll up twice
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
     expect(lastFrame()).toContain("offset:2");
     expect(lastFrame()).toContain("autoScroll:false");
 
     // Scroll down once
-    await act(() => {
+    act(() => {
       hookRef!.scrollDown();
     });
     expect(lastFrame()).toContain("offset:1");
     expect(lastFrame()).toContain("autoScroll:false");
 
     // Scroll down to 0 -> autoScroll re-enabled
-    await act(() => {
+    act(() => {
       hookRef!.scrollDown();
     });
     expect(lastFrame()).toContain("offset:0");
@@ -139,16 +132,16 @@ describe("useLogs", () => {
     const { lastFrame } = render(<Wrapper />);
 
     // Scroll up
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
-    await act(() => {
+    act(() => {
       hookRef!.scrollUp();
     });
     expect(lastFrame()).toContain("offset:2");
 
     // Reset
-    await act(() => {
+    act(() => {
       hookRef!.resetScroll();
     });
     expect(lastFrame()).toContain("offset:0");
@@ -169,15 +162,15 @@ describe("useLogs event streaming", () => {
     const { lastFrame } = render(<Wrapper />);
 
     // Wait for snapshot to load
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+    await act(async () => {
+      /* Flush */
     });
 
     expect(vi.mocked(client.getLogSnapshot)).toHaveBeenCalledWith("api");
     expect(lastFrame()).toContain("line1|line2");
 
     // Emit new lines via client event
-    await act(() => {
+    act(() => {
       client.emit("log.lines", "api", ["line3"]);
     });
     expect(lastFrame()).toContain("line1|line2|line3");
@@ -194,13 +187,13 @@ describe("useLogs event streaming", () => {
 
     const { lastFrame } = render(<Wrapper />);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+    await act(async () => {
+      /* Flush */
     });
     expect(lastFrame()).toContain("line1");
 
     // Emit lines for a different service
-    await act(() => {
+    act(() => {
       client.emit("log.lines", "db", ["db-line"]);
     });
     expect(lastFrame()).not.toContain("db-line");

--- a/test/hooks/useRouter.test.tsx
+++ b/test/hooks/useRouter.test.tsx
@@ -1,16 +1,9 @@
 import { Text } from "ink";
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { describe, expect, it } from "vitest";
 
 import { useRouter } from "../../src/hooks/useRouter.js";
-
-// Minimal act() for Ink — triggers React batch update
-async function act(fn: () => void): Promise<void> {
-  fn();
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
 
 // Helper: renders hook in a minimal component and returns getters/actions
 function renderRouter() {
@@ -60,7 +53,7 @@ describe("useRouter", () => {
     expect(lastFrame()).toContain("view:dashboard");
 
     // Call goToLogs via the hook ref
-    await act(() => {
+    act(() => {
       hookRef!.goToLogs("api");
     });
 
@@ -84,13 +77,13 @@ describe("useRouter", () => {
     const { lastFrame } = render(<Wrapper />);
 
     // Go to logs first
-    await act(() => {
+    act(() => {
       hookRef!.goToLogs("db");
     });
     expect(lastFrame()).toContain("view:logs");
 
     // Go back to dashboard
-    await act(() => {
+    act(() => {
       hookRef!.goToDashboard();
     });
     expect(lastFrame()).toContain("view:dashboard");
@@ -106,7 +99,7 @@ describe("useRouter", () => {
 
     const { lastFrame } = render(<Wrapper />);
 
-    await act(() => {
+    act(() => {
       hookRef!.goToTasks();
     });
     expect(lastFrame()).toContain("view:tasks");
@@ -128,7 +121,7 @@ describe("useRouter", () => {
     const { lastFrame } = render(<Wrapper />);
     expect(lastFrame()).toContain("target:null");
 
-    await act(() => {
+    act(() => {
       hookRef!.goToDockerRebuild("postgres");
     });
     expect(lastFrame()).toContain("view:dockerRebuild");

--- a/test/hooks/useSelection.test.tsx
+++ b/test/hooks/useSelection.test.tsx
@@ -1,17 +1,9 @@
 import { Text } from "ink";
 import { render } from "ink-testing-library";
-import { useState } from "react";
+import { act, useState } from "react";
 import { describe, expect, it } from "vitest";
 
 import { useSelection } from "../../src/hooks/useSelection.js";
-
-// Flush React/Ink reconciler — 50ms is enough for batched updates to process
-async function act(fn: () => void): Promise<void> {
-  fn();
-  return new Promise((resolve) => {
-    setTimeout(resolve, 50);
-  });
-}
 
 function renderSelection(itemCount: number) {
   let hookRef: ReturnType<typeof useSelection> | null = null;
@@ -34,12 +26,12 @@ describe("useSelection", () => {
   it("moveDown increments index", async () => {
     const { lastFrame, hookRef } = renderSelection(5);
 
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
     expect(lastFrame()).toContain("index:1");
 
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
     expect(lastFrame()).toContain("index:2");
@@ -48,16 +40,16 @@ describe("useSelection", () => {
   it("moveDown clamps at last index", async () => {
     const { lastFrame, hookRef } = renderSelection(3);
 
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
     expect(lastFrame()).toContain("index:2");
 
     // Past the end
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
     expect(lastFrame()).toContain("index:2");
@@ -66,15 +58,15 @@ describe("useSelection", () => {
   it("moveUp decrements index", async () => {
     const { lastFrame, hookRef } = renderSelection(5);
 
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
-    await act(() => {
+    act(() => {
       hookRef().moveDown();
     });
     expect(lastFrame()).toContain("index:2");
 
-    await act(() => {
+    act(() => {
       hookRef().moveUp();
     });
     expect(lastFrame()).toContain("index:1");
@@ -84,7 +76,7 @@ describe("useSelection", () => {
     const { lastFrame, hookRef } = renderSelection(3);
     expect(lastFrame()).toContain("index:0");
 
-    await act(() => {
+    act(() => {
       hookRef().moveUp();
     });
     expect(lastFrame()).toContain("index:0");
@@ -105,7 +97,7 @@ describe("useSelection", () => {
 
     // Move to index 4
     for (let i = 0; i < 4; i += 1) {
-      await act(() => {
+      act(() => {
         hookRef?.moveDown();
       });
     }
@@ -113,12 +105,12 @@ describe("useSelection", () => {
 
     // Reduce itemCount to 2 -> index should clamp to 1
     // SetCount re-renders, then useEffect fires setIndex clamp
-    await act(() => {
+    act(() => {
       setCount?.(2);
     });
-    // Extra wait for useEffect -> second setState
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+    // Flush useEffect -> second setState
+    await act(async () => {
+      /* Flush */
     });
     expect(lastFrame()).toContain("index:1");
   });
@@ -126,7 +118,7 @@ describe("useSelection", () => {
   it("setIndex sets index directly", async () => {
     const { lastFrame, hookRef } = renderSelection(5);
 
-    await act(() => {
+    act(() => {
       hookRef().setIndex(3);
     });
     expect(lastFrame()).toContain("index:3");

--- a/test/hooks/useServices.test.tsx
+++ b/test/hooks/useServices.test.tsx
@@ -2,19 +2,12 @@ import { EventEmitter } from "node:events";
 
 import { Text } from "ink";
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DaemonClient } from "../../src/client/daemon-client.js";
 import { useServices } from "../../src/hooks/useServices.js";
 import type { ServiceStatus } from "../../src/lib/service/types.js";
-
-// Minimal act()
-async function act(fn: () => void): Promise<void> {
-  fn();
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
 
 function createMockClient(statuses: ServiceStatus[] = []): DaemonClient {
   const emitter = new EventEmitter();
@@ -72,7 +65,7 @@ describe("useServices", () => {
 
     // Emit state change event
     const updated = makeStatus("db", "ready");
-    await act(() => {
+    act(() => {
       client.emit("service.stateChange", "db", updated);
     });
 
@@ -94,7 +87,7 @@ describe("useServices", () => {
 
     // Emit config reload with new service set
     const newStatuses = [makeStatus("web", "stopped"), makeStatus("worker", "stopped")];
-    await act(() => {
+    act(() => {
       client.emit("session.configReloaded", { statuses: newStatuses });
     });
 

--- a/test/integration/helpers/config.ts
+++ b/test/integration/helpers/config.ts
@@ -19,5 +19,6 @@ export function makeConfig(
     },
     configPath: path.join(os.tmpdir(), ".zaps.ts"),
     projectDir: os.tmpdir(),
+    groups: new Map(),
   };
 }

--- a/test/integration/service-manager/crash-recovery.test.ts
+++ b/test/integration/service-manager/crash-recovery.test.ts
@@ -31,6 +31,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 async function waitForState(

--- a/test/integration/service-manager/dependencies.test.ts
+++ b/test/integration/service-manager/dependencies.test.ts
@@ -31,6 +31,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("dependencies integration", () => {

--- a/test/integration/service-manager/docker-expand.test.ts
+++ b/test/integration/service-manager/docker-expand.test.ts
@@ -1,0 +1,187 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { detectPorts, getDescendantPids } from "#src/lib/port.js";
+import { ServiceManager } from "#src/lib/service/manager.js";
+import {
+  capturePane,
+  getWindowName,
+  getWindowOption,
+  panePid,
+  renameWindow,
+  sendCtrlC,
+  sendKeys,
+  setWindowOption,
+  splitPane,
+} from "#src/lib/tmux.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { makeConfig } from "../helpers/config.js";
+import { composeDown, writeComposeFile } from "../helpers/docker.js";
+import { hasDocker, hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+const execFileAsync = promisify(execFile);
+
+const deps = {
+  sendKeys,
+  sendCtrlC,
+  panePid,
+  detectPorts,
+  capturePane,
+  getDescendantPids,
+  renameWindow,
+  getWindowName,
+  getWindowOption,
+  setWindowOption,
+  exec: async (cmd: string, args: string[], cwd?: string) => {
+    await execFileAsync(cmd, args, cwd ? { cwd } : {});
+  },
+};
+
+describe.skipIf(!hasTmux() || !hasDocker())("docker expand integration", () => {
+  let session: TestSession;
+  let mgr: ServiceManager;
+  let tmpDir: string;
+
+  afterEach(async () => {
+    try {
+      await mgr.stopAll();
+    } catch {
+      /* Best-effort stop */
+    }
+    if (tmpDir) {
+      await composeDown(tmpDir);
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+    if (session) {
+      await session.cleanup();
+    }
+  });
+
+  it("expanded services share a pane and reach ready independently", async () => {
+    session = await createTestSession();
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "zaps-expand-"));
+
+    const composeFile = await writeComposeFile(tmpDir, {
+      redis: { image: "redis:7-alpine", ports: ["0:6379"] },
+      memcached: { image: "memcached:1-alpine", ports: ["0:11211"] },
+    });
+
+    // Create a separate pane for the combined services (not the @tui pane)
+    const sharedPaneId = await splitPane(session.initialPaneId, "v");
+    const paneMap: Record<string, string> = {
+      "@tui": session.initialPaneId,
+      redis: sharedPaneId,
+      memcached: sharedPaneId,
+    };
+
+    const config = makeConfig({
+      redis: {
+        docker: { service: "redis", file: composeFile },
+        cwd: tmpDir,
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: true },
+      },
+      memcached: {
+        docker: { service: "memcached", file: composeFile },
+        cwd: tmpDir,
+        dependsOn: ["redis"],
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: false },
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    await mgr.startAll();
+
+    expect(mgr.getStatus("redis").state).toBe("ready");
+    expect(mgr.getStatus("memcached").state).toBe("ready");
+    expect(mgr.getStatus("redis").group).toBe("cache");
+    expect(mgr.getStatus("memcached").group).toBe("cache");
+    expect(mgr.getStatus("redis").ports.length).toBeGreaterThan(0);
+    expect(mgr.getStatus("memcached").ports.length).toBeGreaterThan(0);
+  });
+
+  it("stops individual container without killing pane", async () => {
+    session = await createTestSession();
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "zaps-expand-"));
+
+    const composeFile = await writeComposeFile(tmpDir, {
+      redis: { image: "redis:7-alpine", ports: ["0:6379"] },
+      memcached: { image: "memcached:1-alpine", ports: ["0:11211"] },
+    });
+
+    const sharedPaneId = await splitPane(session.initialPaneId, "v");
+    const paneMap: Record<string, string> = {
+      "@tui": session.initialPaneId,
+      redis: sharedPaneId,
+      memcached: sharedPaneId,
+    };
+
+    const config = makeConfig({
+      redis: {
+        docker: { service: "redis", file: composeFile },
+        cwd: tmpDir,
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: true },
+      },
+      memcached: {
+        docker: { service: "memcached", file: composeFile },
+        cwd: tmpDir,
+        dependsOn: ["redis"],
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: false },
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    await mgr.startAll();
+
+    // Stop memcached only — redis should remain ready
+    await mgr.stopService("memcached");
+
+    expect(mgr.getStatus("memcached").state).toBe("stopped");
+    expect(mgr.getStatus("redis").state).toBe("ready");
+  });
+
+  it("restarts individual container in group", async () => {
+    session = await createTestSession();
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "zaps-expand-"));
+
+    const composeFile = await writeComposeFile(tmpDir, {
+      redis: { image: "redis:7-alpine", ports: ["0:6379"] },
+      memcached: { image: "memcached:1-alpine", ports: ["0:11211"] },
+    });
+
+    const sharedPaneId = await splitPane(session.initialPaneId, "v");
+    const paneMap: Record<string, string> = {
+      "@tui": session.initialPaneId,
+      redis: sharedPaneId,
+      memcached: sharedPaneId,
+    };
+
+    const config = makeConfig({
+      redis: {
+        docker: { service: "redis", file: composeFile },
+        cwd: tmpDir,
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: true },
+      },
+      memcached: {
+        docker: { service: "memcached", file: composeFile },
+        cwd: tmpDir,
+        dependsOn: ["redis"],
+        _combined: { group: "cache", allServices: ["redis", "memcached"], isOwner: false },
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    await mgr.startAll();
+
+    // Restart memcached — should use docker compose restart
+    await mgr.restartService("memcached");
+
+    expect(mgr.getStatus("memcached").state).toBe("ready");
+    expect(mgr.getStatus("redis").state).toBe("ready");
+  });
+});

--- a/test/integration/service-manager/docker-ready.test.ts
+++ b/test/integration/service-manager/docker-ready.test.ts
@@ -33,6 +33,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux() || !hasDocker())("docker-ready integration", () => {

--- a/test/integration/service-manager/edge-cases.test.ts
+++ b/test/integration/service-manager/edge-cases.test.ts
@@ -31,6 +31,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("edge-cases integration", () => {

--- a/test/integration/service-manager/env.test.ts
+++ b/test/integration/service-manager/env.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("env integration", () => {

--- a/test/integration/service-manager/flags.test.ts
+++ b/test/integration/service-manager/flags.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("flags integration", () => {

--- a/test/integration/service-manager/hooks.test.ts
+++ b/test/integration/service-manager/hooks.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("hooks integration", () => {

--- a/test/integration/service-manager/ready-fn.test.ts
+++ b/test/integration/service-manager/ready-fn.test.ts
@@ -33,6 +33,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("ready-fn integration", () => {

--- a/test/integration/service-manager/ready-http.test.ts
+++ b/test/integration/service-manager/ready-http.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("ready-http integration", () => {

--- a/test/integration/service-manager/ready-output.test.ts
+++ b/test/integration/service-manager/ready-output.test.ts
@@ -29,6 +29,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("ready-output integration", () => {

--- a/test/integration/service-manager/ready-port.test.ts
+++ b/test/integration/service-manager/ready-port.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("ready-port integration", () => {

--- a/test/integration/service-manager/restart.test.ts
+++ b/test/integration/service-manager/restart.test.ts
@@ -31,6 +31,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 async function waitForState(

--- a/test/integration/service-manager/start-stop.test.ts
+++ b/test/integration/service-manager/start-stop.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("start-stop integration", () => {

--- a/test/integration/tmux/window-title.test.ts
+++ b/test/integration/tmux/window-title.test.ts
@@ -30,6 +30,9 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("window-title integration", () => {

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -1929,3 +1929,253 @@ describe("cascadeRestart", () => {
     expect(targets.filter((t: string) => t === "%frontend")).toHaveLength(1);
   });
 });
+
+// === Combined (expanded docker) services ===
+
+describe("combined docker services", () => {
+  let dockerSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    probePort.mockResolvedValue(undefined);
+    // Mock getContainerInfo to return a ready container
+    const dockerModule = await import("../../../src/lib/docker.js");
+    dockerSpy = vi.spyOn(dockerModule, "getContainerInfo").mockResolvedValue({
+      state: "running",
+      health: "",
+      ports: [5432],
+    }) as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    dockerSpy?.mockRestore();
+  });
+
+  function makeCombinedConfig() {
+    return makeConfig({
+      postgres: {
+        docker: { service: "postgres" },
+        _combined: { group: "infra", allServices: ["postgres", "redis"], isOwner: true },
+      },
+      redis: {
+        docker: { service: "redis" },
+        _combined: { group: "infra", allServices: ["postgres", "redis"], isOwner: false },
+      },
+    });
+  }
+
+  it("owner sends docker compose up with all services", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const p = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p;
+
+    const sentCommand = (deps.sendKeys as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+    expect(sentCommand).toContain("postgres");
+    expect(sentCommand).toContain("redis");
+  });
+
+  it("non-owner skips sendKeys when owner is not running", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const p = mgr.startService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await p;
+
+    expect(deps.sendKeys).not.toHaveBeenCalled();
+  });
+
+  it("non-owner calls exec when owner is ready", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start owner first
+    const p1 = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p1;
+
+    // Now start non-owner
+    const p2 = mgr.startService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await p2;
+
+    expect(deps.exec).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["start", "redis"]),
+      expect.any(String),
+    );
+  });
+
+  it("sets group on status", () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+    const statuses = mgr.getAllStatuses();
+    expect(statuses.find((s) => s.name === "postgres")?.group).toBe("infra");
+    expect(statuses.find((s) => s.name === "redis")?.group).toBe("infra");
+  });
+
+  it("stop combined uses docker compose stop", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start both
+    const p1 = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p1;
+    const p2 = mgr.startService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await p2;
+
+    // Stop redis
+    const pStop = mgr.stopService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await pStop;
+
+    expect(deps.exec).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["stop", "redis"]),
+      expect.any(String),
+    );
+    // Pane NOT Ctrl-C'd since postgres still running
+    expect(deps.sendCtrlC).not.toHaveBeenCalled();
+  });
+
+  it("stop last sibling Ctrl-C's pane", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start owner only
+    const p1 = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p1;
+
+    // Stop postgres (redis is stopped → all stopped)
+    const pStop = mgr.stopService("postgres");
+    await vi.advanceTimersByTimeAsync(5500);
+    await pStop;
+
+    expect(deps.exec).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["stop", "postgres"]),
+      expect.any(String),
+    );
+    expect(deps.sendCtrlC).toHaveBeenCalledWith("%infra");
+  });
+
+  it("restart combined non-owner uses docker compose restart", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start both
+    const p1 = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p1;
+    const p2 = mgr.startService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await p2;
+
+    (deps.exec as ReturnType<typeof vi.fn>).mockClear();
+
+    // Restart redis
+    const pRestart = mgr.restartService("redis");
+    await vi.advanceTimersByTimeAsync(500);
+    await pRestart;
+
+    expect(deps.exec).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["restart", "redis"]),
+      expect.any(String),
+    );
+  });
+
+  it("crash monitor checks docker container status for combined services", async () => {
+    const config = makeCombinedConfig();
+    const deps = createMockDeps();
+    // Keep processes alive initially
+    (deps.getDescendantPids as ReturnType<typeof vi.fn>).mockResolvedValue([1000, 2000]);
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start owner
+    const p = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p;
+
+    expect(mgr.getStatus("postgres").state).toBe("ready");
+
+    // Crash monitor polls every 2s — simulate container still running
+    await vi.advanceTimersByTimeAsync(2500);
+
+    // Now simulate container crash
+    dockerSpy.mockResolvedValue({ state: "exited", health: "", ports: [] });
+    await vi.advanceTimersByTimeAsync(2500);
+
+    // Should transition to error (no restart config)
+    expect(mgr.getStatus("postgres").state).toBe("error");
+    expect(mgr.getStatus("postgres").lastError).toBe("Process exited unexpectedly");
+  });
+
+  it("crash monitor restarts combined service on crash with restart config", async () => {
+    const config = makeConfig({
+      postgres: {
+        docker: { service: "postgres" },
+        restart: { maxRetries: 2, backoff: 100 },
+        _combined: { group: "infra", allServices: ["postgres", "redis"], isOwner: true },
+      },
+      redis: {
+        docker: { service: "redis" },
+        _combined: { group: "infra", allServices: ["postgres", "redis"], isOwner: false },
+      },
+    });
+    const deps = createMockDeps();
+    (deps.getDescendantPids as ReturnType<typeof vi.fn>).mockResolvedValue([1000, 2000]);
+    const paneMap = { "@tui": "%tui", postgres: "%infra", redis: "%infra" };
+
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Start owner
+    const p = mgr.startService("postgres");
+    await vi.advanceTimersByTimeAsync(500);
+    await p;
+
+    // Simulate crash — container exits
+    dockerSpy.mockResolvedValue({ state: "exited", health: "", ports: [] });
+    await vi.advanceTimersByTimeAsync(2500);
+
+    // Should have detected crash and retried
+    expect(mgr.getStatus("postgres").retryCount).toBe(1);
+
+    // Restore container and advance to let restart complete
+    dockerSpy.mockResolvedValue({ state: "running", health: "", ports: [5432] });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(mgr.getStatus("postgres").state).toBe("ready");
+  });
+});

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -28,6 +28,7 @@ function createMockDeps(): ServiceManagerDeps {
     getWindowName: vi.fn<ServiceManagerDeps["getWindowName"]>().mockResolvedValue("bash"),
     getWindowOption: vi.fn<ServiceManagerDeps["getWindowOption"]>().mockResolvedValue("on"),
     setWindowOption: vi.fn<ServiceManagerDeps["setWindowOption"]>().mockResolvedValue(),
+    exec: vi.fn<ServiceManagerDeps["exec"]>().mockResolvedValue(),
   };
 }
 
@@ -45,6 +46,7 @@ function makeConfig(
     },
     configPath: "/test/.zaps.ts",
     projectDir: "/test",
+    groups: new Map(),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `docker.expand: true` to split a multi-service docker config into individually addressable services sharing one tmux pane
- Each expanded child has independent lifecycle, status, ready detection, and can be referenced in `dependsOn`
- TUI shows grouped rows with indent under the group name
- Fix flaky ink tests by replacing custom setTimeout flush with `React.act()`

## Changes

**Feature (expand)**
- `src/config/schema.ts` / `types.ts` — `expand` field on DockerConfig, `CombinedServiceMeta`, `groups` on ResolvedConfig
- `src/config/loader.ts` — `expandDockerServices()` expands before validation, rewrites dependsOn/restartWith, non-owners depend on owner
- `src/lib/service/manager.ts` — combined start (owner sends `docker compose up`, non-owners use `docker compose start`), stop (`docker compose stop` per container), restart, crash monitoring via container status
- `src/lib/tmux-layout.ts` — group-aware pane mapping
- `src/components/ServiceList.tsx` / `ServiceRow.tsx` — grouped display with indent
- `src/daemon/session.ts` / `server.ts` — shared log buffers, `exec` dep, group metadata

**Test stabilization**
- Replace custom `tick()`/`act()` setTimeout helpers with `React.act()` across 6 test files — eliminates flaky failures under v8 coverage

**Coverage**
- Branch coverage improved from 81.97% to 87.65% (threshold: 85%)
- 40 new tests: loader expansion, combined service lifecycle, crash monitoring, component breakpoints
- 3 new integration tests with real Docker (redis + memcached)

## Config example

```typescript
services: {
  infra: {
    docker: {
      service: ["postgres", "redis", "mailpit"],
      expand: true,
    },
  },
  api: {
    start: "pnpm dev",
    dependsOn: ["postgres"],
  },
}
```

## Test plan

- [x] `pnpm check` passes (typecheck + lint + build + build:native + test:coverage)
- [x] Integration tests pass with real Docker containers
- [x] Previously flaky Router test stable under coverage