### PR TITLE
fix: resolve 5 bugs and improve integration test suite

### DIFF
--- a/src/daemon/log-monitor.ts
+++ b/src/daemon/log-monitor.ts
@@ -15,6 +15,8 @@ export type LogMonitorListener = (serviceName: string, lines: string[]) => void;
 export class LogMonitor {
   private timers = new Map<string, ReturnType<typeof setInterval>>();
   private prevCaptures = new Map<string, string[]>();
+  private inFlight = new Map<string, Promise<void>>();
+  private stopped = new Set<string>();
   private deps: LogMonitorDeps;
   private buffers: Map<string, LogBuffer>;
   private listener?: LogMonitorListener;
@@ -35,16 +37,23 @@ export class LogMonitor {
     }
 
     this.prevCaptures.set(serviceName, []);
+    this.stopped.delete(serviceName);
     let fetching = false;
 
     const timer = setInterval(() => {
-      if (fetching) {
+      if (fetching || this.stopped.has(serviceName)) {
         return;
       }
       fetching = true;
-      void (async () => {
+      const capture = (async () => {
         try {
+          if (this.stopped.has(serviceName)) {
+            return;
+          }
           const output = await this.deps.capturePane(paneTarget, 500);
+          if (this.stopped.has(serviceName)) {
+            return;
+          }
           const currentLines = output.split("\n");
           const prev = this.prevCaptures.get(serviceName) ?? [];
           const newLines = diffOutput(prev, currentLines);
@@ -63,18 +72,43 @@ export class LogMonitor {
           fetching = false;
         }
       })();
+      this.inFlight.set(serviceName, capture);
     }, intervalMs);
 
     this.timers.set(serviceName, timer);
   }
 
+  /**
+   * Stop monitoring and wait for any in-flight capture to finish.
+   */
+  async flush(serviceName: string): Promise<void> {
+    this.stopped.add(serviceName);
+    const timer = this.timers.get(serviceName);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(serviceName);
+    }
+    const pending = this.inFlight.get(serviceName);
+    if (pending) {
+      await pending;
+    }
+    this.inFlight.delete(serviceName);
+    this.prevCaptures.delete(serviceName);
+  }
+
   stop(serviceName: string): void {
+    this.stopped.add(serviceName);
     const timer = this.timers.get(serviceName);
     if (timer) {
       clearInterval(timer);
       this.timers.delete(serviceName);
       this.prevCaptures.delete(serviceName);
     }
+  }
+
+  async flushAll(): Promise<void> {
+    const names = [...this.timers.keys()];
+    await Promise.all(names.map(async (name) => this.flush(name)));
   }
 
   stopAll(): void {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -66,12 +66,13 @@ class DaemonServer implements SessionStore {
             }
           }
         });
-        socket.on("error", () => {
-          // Client disconnected — clean up subscriptions
+        const cleanupSubscriptions = () => {
           for (const session of this.sessions.values()) {
             session.subscribers.delete(socket);
           }
-        });
+        };
+        socket.on("error", cleanupSubscriptions);
+        socket.on("close", cleanupSubscriptions);
       });
 
       this.server.on("error", reject);

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -70,6 +70,7 @@ export class Session {
   manager: ServiceManager;
   logBuffers: Map<string, LogBuffer>;
   logMonitor: LogMonitor;
+  private reloading = false;
 
   constructor(params: SessionCreateParams, manager: ServiceManager) {
     this.id = sessionId(params.configPath);
@@ -192,8 +193,21 @@ export class Session {
    * Reload config, recreate layout, and restart services.
    */
   async reload(): Promise<void> {
+    if (this.reloading) {
+      return;
+    }
+    this.reloading = true;
+
+    try {
+      await this._reload();
+    } finally {
+      this.reloading = false;
+    }
+  }
+
+  private async _reload(): Promise<void> {
     // 1. Stop all services and log monitors
-    this.logMonitor.stopAll();
+    await this.logMonitor.flushAll();
     await this.manager.stopAll();
 
     // 2. Remove old manager listeners
@@ -268,7 +282,7 @@ export class Session {
    * Stop all services and clean up.
    */
   async destroy(): Promise<void> {
-    this.logMonitor.stopAll();
+    await this.logMonitor.flushAll();
     await this.manager.stopAll();
 
     // Notify subscribers of session destruction

--- a/src/lib/ipc/client.ts
+++ b/src/lib/ipc/client.ts
@@ -189,10 +189,6 @@ export function ipcSubscribe(
           return;
         }
 
-        const timer = setTimeout(() => {
-          reject(new Error("Request timed out"));
-        }, 30_000);
-
         let reqBuffer = "";
         function onData(chunk: Buffer) {
           reqBuffer += chunk.toString();
@@ -205,13 +201,18 @@ export function ipcSubscribe(
             }
             const responseMsg = JSON.parse(dataLine) as IpcMessage;
             if (isIpcResponse(responseMsg) && responseMsg.id === id) {
-              clearTimeout(timer);
+              clearTimeout(timer); // eslint-disable-line no-use-before-define -- circular timer/listener
               socket.off("data", onData);
               resolve(responseMsg);
               return;
             }
           }
         }
+
+        const timer = setTimeout(() => {
+          socket.off("data", onData);
+          reject(new Error("Request timed out"));
+        }, 30_000);
 
         socket.on("data", onData);
         socket.write(`${JSON.stringify(req)}\n`);

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -149,6 +149,7 @@ export class ServiceManager extends EventEmitter {
   private autoOpened = new Set<string>();
   private restartWithMap: Map<string, string[]>;
   private cascadingTriggers = new Set<string>();
+  private monitorGenerations = new Map<string, number>();
   private originalWindowTitle: Promise<string>;
   private originalAutoRename: Promise<string | null>;
   // eslint-disable-next-line promise/prefer-await-to-then -- field initializer cannot use await
@@ -444,12 +445,13 @@ export class ServiceManager extends EventEmitter {
       this.emit("stateChange", name, status);
     }
 
-    // Start crash monitor in background
-    void this.monitorCrash(name);
+    // Start crash monitor in background with current generation
+    const gen = this.monitorGenerations.get(name) ?? 0;
+    void this.monitorCrash(name, gen);
 
     // Start output monitor if onOutput is configured
     if (serviceConfig.onOutput) {
-      void this.monitorOutput(name);
+      void this.monitorOutput(name, gen);
     }
   }
 
@@ -474,6 +476,9 @@ export class ServiceManager extends EventEmitter {
     if (controller) {
       controller.abort();
     }
+
+    // Invalidate any active crash/output monitors
+    this.monitorGenerations.set(name, (this.monitorGenerations.get(name) ?? 0) + 1);
 
     const combined = serviceConfig._combined;
 
@@ -677,7 +682,7 @@ export class ServiceManager extends EventEmitter {
   /**
    * Monitor a service for crashes and auto-restart.
    */
-  private async monitorCrash(name: string): Promise<void> {
+  private async monitorCrash(name: string, generation: number): Promise<void> {
     const status = this.statuses.get(name);
     if (!status) {
       return;
@@ -690,6 +695,10 @@ export class ServiceManager extends EventEmitter {
       await sleep(2000);
       // Re-check state after sleep (stopService may have changed it)
       if (status.state !== "ready") {
+        return;
+      }
+      // Check if this monitor has been superseded by a newer generation
+      if ((this.monitorGenerations.get(name) ?? 0) !== generation) {
         return;
       }
 
@@ -711,6 +720,10 @@ export class ServiceManager extends EventEmitter {
       }
 
       if (crashed) {
+        // Re-check state and generation after async crash detection — stopService may have run
+        if (status.state !== "ready" || (this.monitorGenerations.get(name) ?? 0) !== generation) {
+          return;
+        }
         const restartConfig = config.restart;
         if (restartConfig && status.retryCount < (restartConfig.maxRetries ?? 3)) {
           status.state = transition(status.state, "restarting");
@@ -767,7 +780,7 @@ export class ServiceManager extends EventEmitter {
   /**
    * Monitor service output and call onOutput for each new line.
    */
-  private async monitorOutput(name: string): Promise<void> {
+  private async monitorOutput(name: string, generation: number): Promise<void> {
     const status = this.statuses.get(name);
     const serviceConfig = this.config.project.services[name];
     const paneTarget = this.paneMap[name];
@@ -781,7 +794,7 @@ export class ServiceManager extends EventEmitter {
 
     while (status.state === "ready") {
       await sleep(1000);
-      if (status.state !== "ready") {
+      if (status.state !== "ready" || (this.monitorGenerations.get(name) ?? 0) !== generation) {
         return;
       }
 

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -177,10 +177,10 @@ describe("Session", () => {
       const mockSocket = { destroyed: false, destroy: vi.fn(), write: vi.fn() };
       session.subscribers.add(mockSocket as never);
 
-      const stopAllSpy = vi.spyOn(session.logMonitor, "stopAll");
+      const flushAllSpy = vi.spyOn(session.logMonitor, "flushAll").mockResolvedValue();
       await session.destroy();
 
-      expect(stopAllSpy).toHaveBeenCalled();
+      expect(flushAllSpy).toHaveBeenCalled();
       expect(vi.mocked(manager.stopAll)).toHaveBeenCalled();
       expect(session.subscribers.size).toBe(0);
     });

--- a/test/integration/binary/smoke.test.ts
+++ b/test/integration/binary/smoke.test.ts
@@ -50,7 +50,7 @@ async function pollUntil(
   throw new Error("pollUntil timed out");
 }
 
-describe.skipIf(!hasBinary() || !hasTmux() || isCI)("binary smoke", () => {
+describe.skipIf(!hasBinary() || !hasTmux() || isCI)("binary smoke", { timeout: 90_000 }, () => {
   let sessionName: string;
   let tmpDir: string;
 
@@ -95,10 +95,7 @@ describe.skipIf(!hasBinary() || !hasTmux() || isCI)("binary smoke", () => {
     // Need to run inside tmux, so zaps dev is run from within this session
     await sendKeys(initialPane, `cd ${tmpDir} && ${binaryPath} up`);
 
-    // Wait for layout creation — zaps creates panes and spawns TUI
-    await sleep(3000);
-
-    // Poll for either TUI output or the service becoming ready (port open)
+    // Poll for the service becoming ready (port open) — may take a while under parallel load
     await pollUntil(
       async () => {
         try {
@@ -110,7 +107,7 @@ describe.skipIf(!hasBinary() || !hasTmux() || isCI)("binary smoke", () => {
           return false;
         }
       },
-      30_000,
+      50_000,
       2000,
     );
 

--- a/test/integration/daemon/client.test.ts
+++ b/test/integration/daemon/client.test.ts
@@ -62,7 +62,6 @@ describe.skipIf(!hasTmux())("DaemonClient integration", () => {
     } catch {
       /* Best-effort cleanup */
     }
-    await new Promise((resolve) => setTimeout(resolve, 600));
     await daemon.cleanup();
     await tmux.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/integration/daemon/e2e.test.ts
+++ b/test/integration/daemon/e2e.test.ts
@@ -90,8 +90,6 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
           /* Best-effort cleanup */
         }
       }
-      // Let in-flight LogMonitor capturePane calls settle
-      await new Promise((resolve) => setTimeout(resolve, 600));
       await daemon.cleanup();
       await tmux.cleanup();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -187,8 +185,6 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
       } catch {
         /* Best-effort cleanup */
       }
-      // Let in-flight LogMonitor capturePane calls settle
-      await new Promise((resolve) => setTimeout(resolve, 600));
       await daemon.cleanup();
       await tmux.cleanup();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -247,18 +243,25 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
     });
 
     it("logs.snapshot returns captured pane output", async () => {
-      // Wait for LogMonitor to capture at least one cycle (polls every 500ms)
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-
-      const res = await ipcRequest(
-        daemon.socketPath,
-        "logs.snapshot",
-        { service: "web" },
-        5000,
-        sid,
-      );
-      expect(res.error).toBeUndefined();
-      const lines = res.result as string[];
+      // Poll until LogMonitor has captured at least one line
+      const start = Date.now();
+      let lines: string[] = [];
+      while (Date.now() - start < 10_000) {
+        const res = await ipcRequest(
+          daemon.socketPath,
+          "logs.snapshot",
+          { service: "web" },
+          5000,
+          sid,
+        );
+        if (!res.error) {
+          lines = res.result as string[];
+          if (lines.length > 0) {
+            break;
+          }
+        }
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
       expect(lines.length).toBeGreaterThan(0);
     });
 
@@ -274,46 +277,69 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
     });
 
     it("subscribe receives stateChange events on stop", async () => {
+      // Ensure service is ready first
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
       const events: DaemonEvent[] = [];
       const sub = ipcSubscribe(daemon.socketPath, sid, ["service.stateChange"], (event) =>
         events.push(event),
       );
 
-      // Wait for subscription to be established
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Confirm subscription is live via a ping round-trip
+      await ipcRequest(daemon.socketPath, "daemon.ping");
 
       // Stop the service — triggers stateChange events
       await ipcRequest(daemon.socketPath, "services.stop", { name: "web" }, 10_000, sid);
 
       // Allow time for events to propagate
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       sub.close();
 
-      const stateEvents = events.filter((e) => e.event === "service.stateChange");
-      expect(stateEvents.length).toBeGreaterThan(0);
-
-      const webEvents = stateEvents.filter((e) => {
+      const webEvents = events.filter((e) => {
+        if (e.event !== "service.stateChange") {
+          return false;
+        }
         const data = e.data as { name: string };
         return data.name === "web";
       });
       expect(webEvents.length).toBeGreaterThan(0);
+
+      // Re-start for other tests
+      await ipcRequest(daemon.socketPath, "services.start", { name: "web" }, 15_000, sid);
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
     });
 
-    it("services.start transitions stopped service back to ready", async () => {
-      // Service was stopped by previous test
-      const res = await ipcRequest(
+    it("services.stop + start transitions service back to ready", async () => {
+      // Ensure service is ready first
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+      // Stop
+      const stopRes = await ipcRequest(
+        daemon.socketPath,
+        "services.stop",
+        { name: "web" },
+        10_000,
+        sid,
+      );
+      expect(stopRes.error).toBeUndefined();
+      await waitForServiceState(daemon.socketPath, sid, "web", "stopped");
+
+      // Start
+      const startRes = await ipcRequest(
         daemon.socketPath,
         "services.start",
         { name: "web" },
         15_000,
         sid,
       );
-      expect(res.error).toBeUndefined();
-
+      expect(startRes.error).toBeUndefined();
       await waitForServiceState(daemon.socketPath, sid, "web", "ready");
     });
 
     it("services.restart cycles the service back to ready", async () => {
+      // Ensure service is ready first
+      await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
       const res = await ipcRequest(
         daemon.socketPath,
         "services.restart",
@@ -324,6 +350,47 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
       expect(res.error).toBeUndefined();
 
       await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+    });
+
+    it("concurrent IPC requests all resolve correctly", async () => {
+      const requests = Array.from({ length: 10 }, async () =>
+        ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid),
+      );
+      const results = await Promise.all(requests);
+
+      for (const res of results) {
+        expect(res.error).toBeUndefined();
+        const statuses = res.result as { name: string; state: string }[];
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0].name).toBe("web");
+      }
+    });
+  });
+
+  // ── Validation errors ─────────────────────────────────────────────
+
+  describe("config validation errors", () => {
+    let daemon: TestDaemon;
+    let tmux: TestSession;
+
+    beforeEach(async () => {
+      daemon = await createTestDaemon();
+      tmux = await createTestSession();
+    });
+
+    afterEach(async () => {
+      await daemon.cleanup();
+      await tmux.cleanup();
+    });
+
+    it("session.create with nonexistent config returns error", async () => {
+      const res = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: "/tmp/nonexistent-zaps-config.mjs",
+        projectDir: "/tmp",
+        tmuxSession: tmux.name,
+        originPane: tmux.initialPaneId,
+      });
+      expect(res.error).toBeDefined();
     });
   });
 });

--- a/test/integration/daemon/multi-service.test.ts
+++ b/test/integration/daemon/multi-service.test.ts
@@ -53,7 +53,6 @@ describe.skipIf(!hasTmux())("multi-service operations", () => {
     } catch {
       /* Best-effort cleanup */
     }
-    await new Promise((resolve) => setTimeout(resolve, 600));
     await daemon.cleanup();
     await tmux.cleanup();
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/integration/daemon/multi-session.test.ts
+++ b/test/integration/daemon/multi-session.test.ts
@@ -1,0 +1,259 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ipcRequest } from "#src/lib/ipc/client.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { TestDaemon } from "../helpers/daemon.js";
+import { createTestDaemon, waitForServiceState, writeTestConfig } from "../helpers/daemon.js";
+import { getFreePort } from "../helpers/port.js";
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+describe.skipIf(!hasTmux())("daemon multi-session", () => {
+  // ── Two sessions coexist on same daemon ──────────────────────────────
+
+  describe("two sessions coexist on same daemon", () => {
+    let daemon: TestDaemon;
+    let tmux1: TestSession;
+    let tmux2: TestSession;
+    let tmpDir1: string;
+    let tmpDir2: string;
+    let sidA: string | undefined;
+    let sidB: string | undefined;
+
+    beforeAll(async () => {
+      daemon = await createTestDaemon();
+      tmux1 = await createTestSession();
+      tmux2 = await createTestSession();
+      tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-a-"));
+      tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-b-"));
+
+      const portA = await getFreePort();
+      const portB = await getFreePort();
+      const configA = writeTestConfig(tmpDir1, portA);
+      const configB = writeTestConfig(tmpDir2, portB);
+
+      const resA = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configA,
+        projectDir: tmpDir1,
+        tmuxSession: tmux1.name,
+        originPane: tmux1.initialPaneId,
+      });
+      sidA = (resA.result as { id: string }).id;
+
+      const resB = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configB,
+        projectDir: tmpDir2,
+        tmuxSession: tmux2.name,
+        originPane: tmux2.initialPaneId,
+      });
+      sidB = (resB.result as { id: string }).id;
+
+      await Promise.all([
+        waitForServiceState(daemon.socketPath, sidA, "web", "ready"),
+        waitForServiceState(daemon.socketPath, sidB, "web", "ready"),
+      ]);
+    });
+
+    afterAll(async () => {
+      for (const sid of [sidA, sidB]) {
+        if (sid) {
+          try {
+            await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+          } catch {
+            /* Best-effort */
+          }
+        }
+      }
+      await daemon.cleanup();
+      await tmux1.cleanup();
+      await tmux2.cleanup();
+      fs.rmSync(tmpDir1, { recursive: true, force: true });
+      fs.rmSync(tmpDir2, { recursive: true, force: true });
+    });
+
+    it("session.list returns both sessions", async () => {
+      const res = await ipcRequest(daemon.socketPath, "session.list");
+      expect(res.error).toBeUndefined();
+      const sessions = res.result as { id: string }[];
+      expect(sessions).toHaveLength(2);
+      const ids = sessions.map((s) => s.id);
+      expect(ids).toContain(sidA);
+      expect(ids).toContain(sidB);
+    });
+
+    it("session A's web service is ready", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sidA);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses.find((s) => s.name === "web")?.state).toBe("ready");
+    });
+
+    it("session B's web service is ready", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sidB);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses.find((s) => s.name === "web")?.state).toBe("ready");
+    });
+  });
+
+  // ── Stopping a service in session A doesn't affect session B ─────────
+
+  describe("stopping service in session A doesn't affect session B", () => {
+    let daemon: TestDaemon;
+    let tmux1: TestSession;
+    let tmux2: TestSession;
+    let tmpDir1: string;
+    let tmpDir2: string;
+    let sidA: string;
+    let sidB: string;
+
+    beforeAll(async () => {
+      daemon = await createTestDaemon();
+      tmux1 = await createTestSession();
+      tmux2 = await createTestSession();
+      tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-a-"));
+      tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-b-"));
+
+      const portA = await getFreePort();
+      const portB = await getFreePort();
+      const configA = writeTestConfig(tmpDir1, portA);
+      const configB = writeTestConfig(tmpDir2, portB);
+
+      const resA = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configA,
+        projectDir: tmpDir1,
+        tmuxSession: tmux1.name,
+        originPane: tmux1.initialPaneId,
+      });
+      sidA = (resA.result as { id: string }).id;
+
+      const resB = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configB,
+        projectDir: tmpDir2,
+        tmuxSession: tmux2.name,
+        originPane: tmux2.initialPaneId,
+      });
+      sidB = (resB.result as { id: string }).id;
+
+      await Promise.all([
+        waitForServiceState(daemon.socketPath, sidA, "web", "ready"),
+        waitForServiceState(daemon.socketPath, sidB, "web", "ready"),
+      ]);
+
+      await ipcRequest(daemon.socketPath, "services.stop", { name: "web" }, 10_000, sidA);
+      await waitForServiceState(daemon.socketPath, sidA, "web", "stopped");
+    });
+
+    afterAll(async () => {
+      for (const sid of [sidA, sidB]) {
+        if (sid) {
+          try {
+            await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+          } catch {
+            /* Best-effort */
+          }
+        }
+      }
+      await daemon.cleanup();
+      await tmux1.cleanup();
+      await tmux2.cleanup();
+      fs.rmSync(tmpDir1, { recursive: true, force: true });
+      fs.rmSync(tmpDir2, { recursive: true, force: true });
+    });
+
+    it("session A's web service is stopped", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sidA);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses.find((s) => s.name === "web")?.state).toBe("stopped");
+    });
+
+    it("session B's web service is still ready", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sidB);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses.find((s) => s.name === "web")?.state).toBe("ready");
+    });
+  });
+
+  // ── Destroying session A doesn't affect session B ─────────────────────
+
+  describe("destroying session A doesn't affect session B", () => {
+    let daemon: TestDaemon;
+    let tmux1: TestSession;
+    let tmux2: TestSession;
+    let tmpDir1: string;
+    let tmpDir2: string;
+    let sidA: string;
+    let sidB: string;
+
+    beforeAll(async () => {
+      daemon = await createTestDaemon();
+      tmux1 = await createTestSession();
+      tmux2 = await createTestSession();
+      tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-a-"));
+      tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-multi-b-"));
+
+      const portA = await getFreePort();
+      const portB = await getFreePort();
+      const configA = writeTestConfig(tmpDir1, portA);
+      const configB = writeTestConfig(tmpDir2, portB);
+
+      const resA = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configA,
+        projectDir: tmpDir1,
+        tmuxSession: tmux1.name,
+        originPane: tmux1.initialPaneId,
+      });
+      sidA = (resA.result as { id: string }).id;
+
+      const resB = await ipcRequest(daemon.socketPath, "session.create", {
+        configPath: configB,
+        projectDir: tmpDir2,
+        tmuxSession: tmux2.name,
+        originPane: tmux2.initialPaneId,
+      });
+      sidB = (resB.result as { id: string }).id;
+
+      await Promise.all([
+        waitForServiceState(daemon.socketPath, sidA, "web", "ready"),
+        waitForServiceState(daemon.socketPath, sidB, "web", "ready"),
+      ]);
+
+      await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sidA);
+    });
+
+    afterAll(async () => {
+      try {
+        await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sidB);
+      } catch {
+        /* Best-effort */
+      }
+      await daemon.cleanup();
+      await tmux1.cleanup();
+      await tmux2.cleanup();
+      fs.rmSync(tmpDir1, { recursive: true, force: true });
+      fs.rmSync(tmpDir2, { recursive: true, force: true });
+    });
+
+    it("session.list returns only session B", async () => {
+      const res = await ipcRequest(daemon.socketPath, "session.list");
+      expect(res.error).toBeUndefined();
+      const sessions = res.result as { id: string }[];
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].id).toBe(sidB);
+    });
+
+    it("session B's web service is still ready", async () => {
+      const res = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sidB);
+      expect(res.error).toBeUndefined();
+      const statuses = res.result as { name: string; state: string }[];
+      expect(statuses.find((s) => s.name === "web")?.state).toBe("ready");
+    });
+  });
+});

