### PR TITLE
fix: swallow best-effort window-title rename rejection (green main CI)

### DIFF
--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -1362,7 +1362,9 @@ export class ServiceManager extends EventEmitter {
     await this.pendingRename.catch(() => {
       /* Ignored */
     });
-    await this.deps.renameWindow(this.paneMap["@tui"], title);
+    await this.deps.renameWindow(this.paneMap["@tui"], title).catch(() => {
+      // Best-effort cosmetic title update; the tmux window/server may be gone (e.g. teardown).
+    });
   }
 
   public handleExecExited(


### PR DESCRIPTION
## Problem

`main` CI is red on **Integration Tests** ([run](https://github.com/kboshold/zaps/actions/runs/27641223587/job/81741629355)). All 33 integration tests pass — the job fails on an **unhandled promise rejection**:

```
Error: tmux rename-window -t %2 zaps (●1) failed: no server running on /tmp/tmux-1001/zaps-test
  originated in test/integration/daemon/create-staleness.test.ts (A4)
```

The chained window-title update in `ServiceManager.chainRename` awaits `renameWindow(...)` without a `.catch()`. The busy-count title indicator (`zaps (●N)`) is purely cosmetic, but when its async call loses a race with tmux-server teardown it rejects with "no server running"; with no subsequent title update to absorb it via the chain, the rejected promise escapes as an unhandled rejection. Vitest counts any unhandled rejection as a run error → exit 1, even though every test passed. It is timing-flaky (coverage shifts timing), which is why the same command passed on the feature PR but fails on `main`.

## Fix

Wrap the `renameWindow` call in a best-effort `.catch()`, mirroring the existing title-restore path a few lines up (which already swallows the same "session may be gone" case). The cosmetic title update can now never surface as an unhandled rejection regardless of teardown timing.

One line, no behavior change beyond robustness.