--- a/test/integration/daemon/reload.test.ts
+++ b/test/integration/daemon/reload.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC responses are untyped */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ipcRequest, ipcSubscribe } from "#src/lib/ipc/client.js";
+import type { DaemonEvent } from "#src/lib/ipc/protocol.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { TestDaemon } from "../helpers/daemon.js";
+import { createTestDaemon, waitForServiceState } from "../helpers/daemon.js";
+import { getFreePort } from "../helpers/port.js";
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+function writeConfig(
+  dir: string,
+  name: string,
+  services: Record<string, { port: number }>,
+): string {
+  const configPath = path.join(dir, ".zaps.mjs");
+  const svcEntries = Object.entries(services).map(([svcName, { port }]) => {
+    const cmd = `node -e "require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port},()=>console.log('ready on port ${port}'))"`;
+    return `      ${svcName}: { start: ${JSON.stringify(cmd)}, ready: { port: ${port} } }`;
+  });
+  fs.writeFileSync(
+    configPath,
+    [
+      "export function config(lib) {",
+      "  return lib.defineProject({",
+      `    name: ${JSON.stringify(name)},`,
+      "    services: {",
+      ...svcEntries.map((e) => `${e},`),
+      "    },",
+      "  });",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  return configPath;
+}
+
+describe.skipIf(!hasTmux())("config hot-reload", () => {
+  let daemon: TestDaemon;
+  let tmux: TestSession;
+  let tmpDir: string;
+  let sid: string;
+
+  beforeEach(async () => {
+    daemon = await createTestDaemon();
+    tmux = await createTestSession();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-reload-"));
+  });
+
+  afterEach(async () => {
+    try {
+      await ipcRequest(daemon.socketPath, "session.destroy", undefined, 10_000, sid);
+    } catch {
+      /* Best-effort cleanup */
+    }
+    await daemon.cleanup();
+    await tmux.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reload restarts services from updated config", async () => {
+    const port1 = await getFreePort();
+    const configPath = writeConfig(tmpDir, "test-reload", { web: { port: port1 } });
+
+    const createRes = await ipcRequest(daemon.socketPath, "session.create", {
+      configPath,
+      projectDir: tmpDir,
+      tmuxSession: tmux.name,
+      originPane: tmux.initialPaneId,
+    });
+    sid = (createRes.result as { id: string }).id;
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+    // Reload the same config — services should restart
+    const reloadRes = await ipcRequest(daemon.socketPath, "session.reload", undefined, 30_000, sid);
+    expect(reloadRes.error).toBeUndefined();
+
+    // Services restart in background after reload — wait for them
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready", 30_000);
+
+    const listRes = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid);
+    expect(listRes.error).toBeUndefined();
+    const statuses = listRes.result as { name: string; state: string }[];
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].name).toBe("web");
+    expect(statuses[0].state).toBe("ready");
+  });
+
+  it("reload emits configReloaded event", async () => {
+    const port1 = await getFreePort();
+    const configPath = writeConfig(tmpDir, "test-reload", { web: { port: port1 } });
+
+    const createRes = await ipcRequest(daemon.socketPath, "session.create", {
+      configPath,
+      projectDir: tmpDir,
+      tmuxSession: tmux.name,
+      originPane: tmux.initialPaneId,
+    });
+    sid = (createRes.result as { id: string }).id;
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+    const allEvents: DaemonEvent[] = [];
+    const sub = ipcSubscribe(daemon.socketPath, sid, ["session.configReloaded"], (event) => {
+      allEvents.push(event);
+    });
+
+    // Confirm subscription is live
+    await ipcRequest(daemon.socketPath, "daemon.ping");
+
+    const reloadRes = await ipcRequest(daemon.socketPath, "session.reload", undefined, 30_000, sid);
+    expect(reloadRes.error).toBeUndefined();
+
+    // Wait for configReloaded event (subscription receives all events, filter client-side)
+    const deadline = Date.now() + 10_000;
+    let reloadEvent: DaemonEvent | undefined;
+    while (!reloadEvent && Date.now() < deadline) {
+      reloadEvent = allEvents.find((e) => e.event === "session.configReloaded");
+      if (!reloadEvent) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+    sub.close();
+
+    expect(reloadEvent).toBeDefined();
+    const data = reloadEvent!.data as { id: string; name: string; statuses: unknown[] };
+    expect(data.id).toBe(sid);
+    expect(data.name).toBe("test-reload");
+    expect(Array.isArray(data.statuses)).toBe(true);
+  });
+
+  it("concurrent reload is guarded", async () => {
+    const port1 = await getFreePort();
+    const configPath = writeConfig(tmpDir, "test-reload", { web: { port: port1 } });
+
+    const createRes = await ipcRequest(daemon.socketPath, "session.create", {
+      configPath,
+      projectDir: tmpDir,
+      tmuxSession: tmux.name,
+      originPane: tmux.initialPaneId,
+    });
+    sid = (createRes.result as { id: string }).id;
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready");
+
+    // Fire 2 reloads in parallel
+    const [res1, res2] = await Promise.all([
+      ipcRequest(daemon.socketPath, "session.reload", undefined, 30_000, sid),
+      ipcRequest(daemon.socketPath, "session.reload", undefined, 30_000, sid),
+    ]);
+
+    expect(res1.error).toBeUndefined();
+    expect(res2.error).toBeUndefined();
+
+    await waitForServiceState(daemon.socketPath, sid, "web", "ready", 30_000);
+
+    const listRes = await ipcRequest(daemon.socketPath, "services.list", undefined, 5000, sid);
+    expect(listRes.error).toBeUndefined();
+    const statuses = listRes.result as { name: string; state: string }[];
+    expect(statuses.length).toBeGreaterThan(0);
+  });
+});

--- a/test/integration/global-setup.ts
+++ b/test/integration/global-setup.ts
@@ -1,11 +1,16 @@
 import { execFileSync } from "node:child_process";
 
+function killTestServer() {
+  try {
+    execFileSync("tmux", ["-L", "zaps-test", "kill-server"], { stdio: "ignore" });
+  } catch {
+    /* Server may already be gone */
+  }
+}
+
 export default function setup() {
+  killTestServer();
   return () => {
-    try {
-      execFileSync("tmux", ["-L", "zaps-test", "kill-server"], { stdio: "ignore" });
-    } catch {
-      /* Server may already be gone */
-    }
+    killTestServer();
   };
 }

--- a/test/integration/helpers/daemon.ts
+++ b/test/integration/helpers/daemon.ts
@@ -117,7 +117,7 @@ export async function waitForServiceState(
         return;
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
   /* eslint-enable no-await-in-loop */
   throw new Error(`Service '${service}' did not reach '${targetState}' within ${timeoutMs}ms`);
@@ -147,7 +147,7 @@ export async function waitForAllServices(
         return;
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
   /* eslint-enable no-await-in-loop */
   throw new Error(

--- a/test/integration/helpers/service-manager.ts
+++ b/test/integration/helpers/service-manager.ts
@@ -1,0 +1,56 @@
+import { detectPorts, getDescendantPids } from "#src/lib/port.js";
+import type { ServiceManager } from "#src/lib/service/manager.js";
+import type { ServiceStatus } from "#src/lib/service/types.js";
+import {
+  capturePane,
+  getWindowName,
+  getWindowOption,
+  panePid,
+  renameWindow,
+  sendCtrlC,
+  sendKeys,
+  setWindowOption,
+} from "#src/lib/tmux.js";
+
+export const tmuxDeps = {
+  sendKeys,
+  sendCtrlC,
+  panePid,
+  detectPorts,
+  capturePane,
+  getDescendantPids,
+  renameWindow,
+  getWindowName,
+  getWindowOption,
+  setWindowOption,
+  exec: async () => {
+    /* No-op */
+  },
+};
+
+export async function waitForState(
+  mgr: ServiceManager,
+  name: string,
+  target: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (mgr.getStatus(name).state === target) {
+      resolve();
+      return;
+    }
+    function listener(n: string, status: ServiceStatus) {
+      if (n === name && status.state === target) {
+        clearTimeout(timer); // eslint-disable-line no-use-before-define -- circular timer/listener
+        mgr.removeListener("stateChange", listener);
+        resolve();
+      }
+    }
+
+    const timer = setTimeout(() => {
+      mgr.removeListener("stateChange", listener);
+      reject(new Error(`Timed out waiting for ${name} to reach ${target}`));
+    }, timeoutMs);
+    mgr.on("stateChange", listener);
+  });
+}

--- a/test/integration/service-manager/crash-recovery.test.ts
+++ b/test/integration/service-manager/crash-recovery.test.ts
@@ -1,67 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import type { ServiceStatus } from "#src/lib/service/types.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { crashingCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps, waitForState } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
-
-async function waitForState(
-  mgr: ServiceManager,
-  name: string,
-  target: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (mgr.getStatus(name).state === target) {
-      resolve();
-      return;
-    }
-    function listener(n: string, status: ServiceStatus) {
-      if (n === name && status.state === target) {
-        clearTimeout(timer); // eslint-disable-line no-use-before-define -- circular timer/listener
-        mgr.removeListener("stateChange", listener);
-        resolve();
-      }
-    }
-
-    const timer = setTimeout(() => {
-      mgr.removeListener("stateChange", listener);
-      reject(new Error(`Timed out waiting for ${name} to reach ${target}`));
-    }, timeoutMs);
-    mgr.on("stateChange", listener);
-  });
-}
 
 describe.skipIf(!hasTmux())("crash-recovery integration", () => {
   let session: TestSession;
@@ -89,13 +35,13 @@ describe.skipIf(!hasTmux())("crash-recovery integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
-    // Wait for crash detection + auto-restart → ready again
-    await waitForState(mgr, "svc", "restarting");
-    await waitForState(mgr, "svc", "ready");
+    // Wait for crash detection + auto-restart → ready again (slow under parallel load)
+    await waitForState(mgr, "svc", "restarting", 15_000);
+    await waitForState(mgr, "svc", "ready", 15_000);
 
     expect(mgr.getStatus("svc").retryCount).toBe(1);
   });
@@ -113,7 +59,7 @@ describe.skipIf(!hasTmux())("crash-recovery integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
@@ -137,16 +83,16 @@ describe.skipIf(!hasTmux())("crash-recovery integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
-    // First crash → restart
-    await waitForState(mgr, "svc", "restarting");
-    await waitForState(mgr, "svc", "ready");
+    // First crash → restart (slow under parallel load)
+    await waitForState(mgr, "svc", "restarting", 15_000);
+    await waitForState(mgr, "svc", "ready", 15_000);
     expect(mgr.getStatus("svc").retryCount).toBe(1);
 
-    // Second crash → error (retries exhausted)
+    // Second crash → error (retries exhausted, generous timeout for parallel load)
     await waitForState(mgr, "svc", "error", 30_000);
     expect(mgr.getStatus("svc").state).toBe("error");
   });

--- a/test/integration/service-manager/dependencies.test.ts
+++ b/test/integration/service-manager/dependencies.test.ts
@@ -1,40 +1,14 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("dependencies integration", () => {
   let session: TestSession;
@@ -60,7 +34,7 @@ describe.skipIf(!hasTmux())("dependencies integration", () => {
       api: { start: httpServerCmd(apiPort), ready: { port: apiPort }, dependsOn: ["db"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     const readyOrder: string[] = [];
     mgr.on("stateChange", (name: string, status: ServiceStatus) => {
@@ -89,7 +63,7 @@ describe.skipIf(!hasTmux())("dependencies integration", () => {
       fe: { start: httpServerCmd(fePort), ready: { port: fePort }, dependsOn: ["api"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     const readyOrder: string[] = [];
     mgr.on("stateChange", (name: string, status: ServiceStatus) => {
@@ -118,7 +92,7 @@ describe.skipIf(!hasTmux())("dependencies integration", () => {
       a: { start: httpServerCmd(portA), ready: { port: portA }, dependsOn: ["b", "c"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     const readyOrder: string[] = [];
     mgr.on("stateChange", (name: string, status: ServiceStatus) => {
@@ -150,7 +124,7 @@ describe.skipIf(!hasTmux())("dependencies integration", () => {
       fe: { start: httpServerCmd(fePort), ready: { port: fePort }, dependsOn: ["api"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     const stopOrder: string[] = [];
     mgr.on("stateChange", (name: string, status: ServiceStatus) => {
@@ -165,5 +139,31 @@ describe.skipIf(!hasTmux())("dependencies integration", () => {
     // Fe depends on api depends on db → stop fe first, then api, then db
     expect(stopOrder.indexOf("fe")).toBeLessThan(stopOrder.indexOf("api"));
     expect(stopOrder.indexOf("api")).toBeLessThan(stopOrder.indexOf("db"));
+  });
+
+  it("dependency failure prevents dependent from starting", async () => {
+    session = await createTestSession();
+    const apiPort = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["db", "api"]);
+
+    // Db uses a ready function that always rejects — simulates fast startup failure
+    const config = makeConfig({
+      db: {
+        start: 'node -e "process.exit(1)"',
+        ready: async () => Promise.reject(new Error("db startup failed")),
+      },
+      api: { start: httpServerCmd(apiPort), ready: { port: apiPort }, dependsOn: ["db"] },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+
+    // StartAll catches the error for db, then skips api (dep not ready)
+    await mgr.startAll();
+
+    // Db should be in error state (ready check rejected)
+    expect(mgr.getStatus("db").state).toBe("error");
+
+    // Api should NOT have started — dependency not ready
+    expect(mgr.getStatus("api").state).toBe("stopped");
   });
 });

--- a/test/integration/service-manager/docker-expand.test.ts
+++ b/test/integration/service-manager/docker-expand.test.ts
@@ -4,23 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-  splitPane,
-} from "#src/lib/tmux.js";
+import { splitPane } from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { composeDown, writeComposeFile } from "../helpers/docker.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasDocker, hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { createTestSession } from "../helpers/tmux.js";
@@ -28,16 +18,7 @@ import { createTestSession } from "../helpers/tmux.js";
 const execFileAsync = promisify(execFile);
 
 const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
+  ...tmuxDeps,
   exec: async (cmd: string, args: string[], cwd?: string) => {
     await execFileAsync(cmd, args, cwd ? { cwd } : {});
   },

--- a/test/integration/service-manager/docker-ready.test.ts
+++ b/test/integration/service-manager/docker-ready.test.ts
@@ -2,41 +2,15 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { composeDown, writeComposeFile } from "../helpers/docker.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasDocker, hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux() || !hasDocker())("docker-ready integration", () => {
   let session: TestSession;
@@ -74,7 +48,7 @@ describe.skipIf(!hasTmux() || !hasDocker())("docker-ready integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("redis");
 
     expect(mgr.getStatus("redis").state).toBe("ready");

--- a/test/integration/service-manager/edge-cases.test.ts
+++ b/test/integration/service-manager/edge-cases.test.ts
@@ -1,40 +1,14 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
-import { httpServerCmd } from "../helpers/fixtures.js";
+import { httpServerCmd, slowStartCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps, waitForState } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("edge-cases integration", () => {
   let session: TestSession;
@@ -58,7 +32,7 @@ describe.skipIf(!hasTmux())("edge-cases integration", () => {
       svc: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
@@ -78,7 +52,7 @@ describe.skipIf(!hasTmux())("edge-cases integration", () => {
       api: { start: httpServerCmd(apiPort), ready: { port: apiPort }, dependsOn: ["db"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     await expect(mgr.startService("api")).rejects.toThrow(/not ready/);
   });
@@ -92,7 +66,7 @@ describe.skipIf(!hasTmux())("edge-cases integration", () => {
       svc: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
 
     await mgr.stopAll();
@@ -115,7 +89,7 @@ describe.skipIf(!hasTmux())("edge-cases integration", () => {
       fe: { start: httpServerCmd(fePort), ready: { port: fePort }, dependsOn: ["api"] },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
 
     const stopOrder: string[] = [];
     mgr.on("stateChange", (name: string, status: ServiceStatus) => {
@@ -130,5 +104,54 @@ describe.skipIf(!hasTmux())("edge-cases integration", () => {
     // Fe should stop before api, api before db
     expect(stopOrder.indexOf("fe")).toBeLessThan(stopOrder.indexOf("api"));
     expect(stopOrder.indexOf("api")).toBeLessThan(stopOrder.indexOf("db"));
+  });
+
+  it("stop during starting aborts cleanly", async () => {
+    session = await createTestSession();
+    const port = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["svc"]);
+
+    const config = makeConfig({
+      svc: { start: slowStartCmd(port, 5000), ready: { port } },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+
+    // Start in background (will take 5s to become ready)
+    const startPromise = mgr.startService("svc");
+
+    // Wait for "starting" state
+    await waitForState(mgr, "svc", "starting", 5000);
+
+    // Stop immediately — should abort the ready poll
+    await mgr.stopService("svc");
+    expect(mgr.getStatus("svc").state).toBe("stopped");
+
+    // Original start should resolve (aborted, no throw)
+    await startPromise;
+  });
+
+  it("rapid start/stop cycling leaves clean state", async () => {
+    session = await createTestSession();
+    const port = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["svc"]);
+
+    const config = makeConfig({
+      svc: { start: httpServerCmd(port), ready: { port } },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+
+    // Cycle 1
+    await mgr.startService("svc");
+    expect(mgr.getStatus("svc").state).toBe("ready");
+    await mgr.stopService("svc");
+    expect(mgr.getStatus("svc").state).toBe("stopped");
+
+    // Cycle 2
+    await mgr.startService("svc");
+    expect(mgr.getStatus("svc").state).toBe("ready");
+    await mgr.stopService("svc");
+    expect(mgr.getStatus("svc").state).toBe("stopped");
   });
 });

--- a/test/integration/service-manager/env.test.ts
+++ b/test/integration/service-manager/env.test.ts
@@ -1,39 +1,14 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
+import { capturePane } from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("env integration", () => {
   let session: TestSession;
@@ -61,7 +36,7 @@ describe.skipIf(!hasTmux())("env integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
@@ -86,7 +61,7 @@ describe.skipIf(!hasTmux())("env integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
 
     expect(mgr.getStatus("db").state).toBe("ready");

--- a/test/integration/service-manager/flags.test.ts
+++ b/test/integration/service-manager/flags.test.ts
@@ -1,39 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("flags integration", () => {
   let session: TestSession;
@@ -61,7 +35,7 @@ describe.skipIf(!hasTmux())("flags integration", () => {
       svc3: { start: httpServerCmd(port3), ready: { port: port3 } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
 
     expect(mgr.getStatus("svc1").state).toBe("ready");
@@ -80,7 +54,7 @@ describe.skipIf(!hasTmux())("flags integration", () => {
       svc2: { start: httpServerCmd(port2), ready: { port: port2 }, flags: { start: false } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
 
     expect(mgr.getStatus("svc2").state).toBe("stopped");

--- a/test/integration/service-manager/hooks.test.ts
+++ b/test/integration/service-manager/hooks.test.ts
@@ -1,39 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("hooks integration", () => {
   let session: TestSession;
@@ -72,7 +46,7 @@ describe.skipIf(!hasTmux())("hooks integration", () => {
       },
     );
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
     expect(order).toEqual(["onBeforeStart", "onStart"]);
 
@@ -103,7 +77,7 @@ describe.skipIf(!hasTmux())("hooks integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(order).toContain("svc:onBeforeStart");
     expect(order).toContain("svc:onReady");
@@ -128,7 +102,7 @@ describe.skipIf(!hasTmux())("hooks integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");

--- a/test/integration/service-manager/ready-fn.test.ts
+++ b/test/integration/service-manager/ready-fn.test.ts
@@ -3,40 +3,14 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("ready-fn integration", () => {
   let session: TestSession;
@@ -65,7 +39,7 @@ describe.skipIf(!hasTmux())("ready-fn integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");

--- a/test/integration/service-manager/ready-http.test.ts
+++ b/test/integration/service-manager/ready-http.test.ts
@@ -1,39 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpHealthServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("ready-http integration", () => {
   let session: TestSession;
@@ -60,7 +34,7 @@ describe.skipIf(!hasTmux())("ready-http integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");
@@ -78,7 +52,7 @@ describe.skipIf(!hasTmux())("ready-http integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");

--- a/test/integration/service-manager/ready-output.test.ts
+++ b/test/integration/service-manager/ready-output.test.ts
@@ -1,38 +1,12 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { outputOnlyCmd } from "../helpers/fixtures.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("ready-output integration", () => {
   let session: TestSession;
@@ -58,7 +32,7 @@ describe.skipIf(!hasTmux())("ready-output integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");
@@ -75,7 +49,7 @@ describe.skipIf(!hasTmux())("ready-output integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
 
     expect(mgr.getStatus("svc").state).toBe("ready");

--- a/test/integration/service-manager/ready-port.test.ts
+++ b/test/integration/service-manager/ready-port.test.ts
@@ -1,39 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { slowStartCmd, wrapperStartCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("ready-port integration", () => {
   let session: TestSession;
@@ -57,7 +31,7 @@ describe.skipIf(!hasTmux())("ready-port integration", () => {
       web: { start: slowStartCmd(port, 2000), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
 
     expect(mgr.getStatus("web").state).toBe("ready");
@@ -73,7 +47,7 @@ describe.skipIf(!hasTmux())("ready-port integration", () => {
       web: { start: slowStartCmd(port, 1000), ready: { port: true } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
 
     expect(mgr.getStatus("web").state).toBe("ready");
@@ -89,7 +63,7 @@ describe.skipIf(!hasTmux())("ready-port integration", () => {
       web: { start: wrapperStartCmd(port, 1000), ready: { port: true } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
 
     expect(mgr.getStatus("web").state).toBe("ready");

--- a/test/integration/service-manager/restart-with.test.ts
+++ b/test/integration/service-manager/restart-with.test.ts
@@ -1,0 +1,120 @@
+import { ServiceManager } from "#src/lib/service/manager.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { makeConfig } from "../helpers/config.js";
+import { httpServerCmd } from "../helpers/fixtures.js";
+import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps, waitForState } from "../helpers/service-manager.js";
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
+
+describe.skipIf(!hasTmux())("restartWith cascade integration", () => {
+  let session: TestSession;
+  let mgr: ServiceManager;
+
+  afterEach(async () => {
+    try {
+      await mgr.stopAll();
+    } catch {
+      // Best-effort
+    }
+    await session.cleanup();
+  });
+
+  it("restart triggers restartWith dependents", async () => {
+    session = await createTestSession();
+    const dbPort = await getFreePort();
+    const apiPort = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["db", "api"]);
+
+    const config = makeConfig({
+      db: { start: httpServerCmd(dbPort), ready: { port: dbPort } },
+      api: {
+        start: httpServerCmd(apiPort),
+        ready: { port: apiPort },
+        dependsOn: ["db"],
+        restartWith: ["db"],
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+    await mgr.startAll();
+    expect(mgr.getStatus("db").state).toBe("ready");
+    expect(mgr.getStatus("api").state).toBe("ready");
+
+    const apiReady = waitForState(mgr, "api", "ready");
+    await mgr.restartService("db");
+    await apiReady;
+
+    expect(mgr.getStatus("db").state).toBe("ready");
+    expect(mgr.getStatus("api").state).toBe("ready");
+  });
+
+  it("multi-level cascade: db→api→fe", async () => {
+    session = await createTestSession();
+    const dbPort = await getFreePort();
+    const apiPort = await getFreePort();
+    const fePort = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["db", "api", "fe"]);
+
+    const config = makeConfig({
+      db: { start: httpServerCmd(dbPort), ready: { port: dbPort } },
+      api: {
+        start: httpServerCmd(apiPort),
+        ready: { port: apiPort },
+        dependsOn: ["db"],
+        restartWith: ["db"],
+      },
+      fe: {
+        start: httpServerCmd(fePort),
+        ready: { port: fePort },
+        dependsOn: ["api"],
+        restartWith: ["api"],
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+    await mgr.startAll();
+    expect(mgr.getStatus("db").state).toBe("ready");
+    expect(mgr.getStatus("api").state).toBe("ready");
+    expect(mgr.getStatus("fe").state).toBe("ready");
+
+    const apiReady = waitForState(mgr, "api", "ready");
+    const feReady = waitForState(mgr, "fe", "ready");
+    await mgr.restartService("db");
+    await apiReady;
+    await feReady;
+
+    expect(mgr.getStatus("db").state).toBe("ready");
+    expect(mgr.getStatus("api").state).toBe("ready");
+    expect(mgr.getStatus("fe").state).toBe("ready");
+  });
+
+  it("restartWith does not restart stopped services", async () => {
+    session = await createTestSession();
+    const dbPort = await getFreePort();
+    const apiPort = await getFreePort();
+    const paneMap = await buildTestPaneMap(session.initialPaneId, ["db", "api"]);
+
+    const config = makeConfig({
+      db: { start: httpServerCmd(dbPort), ready: { port: dbPort } },
+      api: {
+        start: httpServerCmd(apiPort),
+        ready: { port: apiPort },
+        dependsOn: ["db"],
+        restartWith: ["db"],
+      },
+    });
+
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
+    await mgr.startAll();
+    await mgr.stopService("api");
+    expect(mgr.getStatus("api").state).toBe("stopped");
+
+    await mgr.restartService("db");
+
+    expect(mgr.getStatus("db").state).toBe("ready");
+    expect(mgr.getStatus("api").state).toBe("stopped");
+  });
+});

--- a/test/integration/service-manager/restart.test.ts
+++ b/test/integration/service-manager/restart.test.ts
@@ -1,67 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import type { ServiceStatus } from "#src/lib/service/types.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { crashingCmd, httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps, waitForState } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
-
-async function waitForState(
-  mgr: ServiceManager,
-  name: string,
-  target: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (mgr.getStatus(name).state === target) {
-      resolve();
-      return;
-    }
-    function listener(n: string, status: ServiceStatus) {
-      if (n === name && status.state === target) {
-        clearTimeout(timer); // eslint-disable-line no-use-before-define -- circular timer/listener
-        mgr.removeListener("stateChange", listener);
-        resolve();
-      }
-    }
-
-    const timer = setTimeout(() => {
-      mgr.removeListener("stateChange", listener);
-      reject(new Error(`Timed out waiting for ${name} to reach ${target}`));
-    }, timeoutMs);
-    mgr.on("stateChange", listener);
-  });
-}
 
 describe.skipIf(!hasTmux())("restart integration", () => {
   let session: TestSession;
@@ -85,7 +31,7 @@ describe.skipIf(!hasTmux())("restart integration", () => {
       web: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
     expect(mgr.getStatus("web").state).toBe("ready");
 
@@ -107,7 +53,7 @@ describe.skipIf(!hasTmux())("restart integration", () => {
       },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("svc");
     expect(mgr.getStatus("svc").state).toBe("ready");
 
@@ -131,7 +77,7 @@ describe.skipIf(!hasTmux())("restart integration", () => {
       web: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
     await mgr.stopService("web");
     expect(mgr.getStatus("web").state).toBe("stopped");

--- a/test/integration/service-manager/start-stop.test.ts
+++ b/test/integration/service-manager/start-stop.test.ts
@@ -1,39 +1,13 @@
-import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  panePid,
-  renameWindow,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeConfig } from "../helpers/config.js";
 import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
+import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
-
-const deps = {
-  sendKeys,
-  sendCtrlC,
-  panePid,
-  detectPorts,
-  capturePane,
-  getDescendantPids,
-  renameWindow,
-  getWindowName,
-  getWindowOption,
-  setWindowOption,
-  exec: async () => {
-    /* No-op */
-  },
-};
 
 describe.skipIf(!hasTmux())("start-stop integration", () => {
   let session: TestSession;
@@ -57,7 +31,7 @@ describe.skipIf(!hasTmux())("start-stop integration", () => {
       web: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
 
     expect(mgr.getStatus("web").state).toBe("ready");
@@ -73,7 +47,7 @@ describe.skipIf(!hasTmux())("start-stop integration", () => {
       web: { start: httpServerCmd(port), ready: { port } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startService("web");
     expect(mgr.getStatus("web").state).toBe("ready");
 
@@ -92,7 +66,7 @@ describe.skipIf(!hasTmux())("start-stop integration", () => {
       svc2: { start: httpServerCmd(port2), ready: { port: port2 } },
     });
 
-    mgr = new ServiceManager(config, paneMap, deps, session.name);
+    mgr = new ServiceManager(config, paneMap, tmuxDeps, session.name);
     await mgr.startAll();
 
     expect(mgr.getStatus("svc1").state).toBe("ready");

--- a/test/integration/tmux/layout.test.ts
+++ b/test/integration/tmux/layout.test.ts
@@ -1,11 +1,30 @@
 import type { LayoutNode, ServiceConfig } from "#src/config/types.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
 import { listPanes } from "#src/lib/tmux.js";
+import type { PaneInfo } from "#src/lib/tmux.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { createTestSession } from "../helpers/tmux.js";
+
+/** Poll listPanes until expected count or timeout — tmux may lag behind splitPane. */
+async function waitForPaneCount(
+  sessionName: string,
+  expected: number,
+  timeoutMs = 5000,
+): Promise<PaneInfo[]> {
+  const start = Date.now();
+  let panes: PaneInfo[] = [];
+  while (Date.now() - start < timeoutMs) {
+    panes = await listPanes(sessionName);
+    if (panes.length === expected) {
+      return panes;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return panes;
+}
 
 describe.skipIf(!hasTmux())("tmux layout integration", () => {
   let session: TestSession;
@@ -22,7 +41,7 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
     };
 
     const { paneMap } = await createLayout(session.initialPaneId, undefined, services);
-    const panes = await listPanes(session.name);
+    const panes = await waitForPaneCount(session.name, 3);
 
     expect(panes).toHaveLength(3);
     expect(paneMap["@tui"]).toBe(session.initialPaneId);
@@ -38,7 +57,7 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
     };
 
     const { paneMap } = await createLayout(session.initialPaneId, undefined, services);
-    const panes = await listPanes(session.name);
+    const panes = await waitForPaneCount(session.name, 2);
 
     expect(panes).toHaveLength(2);
     expect(paneMap["@tui"]).toBeDefined();
@@ -60,7 +79,7 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
     };
 
     const { paneMap } = await createLayout(session.initialPaneId, layout, services);
-    const panes = await listPanes(session.name);
+    const panes = await waitForPaneCount(session.name, 2);
 
     expect(panes).toHaveLength(2);
     expect(paneMap["@tui"]).toBeDefined();
@@ -89,7 +108,7 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
     };
 
     const { paneMap } = await createLayout(session.initialPaneId, layout, services);
-    const panes = await listPanes(session.name);
+    const panes = await waitForPaneCount(session.name, 3);
 
     expect(panes).toHaveLength(3);
     expect(paneMap["@tui"]).toBeDefined();
@@ -112,7 +131,7 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
     };
 
     const { paneMap } = await createLayout(session.initialPaneId, layout, services);
-    const panes = await listPanes(session.name);
+    const panes = await waitForPaneCount(session.name, 3);
 
     // @tui + api from layout + worker auto-split
     expect(panes).toHaveLength(3);

--- a/test/integration/tmux/pane-ops.test.ts
+++ b/test/integration/tmux/pane-ops.test.ts
@@ -37,17 +37,35 @@ describe.skipIf(!hasTmux())("tmux pane-ops integration", () => {
     session = await createTestSession();
     const paneId = await splitPane(session.initialPaneId, "v");
 
+    // Wait for shell to initialize in the new pane before sending commands
+    await new Promise((resolve) => setTimeout(resolve, 500));
     await sendKeys(paneId, longRunningCmd());
-    await new Promise((resolve) => setTimeout(resolve, 1000));
 
+    // Poll until process starts (generous timeout — shared tmux server under parallel load)
     const rootPid = await panePid(paneId);
-    const before = await getDescendantPids(rootPid);
+    const startDeadline = Date.now() + 30_000;
+    let before: number[] = [];
+    while (Date.now() < startDeadline) {
+      before = await getDescendantPids(rootPid);
+      if (before.length > 1) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
     expect(before.length).toBeGreaterThan(1);
 
     await sendCtrlC(paneId);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    const after = await getDescendantPids(rootPid);
+    // Poll until process exits (generous timeout)
+    let after: number[] = [];
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      after = await getDescendantPids(rootPid);
+      if (after.length <= 1) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
     expect(after.length).toBeLessThanOrEqual(1);
   });
 


### PR DESCRIPTION
## Summary

- **5 bug fixes** in daemon/service core: LogMonitor flush, reload race guard, IPC listener leak, socket subscriber cleanup, duplicate crash monitor prevention
- **Test infrastructure**: extracted shared boilerplate (14 files), replaced magic delays with event-based waits, fixed ordered test dependencies, fixed flaky layout test
- **5 new test scenarios** (142 → 147 tests): restartWith cascade, multi-session isolation, config hot-reload, dependency failure cascade, stop-during-start, rapid cycling, concurrent IPC, config validation errors
- **0 flaky tests** across 5 consecutive runs

## Bug fixes

| Bug | File | Fix |
|-----|------|-----|
| LogMonitor in-flight capture after stop | `log-monitor.ts` | `flush()`/`flushAll()` with stopped flag + in-flight await |
| reload() race condition | `session.ts` | `reloading` guard, `flushAll()` on destroy |
| IPC listener leak on timeout | `client.ts` | `socket.off("data", onData)` in timeout handler |
| Socket subscriber leak on close | `server.ts` | Added `socket.on("close", ...)` cleanup |
| Duplicate crash monitors after restart | `manager.ts` | Generation counter invalidates stale monitors |