### PR TITLE
feat: optional / lazy tmux panes with dynamic layout reflow

### DIFF
--- a/.claude/skills/zaps-config/references/02-services.md
+++ b/.claude/skills/zaps-config/references/02-services.md
@@ -2,25 +2,26 @@
 
 ## Options
 
-| Field       | Type                                      | Default     | Description                                    |
-| ----------- | ----------------------------------------- | ----------- | ---------------------------------------------- |
-| `start`     | `string \| () => string`                  | —           | Long-running process command (server)          |
-| `run`       | `string \| () => string`                  | —           | One-shot command                               |
-| `stop`      | `string \| () => string`                  | —           | Custom stop command                            |
-| `cwd`       | `string`                                  | —           | Working directory for the service              |
-| `detached`  | `boolean`                                 | `false`     | Run pane-less (outside the tmux layout)        |
-| `docker`    | `DockerConfig`                            | —           | Docker Compose config (see docker reference)   |
-| `ready`     | `ReadyConfig`                             | —           | Ready detection (see ready reference)          |
-| `dependsOn` | `string[]`                                | —           | Services that must be ready first              |
-| `env`       | `EnvConfig`                               | —           | Environment variables                          |
-| `flags`     | `ServiceFlags`                            | —           | `{ start?: boolean, open?: boolean }`          |
-| `url`       | `string \| false \| (ctx) => string`      | auto-detect | URL for the service                            |
-| `raw`       | `boolean`                                 | `false`     | Bypass wrapper — show env vars inline in pane  |
-| `restart`   | `{ maxRetries?, backoff? }`               | —           | Restart policy with exponential backoff        |
-| `onReady`   | `() => void \| Promise<void>`             | —           | Hook: service reached ready state              |
-| `onStop`    | `() => void \| Promise<void>`             | —           | Hook: service stopped                          |
-| `onOutput`  | `(line: string) => void \| Promise<void>` | —           | Hook: new output line from tmux pane           |
-| `optional`  | `boolean \| () => Promise<boolean>`       | —           | Mark service as optional (skip if unavailable) |
+| Field       | Type                                      | Default     | Description                                                                                |
+| ----------- | ----------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `start`     | `string \| () => string`                  | —           | Long-running process command (server)                                                      |
+| `run`       | `string \| () => string`                  | —           | One-shot command                                                                           |
+| `stop`      | `string \| () => string`                  | —           | Custom stop command                                                                        |
+| `cwd`       | `string`                                  | —           | Working directory for the service                                                          |
+| `detached`  | `boolean`                                 | `false`     | Run pane-less (outside the tmux layout)                                                    |
+| `lazyPane`  | `boolean`                                 | _auto_      | Pane created on start, dropped on explicit stop (default `true` when `flags.start: false`) |
+| `docker`    | `DockerConfig`                            | —           | Docker Compose config (see docker reference)                                               |
+| `ready`     | `ReadyConfig`                             | —           | Ready detection (see ready reference)                                                      |
+| `dependsOn` | `string[]`                                | —           | Services that must be ready first                                                          |
+| `env`       | `EnvConfig`                               | —           | Environment variables                                                                      |
+| `flags`     | `ServiceFlags`                            | —           | `{ start?: boolean, open?: boolean }`                                                      |
+| `url`       | `string \| false \| (ctx) => string`      | auto-detect | URL for the service                                                                        |
+| `raw`       | `boolean`                                 | `false`     | Bypass wrapper — show env vars inline in pane                                              |
+| `restart`   | `{ maxRetries?, backoff? }`               | —           | Restart policy with exponential backoff                                                    |
+| `onReady`   | `() => void \| Promise<void>`             | —           | Hook: service reached ready state                                                          |
+| `onStop`    | `() => void \| Promise<void>`             | —           | Hook: service stopped                                                                      |
+| `onOutput`  | `(line: string) => void \| Promise<void>` | —           | Hook: new output line from tmux pane                                                       |
+| `optional`  | `boolean \| () => Promise<boolean>`       | —           | Mark service as optional (skip if unavailable)                                             |
 
 **Required**: Every service must have at least one of `start`, `run`, or `docker`.
 
@@ -64,6 +65,62 @@ services: {
   },
 }
 ```
+
+## Lazy Panes
+
+A lazy service's tmux pane only exists while the process is running:
+
+- Pane **created on start** at the exact declared layout position (insert);
+  pane **destroyed on explicit stop** (remove); survivors re-expand.
+- **Crash keeps the pane** (post-mortem output stays visible).
+- **Restart keeps the pane** (process replaced in place; restarting a
+  stopped pane-less lazy service re-creates the pane at the declared slot).
+- Service `logs` history is retained across the lazy stop, so
+  `zaps logs <name>` still returns prior output after the pane is gone.
+
+**Default rule:** `lazyPane` defaults to `true` for non-autostart services
+(`flags.start: false`) and `false` for autostart services. An explicit value
+always wins.
+
+**Group members and detached services are never lazy.** A docker-group
+member (a child expanded from `docker.service: [...]` with `expand`) and a
+`detached: true` service both resolve to `lazyPane: false` even when
+`flags.start: false` is set — the group's shared pane / pane-less detached
+behavior is unchanged. The boot-skip predicate only fires for own-pane
+services.
+
+```ts
+services: {
+  // Non-autostart → defaults to lazyPane:true (pane appears on first start)
+  mailpit: {
+    start: "mailpit",
+    flags: { start: false },
+    ready: { port: 8025 },
+  },
+
+  // Explicit opt-in lazy on an autostart service: boots paned, but a manual
+  // stop drops the pane (vs the non-lazy default of keeping it).
+  worker: {
+    start: "node worker.js",
+    lazyPane: true,
+  },
+
+  // Explicit opt-out: keep the legacy empty-reserved-pane-at-boot behavior.
+  legacyConsole: {
+    start: "tail -f /var/log/app.log",
+    flags: { start: false },
+    lazyPane: false,
+  },
+}
+```
+
+**Illegal combinations** (config load errors):
+
+- `lazyPane: true` + `detached: true` — a detached service has no pane.
+  Schema-level rejection.
+- `lazyPane: true` on a docker-group member (a child of `docker.service: [...]`
+  with `expand`) — group members share one pane, so per-member lazy is
+  ambiguous. Loader-level rejection after expansion.
 
 ## Flags
 

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -106,6 +106,14 @@ zaps --help # see all functions
 - **Detached services** (`detached: true`) and detached sessions (`zaps up -d`) run
   pane-less — there is no terminal to scroll. Read their output with
   `zaps logs <svc>` (`-f` to stream). Lifecycle (`start`/`stop`/`restart`) works normally.
+- **Lazy panes (non-autostart services).** A service with `flags.start: false`
+  (or explicit `lazyPane: true`) now boots **pane-less** — its tmux pane only
+  appears when you `zaps start <svc>` (or restart from stopped), at its
+  declared layout position; a `zaps stop <svc>` drops the pane and re-expands
+  survivors. Crash + restart keep the pane. `zaps logs <svc>` returns `[]`
+  before the first start, streams live while the service is running, and
+  returns the retained history after stop. To keep the legacy
+  idle-empty-reserved-pane behavior, set `lazyPane: false` on the service.
 - **Config reload** is validate-then-swap: an invalid edit is reported and the running
   session keeps the old config (it is never torn down). In the TUI, a changed config
   shows a `config changed — press c to reload` header hint; press `c` (when idle) to apply.

--- a/README.md
+++ b/README.md
@@ -300,26 +300,27 @@ service is mid-operation) to apply it.
 
 ### Options
 
-| Option          | Type                                        | Default | Description                                                                      |
-| --------------- | ------------------------------------------- | ------- | -------------------------------------------------------------------------------- |
-| `start`         | `string \| () => string`                    | —       | Command to start the service                                                     |
-| `run`           | `string \| () => string`                    | —       | Alias for `start`                                                                |
-| `stop`          | `string \| () => string`                    | —       | Custom stop command (default: Ctrl-C)                                            |
-| `docker`        | `DockerConfig`                              | —       | Docker Compose service config                                                    |
-| `ready`         | `ReadyConfig`                               | —       | How to detect the service is ready                                               |
-| `dependsOn`     | `string[]`                                  | `[]`    | Services that must be ready first                                                |
-| `env`           | `Record<string, string> \| (ctx) => Record` | —       | Environment variables                                                            |
-| `cwd`           | `string`                                    | —       | Working directory                                                                |
-| `url`           | `string \| (ctx) => string`                 | —       | URL for browser open (`o` key)                                                   |
-| `flags`         | `{ start?: boolean, open?: boolean }`       | —       | `start`: auto-start on launch (default `true`), `open`: auto-open URL when ready |
-| `detached`      | `boolean`                                   | `false` | Run outside tmux (no pane)                                                       |
-| `raw`           | `boolean`                                   | `false` | Bypass wrapper — show env vars inline in pane                                    |
-| `restart`       | `{ maxRetries?, backoff? }`                 | —       | Auto-restart on crash                                                            |
-| `onBeforeStart` | `() => void \| Promise<void>`               | —       | Callback before command is sent                                                  |
-| `onReady`       | `() => void \| Promise<void>`               | —       | Callback when service becomes ready                                              |
-| `onStop`        | `() => void \| Promise<void>`               | —       | Callback when service stops                                                      |
-| `onOutput`      | `(line: string) => void \| Promise<void>`   | —       | Called for each new output line                                                  |
-| `optional`      | `boolean \| () => Promise<boolean>`         | —       | Mark service as optional (see below)                                             |
+| Option          | Type                                        | Default | Description                                                                                   |
+| --------------- | ------------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `start`         | `string \| () => string`                    | —       | Command to start the service                                                                  |
+| `run`           | `string \| () => string`                    | —       | Alias for `start`                                                                             |
+| `stop`          | `string \| () => string`                    | —       | Custom stop command (default: Ctrl-C)                                                         |
+| `docker`        | `DockerConfig`                              | —       | Docker Compose service config                                                                 |
+| `ready`         | `ReadyConfig`                               | —       | How to detect the service is ready                                                            |
+| `dependsOn`     | `string[]`                                  | `[]`    | Services that must be ready first                                                             |
+| `env`           | `Record<string, string> \| (ctx) => Record` | —       | Environment variables                                                                         |
+| `cwd`           | `string`                                    | —       | Working directory                                                                             |
+| `url`           | `string \| (ctx) => string`                 | —       | URL for browser open (`o` key)                                                                |
+| `flags`         | `{ start?: boolean, open?: boolean }`       | —       | `start`: auto-start on launch (default `true`), `open`: auto-open URL when ready              |
+| `detached`      | `boolean`                                   | `false` | Run outside tmux (no pane)                                                                    |
+| `lazyPane`      | `boolean`                                   | _auto_  | Create the pane on start, drop it on explicit stop (default `true` when `flags.start: false`) |
+| `raw`           | `boolean`                                   | `false` | Bypass wrapper — show env vars inline in pane                                                 |
+| `restart`       | `{ maxRetries?, backoff? }`                 | —       | Auto-restart on crash                                                                         |
+| `onBeforeStart` | `() => void \| Promise<void>`               | —       | Callback before command is sent                                                               |
+| `onReady`       | `() => void \| Promise<void>`               | —       | Callback when service becomes ready                                                           |
+| `onStop`        | `() => void \| Promise<void>`               | —       | Callback when service stops                                                                   |
+| `onOutput`      | `(line: string) => void \| Promise<void>`   | —       | Called for each new output line                                                               |
+| `optional`      | `boolean \| () => Promise<boolean>`         | —       | Mark service as optional (see below)                                                          |
 
 ### Optional Services
 
@@ -389,6 +390,52 @@ services: {
   log buffer (`zaps logs worker`, `-f` to stream).
 - A detached service **must not** appear in `layout`, and cannot be combined with
   `docker` or `raw` (both need a pane) — these are config load errors.
+
+### Lazy Panes
+
+A **lazy** service is one whose tmux pane only exists while the process is
+running: the pane is created at its exact declared layout position when the
+service is started, and destroyed when the service is **explicitly** stopped.
+A crash keeps the pane (so you can inspect the post-mortem output); a restart
+keeps the pane (the process is replaced in place). The first manual start
+brings the pane in; the first manual stop takes it out.
+
+```typescript
+services: {
+  mailpit: {
+    start: "mailpit",
+    flags: { start: false }, // No autostart — opt-in via `s` / TUI / CLI.
+    ready: { port: 8025 },
+  },
+}
+```
+
+**Default rule:** `lazyPane: true` when the service is non-autostart
+(`flags.start: false`); `lazyPane: false` for autostart services. An explicit
+`lazyPane: true | false` always wins.
+
+**Docker groups and detached services are never lazy** — even when
+`flags.start: false` is set, a docker-group member keeps its shared group pane
+and a `detached: true` service stays pane-less. The boot-skip rule applies to
+own-pane services only, so the group/detached behavior is unchanged.
+
+`lazyPane` is the lifecycle counterpart to [`detached`](#detached-services):
+**detached** services are NEVER paned (no terminal at all), while **lazy**
+services are paned **on demand** (a real pane appears at start and disappears
+on explicit stop).
+
+**Illegal combinations** (config load errors):
+
+- `lazyPane: true` with `detached: true` — a detached service has no pane.
+- `lazyPane: true` on a docker-group member (a service expanded from
+  `docker.service: [...]` with `expand`) — group members share one pane, so
+  per-member lazy is ambiguous; apply `lazyPane` at the group level once
+  group-granularity lazy ships.
+
+**Migration note.** Before this version, every non-autostart service got an
+empty reserved tmux pane at boot. Non-autostart services now boot **pane-less**
+by default. To keep the old behavior (an idle empty pane reserved at boot),
+set `lazyPane: false` on the service.
 
 ### Ready Detection
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -235,6 +235,46 @@ function validateLazyPaneGroups(project: ProjectConfig): void {
 
 // Explicit task shortcuts colliding with a reserved key (q/j/k) are dropped by getTaskShortcuts.
 // Warn at load time so the user knows their requested key was ignored.
+/**
+ * Resolve every service's effective `lazyPane` boolean (P04-T02).
+ *
+ * Rule, guard-FIRST so the default never leaks `true` to a service that has no
+ * Own pane:
+ *
+ *   effective = (detached || _combined) ? false
+ *                                       : (svc.lazyPane ?? (flags.start === false))
+ *
+ * Autostart semantics mirror `manager.ts:419` exactly — `flags?.start !== false`
+ * Means "autostart", so the lazy default is `flags?.start === false`. We use the
+ * SAME interpretation here.
+ *
+ * P04-T01 catches the load error for an EXPLICIT `lazyPane: true` on a group
+ * Member or detached service, but does NOT stop the *default* rule from
+ * Computing `true` for a non-autostart member/detached service. The guard
+ * Closes that gap: every group member and detached service resolves to `false`
+ * Here unconditionally, so downstream consumers (manager boot-skip in P04-T03,
+ * InsertPane wiring in P04-T04) cannot misfire.
+ */
+function resolveLazyPanes(project: ProjectConfig): Map<string, boolean> {
+  const out = new Map<string, boolean>();
+  for (const [name, svc] of Object.entries(project.services)) {
+    // Guard first: no own pane → never lazy (Q5 + Round-6 risk closure).
+    // `_combined` is set by `expandDockerServices` (loader.ts:145) or absent;
+    // It is never explicitly `null`, so `!== undefined` is the right test.
+    if (svc.detached === true || svc._combined !== undefined) {
+      out.set(name, false);
+      continue;
+    }
+    if (svc.lazyPane !== undefined) {
+      out.set(name, svc.lazyPane);
+      continue;
+    }
+    // Default: non-autostart (`flags.start === false`) opts in to lazy.
+    out.set(name, svc.flags?.start === false);
+  }
+  return out;
+}
+
 function warnReservedTaskShortcuts(project: ProjectConfig): void {
   for (const [key, task] of Object.entries(project.tasks ?? {})) {
     if (task.shortcut && RESERVED_TASK_SHORTCUT_KEYS.has(task.shortcut)) {
@@ -560,6 +600,10 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
 
   validateSemantics(resolved, groups);
 
+  // Derived per-service `lazyPane` resolved ONCE — manager + createLayout read
+  // From this map instead of re-implementing the rule + guard.
+  const lazyPaneByService = resolveLazyPanes(resolved);
+
   return {
     project: resolved,
     configPath,
@@ -567,6 +611,7 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
     bindActions,
     groups,
     unavailableServices,
+    lazyPaneByService,
   };
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -215,6 +215,24 @@ function validateDetachedGroups(project: ProjectConfig): void {
   }
 }
 
+/**
+ * Reject `lazyPane: true` on a docker-group member (Q5 resolved: v1 load error;
+ * Group-granularity lazy is a follow-up). Group members share a pane, so a
+ * Per-member opt-out is ambiguous — does the whole group go lazy, or just the
+ * Member's slice? Punt by erroring; the user can add `lazyPane` to the wrapping
+ * Group once group-granularity lazy ships. Runs after expansion so the
+ * `_combined` meta carries the owning group name.
+ */
+function validateLazyPaneGroups(project: ProjectConfig): void {
+  for (const [name, svc] of Object.entries(project.services)) {
+    if (svc.lazyPane === true && svc._combined) {
+      throw new Error(
+        `Service '${name}': 'lazyPane: true' is not supported on members of combined group '${svc._combined.group}' (group-granularity lazy panes are a follow-up). Remove 'lazyPane' from this member, or apply it at the group level once that is supported.`,
+      );
+    }
+  }
+}
+
 // Explicit task shortcuts colliding with a reserved key (q/j/k) are dropped by getTaskShortcuts.
 // Warn at load time so the user knows their requested key was ignored.
 function warnReservedTaskShortcuts(project: ProjectConfig): void {
@@ -233,6 +251,7 @@ function validateSemantics(project: ProjectConfig, groups: Map<string, string[]>
   warnNonAutostartDeps(project);
   warnReservedTaskShortcuts(project);
   validateDetachedGroups(project);
+  validateLazyPaneGroups(project);
 
   // Validate task dependsOn refs
   if (project.tasks) {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -615,5 +615,25 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
   };
 }
 
+/**
+ * Boot-skip predicate (P04-T03): the set of service names that should NOT get
+ * A pane at session boot (or reload). A service skips iff it is lazy
+ * (loader-resolved `lazyPaneByService` is `true`) AND it won't autostart
+ * (`flags?.start === false`). Group members + detached services have
+ * `lazyPaneByService=false` enforced by P04-T02's guard, so they are never
+ * Skipped here — no group-pane desync. Used by both `buildSession` (boot)
+ * And `Session.rebuildLayout` (reload) so the boot-pane decision is identical
+ * Across the two paths.
+ */
+export function computeBootSkip(config: ResolvedConfig): Set<string> {
+  const skip = new Set<string>();
+  for (const [name, svc] of Object.entries(config.project.services)) {
+    if (config.lazyPaneByService.get(name) === true && svc.flags?.start === false) {
+      skip.add(name);
+    }
+  }
+  return skip;
+}
+
 /** @internal Exported for testing */
 export { collapseLayoutTree, resolveOptionalServices, stripUnavailableServices };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -94,6 +94,7 @@ const serviceConfigBaseSchema = z.object({
   run: z.optional(commandSchema),
   stop: z.optional(commandSchema),
   detached: z.optional(z.boolean()),
+  lazyPane: z.optional(z.boolean()),
   docker: z.optional(dockerConfigSchema),
   ready: z.optional(readyConfigSchema),
   dependsOn: z.optional(z.array(z.string())),
@@ -183,6 +184,26 @@ function dockerReadyIssues(name: string, svc: ServiceConfigInput): string[] {
   return [];
 }
 
+/**
+ * `lazyPane: true` services start pane-less and acquire their pane only on
+ * Explicit start (Flow B). `detached: true` services NEVER own a pane (they
+ * Run process-only) — the combination is contradictory, so reject as a load
+ * Error here. Docker-group-membership rejection lives in the loader where
+ * `_combined` expansion is known (P04-T01 NOTE in the task file).
+ */
+function lazyPaneIssues(name: string, svc: ServiceConfigInput): string[] {
+  if (svc.lazyPane !== true) {
+    return [];
+  }
+  const issues: string[] = [];
+  if (svc.detached) {
+    issues.push(
+      `Service '${name}': 'lazyPane: true' cannot be combined with 'detached: true' — a detached service has no pane.`,
+    );
+  }
+  return issues;
+}
+
 /** `optional: true` needs a string command so the binary-availability probe can run. */
 function optionalIssues(name: string, svc: ServiceConfigInput): string[] {
   if (svc.optional !== true) {
@@ -210,6 +231,7 @@ const servicesSchema = z.record(z.string(), serviceConfigBaseSchema).superRefine
   for (const [name, svc] of entries) {
     const issues = [
       ...detachedIssues(name, svc),
+      ...lazyPaneIssues(name, svc),
       ...baseCommandIssues(name, svc),
       ...dockerReadyIssues(name, svc),
       ...optionalIssues(name, svc),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -236,6 +236,21 @@ export interface ResolvedConfig {
   /** Maps group name → expanded child service names (from docker expand) */
   groups: Map<string, string[]>;
   unavailableServices: Map<string, UnavailableServiceInfo>;
+  /**
+   * Resolved per-service `lazyPane` boolean (P04-T02). Computed ONCE here so the
+   * Manager + `createLayout` never re-derive the rule. The exact rule, with the
+   * Group/detached guard applied FIRST:
+   *
+   *   (svc.detached || svc._combined != null) ? false
+   *                                           : (svc.lazyPane ?? (flags.start === false))
+   *
+   * Group members share a pane and detached services own no pane — `true` would
+   * Drive a spurious separate-pane insert (P04-T04) or a desynced boot-skip
+   * (P04-T03), so the guard forces `false` even if the user explicitly set
+   * `lazyPane: true` (the LOAD error for that case is P04-T01's job; this map
+   * Refuses to emit `true` in either situation).
+   */
+  lazyPaneByService: Map<string, boolean>;
 }
 
 // === Type Guards ===

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -83,6 +83,13 @@ export interface ServiceConfig {
   run?: Command;
   stop?: Command;
   detached?: boolean;
+  /**
+   * Opt out of getting a tmux pane at boot. The service starts pane-less and
+   * Receives its pane only when explicitly started (Flow B). Implementing the
+   * `applyDefaults` rule for this field is P04-T02; this is the type + schema
+   * Field only.
+   */
+  lazyPane?: boolean;
   docker?: DockerConfig;
   ready?: ReadyConfig;
   dependsOn?: string[];

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import net from "node:net";
 import { promisify } from "node:util";
 
-import { loadConfig } from "#src/config/loader.js";
+import { computeBootSkip, loadConfig } from "#src/config/loader.js";
 import { ipcErr, ipcOk } from "#src/lib/ipc/protocol.js";
 import type { IpcRequest, IpcResponse } from "#src/lib/ipc/protocol.js";
 import { checkPortPreflight } from "#src/lib/port-preflight.js";
@@ -176,12 +176,19 @@ class DaemonServer implements SessionStore {
     // Load config
     const config = await loadConfig(params.configPath, params.projectDir);
 
-    // Build pane layout
+    // Build pane layout. Boot-skip the pane for any service that is lazy
+    // (P04-T02 resolved `lazyPaneByService`) AND won't autostart
+    // (`flags?.start === false`). The guard-first resolution already forces
+    // `lazyPaneByService=false` for `_combined` members + detached, so the
+    // Skip predicate never fires for those — group/detached panes are built
+    // Exactly as before.
+    const skip = computeBootSkip(config);
     const { paneMap, focusPane } = await createLayout(
       params.originPane,
       config.project.layout,
       config.project.services,
       config.groups,
+      { skip },
     );
     // Splitting panes off @tui can leave its kernel pty winsize stale at the
     // Pre-split width, garbling the in-process TUI until a manual resize. Force

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -225,6 +225,24 @@ class DaemonServer implements SessionStore {
       },
       sessionId: id,
       zapsCommand: process.env.ZAPS_COMMAND ?? "zaps",
+      // Reflow hooks late-bind to the session (same ref pattern as
+      // `storeExecInfo`). They always invoke `session.reflowInsert/Remove`,
+      // Which wrap `withOpLock` around the LIVE-getter `Session.reflow`. After
+      // A reload, `ref.session` is the same Session instance but
+      // `session.paneMap`/`session.config` have been atomically swapped — the
+      // Reflow's live getters pick that up without any reconstruction here.
+      reflowInsert: async (name: string) => {
+        if (!ref.session) {
+          throw new Error("reflowInsert: session not yet wired");
+        }
+        await ref.session.reflowInsert(name);
+      },
+      reflowRemove: async (name: string) => {
+        if (!ref.session) {
+          throw new Error("reflowRemove: session not yet wired");
+        }
+        await ref.session.reflowRemove(name);
+      },
     };
 
     // Create ServiceManager

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import type net from "node:net";
 
 import type { TaskRunRecord } from "#src/components/TaskRunRecord.js";
-import { loadConfig } from "#src/config/loader.js";
+import { computeBootSkip, loadConfig } from "#src/config/loader.js";
 import type { ResolvedConfig, UiConfig } from "#src/config/types.js";
 import type { DaemonEvent } from "#src/lib/ipc/protocol.js";
 import type { ServiceManager, ServiceManagerDeps } from "#src/lib/service/manager.js";
@@ -397,12 +397,15 @@ export class Session {
    */
   private async rebuildLayout(tuiPaneId: string, newConfig: ResolvedConfig): Promise<PaneMap> {
     try {
+      // Reload uses the SAME boot-skip predicate as initial boot so a
+      // Non-running lazy service stays pane-less after a config edit.
+      const skip = computeBootSkip(newConfig);
       const { paneMap } = await createLayout(
         tuiPaneId,
         newConfig.project.layout,
         newConfig.project.services,
         newConfig.groups,
-        { reserveTuiPane: true },
+        { reserveTuiPane: true, skip },
       );
       return paneMap;
     } catch (error) {

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -11,6 +11,7 @@ import type { ExecInfo, ServiceStatus } from "#src/lib/service/types.js";
 import type { PaneRunInfo } from "#src/lib/task/run-in-pane.js";
 import { getTaskShortcuts } from "#src/lib/taskShortcuts.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
+import { LayoutReflow } from "#src/lib/tmux-reflow.js";
 import { killPane } from "#src/lib/tmux.js";
 
 import { LogBuffer } from "./log-buffer.js";
@@ -125,8 +126,28 @@ export class Session {
   public manager: ServiceManager;
   public logBuffers: Map<string, LogBuffer>;
   public logMonitor: LogMonitor;
-  /** Monitor key (pane id) → member service names sharing it; drives fan-out (D2). */
-  private paneMembers: Map<string, string[]>;
+  /**
+   * Monitor key (pane id) → shared `LogBuffer`. This is the SAME map instance the
+   * `LogMonitor` holds internally — `allocatePaneLog`/`freePaneLog` mutate it so
+   * the monitor's `start(key,…)` finds the new buffer by pane-id without any
+   * pipeline rebuild. Reassigned (not mutated) on reload, in lockstep with
+   * `logMonitor`/`logBuffers`/`paneMembers` (E14 invariant).
+   */
+  public paneBuffers: Map<string, LogBuffer>;
+  /**
+   * Monitor key (pane id) → member service names sharing it; drives fan-out (D2).
+   * Public for the same reason `paneBuffers` is: dynamic insert/remove mutates
+   * this map in lockstep with `paneBuffers`/`logBuffers`/`logMonitor`, and
+   * tests need to assert the lockstep without surfacing a side accessor.
+   */
+  public paneMembers: Map<string, string[]>;
+  /**
+   * Pre-built `LayoutReflow` whose deps are CLOSURES over `this`, so reload's
+   * reassignment of `config`/`paneMap`/`logMonitor`/log maps is visible without
+   * re-constructing the reflow. Insert/remove invocations from Phase 4 will
+   * call into this instance; the hooks below wire dynamic log allocation.
+   */
+  public readonly reflow: LayoutReflow;
   /** Tracked in-flight `startAll`; reload/destroy abort then await its settlement. */
   public startPromise: Promise<void> | null = null;
   /** Set once `destroy()` runs; guards the reload-after-destroy race (A5). */
@@ -160,7 +181,25 @@ export class Session {
     const pipeline = this.buildLogPipeline(this.config, this.paneMap);
     this.logBuffers = pipeline.buffers;
     this.logMonitor = pipeline.monitor;
+    this.paneBuffers = pipeline.paneBuffers;
     this.paneMembers = pipeline.paneMembers;
+
+    // Pre-build LayoutReflow with LIVE-getter deps. The closures dereference
+    // `this.config`/`this.paneMap`/etc. at call time, so a post-construction
+    // Reload that reassigns those fields is transparent to the reflow. Hooks
+    // Bind through `this` for the same reason — they re-read `this.logMonitor`
+    // And the log maps fresh on every fire, never closing over stale instances.
+    this.reflow = new LayoutReflow({
+      getLayout: () => this.config.project.layout,
+      getPaneMap: () => this.paneMap,
+      getWindowTarget: () => this.tmuxSession,
+      onPaneInserted: (name, paneId) => {
+        this.allocatePaneLog(name, paneId);
+      },
+      onPaneRemoved: (name, paneId) => {
+        this.freePaneLog(name, paneId);
+      },
+    });
 
     this.wireManagerEvents(manager);
   }
@@ -173,7 +212,12 @@ export class Session {
   private buildLogPipeline(
     config: ResolvedConfig,
     paneMap: PaneMap,
-  ): { buffers: Map<string, LogBuffer>; monitor: LogMonitor; paneMembers: Map<string, string[]> } {
+  ): {
+    buffers: Map<string, LogBuffer>;
+    monitor: LogMonitor;
+    paneBuffers: Map<string, LogBuffer>;
+    paneMembers: Map<string, string[]>;
+  } {
     const { buffers, paneBuffers, paneMembers } = allocateLogBuffers(config, paneMap);
     const monitor = new LogMonitor(
       { capturePane: this.deps.capturePane },
@@ -188,7 +232,7 @@ export class Session {
         }
       },
     );
-    return { buffers, monitor, paneMembers };
+    return { buffers, monitor, paneBuffers, paneMembers };
   }
 
   private wireManagerEvents(manager: ServiceManager): void {
@@ -403,6 +447,7 @@ export class Session {
     this.manager = newManager;
     this.logBuffers = pipeline.buffers;
     this.logMonitor = pipeline.monitor;
+    this.paneBuffers = pipeline.paneBuffers;
     this.paneMembers = pipeline.paneMembers;
 
     this.wireManagerEvents(newManager);
@@ -512,6 +557,67 @@ export class Session {
     } else {
       this.staleNotified = false;
     }
+  }
+
+  /**
+   * Re-point the service's pane-less private buffer to a pane-shared `LogBuffer`
+   * and start monitoring the new pane. Called by `LayoutReflow.insertPane` via
+   * the `onPaneInserted` hook, AFTER `paneMap[name]` is set.
+   *
+   * All map dereferences read `this.*` AT CALL TIME — reload reassigns the four
+   * log fields to fresh instances, and capturing any of them would silently
+   * leak inserts into the dead pipeline.
+   *
+   * Idempotent: re-invoking with the same `(name, paneId)` is a no-op (the
+   * monitor's `start` is already idempotent — `log-monitor.ts:36-38`). This
+   * matters because `insertPane`'s rollback runs AFTER the hook fires; a
+   * retry must not orphan the just-allocated buffer or duplicate membership.
+   */
+  public allocatePaneLog(name: string, paneId: string): void {
+    // Idempotent fast path: already wired to this exact pane with the same
+    // Pane-shared buffer → just ensure the monitor + membership invariants
+    // Without creating a new buffer (would orphan the previously-referenced
+    // One and break any consumer holding a reference).
+    const existingPaneBuf = this.paneBuffers.get(paneId);
+    if (existingPaneBuf && this.logBuffers.get(name) === existingPaneBuf) {
+      const members = this.paneMembers.get(paneId) ?? [];
+      if (!members.includes(name)) {
+        members.push(name);
+        this.paneMembers.set(paneId, members);
+      }
+      this.logMonitor.start(paneId, paneId);
+      return;
+    }
+
+    // Re-point: replace whatever buffer the service had (the pane-less private
+    // One from boot, or a stale entry) with a fresh pane-shared `LogBuffer`.
+    const buf = new LogBuffer();
+    this.logBuffers.set(name, buf);
+    this.paneBuffers.set(paneId, buf);
+    this.paneMembers.set(paneId, [name]);
+    this.logMonitor.start(paneId, paneId);
+  }
+
+  /**
+   * Stop the pane's monitor and drop the pane-keyed entries. Round 7 invariant:
+   * **`this.logBuffers[name]` is intentionally RETAINED** so the stopped lazy
+   * service still snapshots its history (matching every other stopped service)
+   * — deleting it would make `logs.snapshot(name)` throw `Unknown service`
+   * (`handlers/session.ts:578`) and drop the service from `attachSnapshot`
+   * (`session.ts:521`).
+   *
+   * Idempotent: re-calling with an already-freed `paneId` is a no-op (the
+   * monitor's `stop` is idempotent — `log-monitor.ts:105-114`); the
+   * `delete` returns false on missing keys.
+   *
+   * No unbounded growth: `paneBuffers`/`paneMembers` shrink in lockstep with
+   * `paneMap`, mirroring the `D6` invariant in `log-monitor.ts`.
+   */
+  public freePaneLog(_name: string, paneId: string): void {
+    this.logMonitor.stop(paneId);
+    this.paneBuffers.delete(paneId);
+    this.paneMembers.delete(paneId);
+    // NOTE: `this.logBuffers[name]` is RETAINED on purpose — see method docstring.
   }
 
   /**

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -199,6 +199,14 @@ export class Session {
       onPaneRemoved: (name, paneId) => {
         this.freePaneLog(name, paneId);
       },
+      onPaneInsertFailed: (name, paneId) => {
+        // Symmetric with `onPaneRemoved` — same freePaneLog cleanup. Closes the
+        // Round-7 buffer-leak path: after a failed insert (split succeeded but
+        // ApplyGeometry/select-pane threw), `paneBuffers[paneId]` + the running
+        // Monitor key would otherwise orphan when a retry with a NEW pane id
+        // Lands (idempotency only covers same-id retry).
+        this.freePaneLog(name, paneId);
+      },
     });
 
     this.wireManagerEvents(manager);

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -571,6 +571,27 @@ export class Session {
   }
 
   /**
+   * Public entry points for the manager's lazy-lifecycle wiring (P04-T04).
+   * Both insert and remove run under the SESSION op-lock, so they cannot race
+   * Each other or `_reload`. The op-lock is OUTERMOST: callers (manager
+   * `startService`/`stopService` wrappers) MUST call these BEFORE/AFTER any
+   * `withServiceLock`, NEVER while holding it — otherwise a concurrent manual
+   * Start + reload deadlocks (reload holds op-lock → blocks on service-lock;
+   * The other path holds service-lock → blocks on op-lock).
+   */
+  public async reflowInsert(name: string): Promise<void> {
+    await this.withOpLock(async () => {
+      await this.reflow.insertPane(name);
+    });
+  }
+
+  public async reflowRemove(name: string): Promise<void> {
+    await this.withOpLock(async () => {
+      await this.reflow.removePane(name);
+    });
+  }
+
+  /**
    * Re-point the service's pane-less private buffer to a pane-shared `LogBuffer`
    * and start monitoring the new pane. Called by `LayoutReflow.insertPane` via
    * the `onPaneInserted` hook, AFTER `paneMap[name]` is set.

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -583,8 +583,23 @@ export class ServiceManager extends EventEmitter {
     // Already-paned (e.g. autostart after first start, or explicit
     // `lazyPane: true` on an autostart service) and detached services bypass
     // The reflow entirely — non-lazy behavior is byte-identical to before.
+    // CRITICAL: skip reflowInsert during shutdown (reload/destroy). Same deadlock
+    // Class as the reflowRemove guard in `stopService` — a `onStop` hook is
+    // Allowed to call `lib.startService`/`lib.restartService` (config/builder.ts:49-53),
+    // And `onStop` fires during reload's stopAll loop. Without this guard:
+    //   Reload holds withOpLock → manager.stopAll → stopService(svc1) →
+    //   StopServiceInternal → onStop hook → lib.startService(svc2) →
+    //   Deps.reflowInsert(svc2) → Session.reflowInsert → withOpLock (not
+    //   Re-entrant) → chains AFTER the outer reload fn → permanent hang.
+    // Safe to skip during shutdown: services aren't meaningfully starting
+    // During stopAll, and `_reload` rebuilds the layout fresh via `createLayout
+    // + computeBootSkip` afterwards — any service that ends up running post-
+    // Reload gets its pane via the rebuild, not via a hook-driven reflowInsert
+    // Mid-stopAll. `startServiceInternal` will throw `Unknown service` on the
+    // Missing paneMap entry (existing contract); the hook's promise rejects,
+    // Which is preferable to deadlocking the whole reload.
     const isLazy = this.config.lazyPaneByService.get(name) === true;
-    if (isLazy && !this.paneMap[name]) {
+    if (!this.shuttingDown && isLazy && !this.paneMap[name]) {
       await this.deps.reflowInsert(name);
     }
     return this.withServiceLock(name, async () => this.startServiceInternal(name, satisfiedDeps));
@@ -1114,8 +1129,12 @@ export class ServiceManager extends EventEmitter {
     // Restart just as it is for start. A restart of an ALREADY-paned service
     // (the common "restart the running worker") sees `paneMap[name]` already
     // Set and skips this — preserving the existing pane id (P04-T04 Flow E).
+    // CRITICAL: same shuttingDown guard as `startService` — `onStop` hooks can
+    // Reach `lib.restartService` during reload's stopAll loop; without the
+    // Guard we'd re-enter withOpLock through reflowInsert and deadlock. See
+    // `startService` for the full chain.
     const isLazy = this.config.lazyPaneByService.get(name) === true;
-    if (isLazy && !this.paneMap[name]) {
+    if (!this.shuttingDown && isLazy && !this.paneMap[name]) {
       await this.deps.reflowInsert(name);
     }
     return this.withServiceLock(name, async () => this.restartServiceInternal(name));

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -938,8 +938,20 @@ export class ServiceManager extends EventEmitter {
     // (`handleCrash`) and restart (`restartServiceInternal`) intentionally
     // Skip it so the pane survives across a crash-restart loop.
     const result = await this.withServiceLock(name, async () => this.stopServiceInternal(name));
+    // CRITICAL: skip reflowRemove during shutdown (reload/destroy). The session
+    // Op-lock holds `_reload`/`destroy`, which calls `manager.stopAll()`, which
+    // Sets `this.shuttingDown = true` BEFORE iterating `stopAllServices`
+    // (manager.ts:496). Without this guard, every stopService inside that loop
+    // Would await `deps.reflowRemove` → `Session.reflowRemove` → `withOpLock`,
+    // Which is a promise-chain mutex and not re-entrant — the inner reflow
+    // Would chain AFTER the outer reload's `fn`, which is itself awaiting
+    // `stopAll` → permanent hang. Skipping is correct in addition to safe:
+    // `_reload` step 4 (session.ts:434-440) already kill-panes every non-`@tui`
+    // Pane before rebuilding the layout, so a reflowRemove here would be both
+    // Redundant and deadlock-prone. The manual stop path (no reload/destroy
+    // In flight) still runs reflowRemove as intended.
     const isLazy = this.config.lazyPaneByService.get(name) === true;
-    if (isLazy && this.paneMap[name] !== undefined) {
+    if (!this.shuttingDown && isLazy && this.paneMap[name] !== undefined) {
       await this.deps.reflowRemove(name);
     }
     return result;

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -571,6 +571,22 @@ export class ServiceManager extends EventEmitter {
     name: string,
     satisfiedDeps?: ReadonlySet<string>,
   ): Promise<ServiceActionResult> {
+    // Lazy-pane services start pane-less and acquire their pane on first
+    // Start (Flow B). MUST insert BEFORE `withServiceLock`:
+    //   1. `startServiceInternal` (manager.ts:577) throws `Unknown service`
+    //      If `paneMap[name]` is missing for a non-detached service, so the
+    //      Insert is REQUIRED before the lock-guarded body runs.
+    //   2. The reflow takes the SESSION op-lock; calling it INSIDE the per-
+    //      Service lock would invert the global lock order (`reload` already
+    //      Holds op-lock then takes service-lock via stopAll/startAll) and
+    //      Deadlock a concurrent manual start + reload (Round-4 trap).
+    // Already-paned (e.g. autostart after first start, or explicit
+    // `lazyPane: true` on an autostart service) and detached services bypass
+    // The reflow entirely — non-lazy behavior is byte-identical to before.
+    const isLazy = this.config.lazyPaneByService.get(name) === true;
+    if (isLazy && !this.paneMap[name]) {
+      await this.deps.reflowInsert(name);
+    }
     return this.withServiceLock(name, async () => this.startServiceInternal(name, satisfiedDeps));
   }
 
@@ -916,7 +932,17 @@ export class ServiceManager extends EventEmitter {
    * Stop a single service (serialized per service).
    */
   public async stopService(name: string): Promise<ServiceActionResult> {
-    return this.withServiceLock(name, async () => this.stopServiceInternal(name));
+    // Stop the process inside `withServiceLock` (state machine + side effects),
+    // Then drop the pane OUTSIDE the lock — same op-lock-outermost discipline
+    // As `startService`. This is the ONLY call site for `reflowRemove`; crash
+    // (`handleCrash`) and restart (`restartServiceInternal`) intentionally
+    // Skip it so the pane survives across a crash-restart loop.
+    const result = await this.withServiceLock(name, async () => this.stopServiceInternal(name));
+    const isLazy = this.config.lazyPaneByService.get(name) === true;
+    if (isLazy && this.paneMap[name] !== undefined) {
+      await this.deps.reflowRemove(name);
+    }
+    return result;
   }
 
   private async stopServiceInternal(name: string): Promise<ServiceActionResult> {
@@ -1514,6 +1540,16 @@ export interface ServiceManagerDeps {
   storeExecInfo: (service: string, info: ExecInfo) => void;
   sessionId: string;
   zapsCommand: string;
+  /**
+   * Lazy-pane reflow hooks (P04-T04). Both run under the SESSION op-lock so they
+   * Serialize against each other AND against `_reload` (no half-applied geometry
+   * Visible across a config edit). `startService` calls `reflowInsert` BEFORE
+   * Taking the per-service lock; `stopService` calls `reflowRemove` AFTER
+   * Releasing it. The op-lock-outermost discipline is what prevents the
+   * Round-4 deadlock (manual start + reload).
+   */
+  reflowInsert: (name: string) => Promise<void>;
+  reflowRemove: (name: string) => Promise<void>;
 }
 
 export { diffOutput };

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -1106,6 +1106,18 @@ export class ServiceManager extends EventEmitter {
    * Restart a single service (serialized per service).
    */
   public async restartService(name: string): Promise<void> {
+    // Same lazy-pane invariant as `startService`: if the service is pane-less +
+    // Lazy, ensure the pane exists BEFORE entering the lock-guarded body —
+    // `restartServiceInternal` eventually calls `startServiceInternal`, which
+    // Throws `Unknown service` on a missing pane. The OUTSIDE-the-lock
+    // Placement keeps op-lock-outermost: the Round-4 trap stays closed for
+    // Restart just as it is for start. A restart of an ALREADY-paned service
+    // (the common "restart the running worker") sees `paneMap[name]` already
+    // Set and skips this — preserving the existing pane id (P04-T04 Flow E).
+    const isLazy = this.config.lazyPaneByService.get(name) === true;
+    if (isLazy && !this.paneMap[name]) {
+      await this.deps.reflowInsert(name);
+    }
     return this.withServiceLock(name, async () => this.restartServiceInternal(name));
   }
 

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -704,3 +704,34 @@ export function resolvePermutation(current: string[], target: string[]): [string
   }
   return swaps;
 }
+
+/**
+ * Where to split so a newly-inserted pane lands at its target spatial slot with
+ * zero swaps. `tree` is the TARGET filtered tree (the visible set *including* the
+ * pane being inserted); `name` is the inserted pane. Using the tree's DFS leaf
+ * order: a pane at slot `k > 0` splits *after* the leaf at `k − 1`
+ * (`split-window` default), and a pane at slot `0` splits *before* the next leaf
+ * (`split-window -b`). tmux gives the new pane the adjacent `pane_index`, so the
+ * spatial order already matches the target and no `swap-pane` is needed.
+ *
+ * Throws if `name` is not a leaf in `tree`, or if it is the only leaf (no
+ * neighbor to anchor against — `@tui` is always visible, so this should not
+ * happen in practice).
+ */
+export function splitAnchor(
+  tree: LayoutNode,
+  name: string,
+): { mode: "after"; predecessor: string } | { mode: "before"; successor: string } {
+  const leaves = collectPaneNames(tree);
+  const k = leaves.indexOf(name);
+  if (k === -1) {
+    throw new Error(`splitAnchor: pane '${name}' is not a leaf in the target tree`);
+  }
+  if (leaves.length < 2) {
+    throw new Error(`splitAnchor: pane '${name}' is the only leaf; no neighbor to anchor against`);
+  }
+  if (k > 0) {
+    return { mode: "after", predecessor: leaves[k - 1] };
+  }
+  return { mode: "before", successor: leaves[1] };
+}

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -212,6 +212,150 @@ function withSize(node: LayoutNode, size: string | undefined): LayoutNode {
   return split;
 }
 
+/** Absolute tmux cell rectangle of a single pane (declared here, exported below). */
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Thrown by `computeRects` when a pane's computed extent drops below 1 cell, so
+ * an invalid geometry is never serialized into a `select-layout` string. Carries
+ * the offending pane name and a stable `code` for callers to branch on.
+ */
+class PaneTooSmallError extends Error {
+  public readonly code = "PANE_TOO_SMALL" as const;
+  public readonly pane: string;
+
+  public constructor(pane: string, dimension: "width" | "height", value: number) {
+    super(`Layout pane '${pane}' computes ${dimension} ${value}; minimum is 1 cell`);
+    this.name = "PaneTooSmallError";
+    this.pane = pane;
+  }
+}
+
+/**
+ * Per-child proportional weight, reusing the createLayout/validateLayoutSizes
+ * size math: explicit-size children weigh their percent, implicit children each
+ * weigh an equal share of the remainder. The weights are normalized against
+ * their own sum in `distributeExtents`, which rescales surviving proportions to
+ * fill the available extent (so a filtered split whose survivors no longer sum
+ * to 100 still fills the parent without a gap).
+ */
+function childWeights(children: LayoutNode[]): number[] {
+  const explicitTotal = children.reduce(
+    (sum, child) => sum + (child.size ? Number.parseInt(child.size, 10) : 0),
+    0,
+  );
+  const implicitCount = children.filter((child) => !child.size).length;
+  const implicitSize = implicitCount > 0 ? Math.floor((100 - explicitTotal) / implicitCount) : 0;
+  return children.map((child) => (child.size ? Number.parseInt(child.size, 10) : implicitSize));
+}
+
+/**
+ * Split `parentExtent` cells among `children` along one axis, charging a 1-cell
+ * divider per boundary. The children share `content = parentExtent − (n − 1)`
+ * cells, distributed by cumulative-boundary rounding of their normalized
+ * weights: boundary_i = round(content · Σweights≤i / Σweights), each child's
+ * extent is the gap between successive boundaries. This matches tmux's own
+ * division (an 80-col 2-way split yields 40|39, the first child taking the
+ * rounded-up half), guarantees `Σextents === content` exactly (the last child
+ * absorbs the residual), and rescales survivors to fill after a filter drop.
+ */
+/**
+ * Cumulative boundary cell after child `i` (1-based count `i + 1`). The last
+ * child's boundary is pinned to `content` so the extents always sum exactly;
+ * earlier boundaries round the normalized cumulative weight, with an even-split
+ * fallback for the degenerate all-zero-weight case.
+ */
+function cumulativeBoundary(
+  i: number,
+  n: number,
+  content: number,
+  cumulativeWeight: number,
+  totalWeight: number,
+): number {
+  if (i === n - 1) {
+    return content;
+  }
+  if (totalWeight > 0) {
+    return Math.round((content * cumulativeWeight) / totalWeight);
+  }
+  return Math.round((content * (i + 1)) / n);
+}
+
+function distributeExtents(children: LayoutNode[], parentExtent: number): number[] {
+  const n = children.length;
+  const weights = childWeights(children);
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  const content = parentExtent - (n - 1);
+
+  const extents: number[] = [];
+  let previousBoundary = 0;
+  let cumulativeWeight = 0;
+  for (let i = 0; i < n; i += 1) {
+    cumulativeWeight += weights[i];
+    const boundary = cumulativeBoundary(i, n, content, cumulativeWeight, totalWeight);
+    extents.push(boundary - previousBoundary);
+    previousBoundary = boundary;
+  }
+  return extents;
+}
+
+/**
+ * Recursively place `node` into the absolute rectangle (`x`, `y`, `width`,
+ * `height`), writing each leaf's `Rect` into `out`. Columns splits divide width
+ * (children share full height), rows splits divide height; each child after the
+ * first starts one divider cell past its predecessor. Throws `PaneTooSmallError`
+ * the moment any extent drops below 1 cell.
+ */
+function fillRects(
+  node: LayoutNode,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  out: Map<string, Rect>,
+): void {
+  if (isLayoutLeaf(node)) {
+    if (width < 1) {
+      throw new PaneTooSmallError(node.pane, "width", width);
+    }
+    if (height < 1) {
+      throw new PaneTooSmallError(node.pane, "height", height);
+    }
+    out.set(node.pane, { x, y, width, height });
+    return;
+  }
+
+  if (isLayoutSplit(node)) {
+    const { children, direction } = node;
+    const isColumns = direction === "columns";
+    const axisExtent = isColumns ? width : height;
+    const extents = distributeExtents(children, axisExtent);
+
+    let offset = isColumns ? x : y;
+    for (let i = 0; i < children.length; i += 1) {
+      const extent = extents[i];
+      if (extent < 1) {
+        throw new PaneTooSmallError(
+          firstLeafName(children[i]) ?? "?",
+          isColumns ? "width" : "height",
+          extent,
+        );
+      }
+      if (isColumns) {
+        fillRects(children[i], offset, y, extent, height, out);
+      } else {
+        fillRects(children[i], x, offset, width, extent, out);
+      }
+      offset += extent + 1; // +1 cell for the divider after this child
+    }
+  }
+}
+
 /**
  * Validate split sizes before any tmux call (E15). Per split: explicit sizes
  * must sum to < 100, or ≤ 100 only when the split has no implicit-size siblings;
@@ -422,4 +566,25 @@ export function filterTree(
   }
 
   return undefined;
+}
+
+export type { Rect };
+export { PaneTooSmallError };
+
+/**
+ * Convert a (filtered) proportional layout tree into absolute tmux cell
+ * rectangles per pane name, exactly honoring tmux's geometry rules so the result
+ * can be serialized into a `select-layout` string tmux accepts without
+ * normalization. `width`/`height` are the tmux window dimensions.
+ *
+ * Each split charges a 1-cell divider per boundary (`Σ child extents + (n − 1)
+ * === parent extent` on the split axis; cross-axis matches the parent), the last
+ * child absorbs the integer-division residual, and surviving proportions are
+ * rescaled to fill the extent. Throws `PaneTooSmallError` (naming the pane) if
+ * any pane would be smaller than 1 cell.
+ */
+export function computeRects(tree: LayoutNode, width: number, height: number): Map<string, Rect> {
+  const rects = new Map<string, Rect>();
+  fillRects(tree, 0, 0, width, height, rects);
+  return rects;
 }

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -1,4 +1,4 @@
-import type { LayoutNode, ServiceConfig } from "#src/config/types.js";
+import type { LayoutLeaf, LayoutNode, LayoutSplit, ServiceConfig } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
 import { killPane, splitPane } from "./tmux.js";
@@ -189,6 +189,30 @@ function reserveStartPaneForTui(layout: LayoutNode, startPaneId: string, paneMap
 }
 
 /**
+ * Shallow-clone `node`, replacing its `size` with `size` (omitted when undefined).
+ * Used when collapsing a single-child split: the lone survivor takes over the
+ * split's slot, so it must inherit the split's size — its own size was relative
+ * to the now-gone split and is no longer meaningful.
+ */
+function withSize(node: LayoutNode, size: string | undefined): LayoutNode {
+  if (isLayoutLeaf(node)) {
+    const leaf: LayoutLeaf = { pane: node.pane };
+    if (size !== undefined) {
+      leaf.size = size;
+    }
+    if (node.focus !== undefined) {
+      leaf.focus = node.focus;
+    }
+    return leaf;
+  }
+  const split: LayoutSplit = { direction: node.direction, children: node.children };
+  if (size !== undefined) {
+    split.size = size;
+  }
+  return split;
+}
+
+/**
  * Validate split sizes before any tmux call (E15). Per split: explicit sizes
  * must sum to < 100, or ≤ 100 only when the split has no implicit-size siblings;
  * and every computed tmux split percent must be ≥ 1. Violations are config
@@ -346,4 +370,56 @@ export async function createLayout(
     }
     throw error;
   }
+}
+
+/**
+ * Filter a declared layout tree down to the currently-visible panes.
+ *
+ * Returns a NEW tree (no input mutation) where:
+ * - leaves whose `pane` is not in `visible` are dropped;
+ * - a split that ends up with one child is collapsed into that child
+ *   (recursively), with the child inheriting the split's slot size;
+ * - a split that ends up with zero visible children returns `undefined`.
+ *
+ * Surviving siblings keep their declared sizes: explicit-size survivors keep
+ * their percent and implicit survivors share the remainder. Because removal can
+ * only lower a split's explicit total, the result never has explicit sizes ≥ 100
+ * alongside implicit siblings — so it is always valid input to `computeRects`,
+ * which normalizes the surviving proportions against the available extent
+ * (e.g. dropping one of two all-explicit survivors leaves the geometry pass to
+ * rescale them). Redistribution math is intentionally NOT duplicated here.
+ */
+export function filterTree(
+  node: LayoutNode | undefined,
+  visible: Set<string>,
+): LayoutNode | undefined {
+  if (!node) {
+    return undefined;
+  }
+
+  if (isLayoutLeaf(node)) {
+    return visible.has(node.pane) ? { ...node } : undefined;
+  }
+
+  if (isLayoutSplit(node)) {
+    const children = node.children
+      .map((child) => filterTree(child, visible))
+      .filter((child): child is LayoutNode => child !== undefined);
+
+    if (children.length === 0) {
+      return undefined;
+    }
+    if (children.length === 1) {
+      // Collapse: the lone survivor takes over this split's slot.
+      return withSize(children[0], node.size);
+    }
+
+    const split: LayoutSplit = { direction: node.direction, children };
+    if (node.size !== undefined) {
+      split.size = node.size;
+    }
+    return split;
+  }
+
+  return undefined;
 }

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -31,6 +31,24 @@ function firstLeafName(node: LayoutNode): string | undefined {
   return undefined;
 }
 
+/**
+ * Per-child proportional weight, reusing the createLayout/validateLayoutSizes
+ * size math: explicit-size children weigh their percent, implicit children each
+ * weigh an equal share of the remainder. The weights are normalized against
+ * their own sum in `distributeExtents` (reflow) and against the running parent
+ * remainder in `walkLayout` (boot), so a filtered split whose survivors no
+ * longer sum to 100 still fills the parent without a gap.
+ */
+function childWeights(children: LayoutNode[]): number[] {
+  const explicitTotal = children.reduce(
+    (sum, child) => sum + (child.size ? Number.parseInt(child.size, 10) : 0),
+    0,
+  );
+  const implicitCount = children.filter((child) => !child.size).length;
+  const implicitSize = implicitCount > 0 ? Math.floor((100 - explicitTotal) / implicitCount) : 0;
+  return children.map((child) => (child.size ? Number.parseInt(child.size, 10) : implicitSize));
+}
+
 async function walkLayout(
   node: LayoutNode,
   currentPaneId: string,
@@ -46,29 +64,33 @@ async function walkLayout(
     const { children, direction } = node;
     const dir = direction === "rows" ? "v" : "h";
 
-    // Parse sizes: explicit sizes kept, implicit get equal share of remainder
-    const explicitTotal = children.reduce(
-      (sum, child) => sum + (child.size ? Number.parseInt(child.size, 10) : 0),
-      0,
-    );
-    const implicitCount = children.filter((child) => !child.size).length;
-    const implicitSize = implicitCount > 0 ? Math.floor((100 - explicitTotal) / implicitCount) : 0;
-
-    const sizes = children.map((child) =>
-      child.size ? Number.parseInt(child.size, 10) : implicitSize,
-    );
+    // Per-child weights — explicit sizes kept, implicit get equal share of the
+    // Remainder, exactly the math `computeRects` uses on the reflow path. The
+    // Sum is treated as 100% of the parent: when survivors of a `filterTree`
+    // Drop no longer sum to 100 (e.g. `[40, 20]` after lazy siblings vanish),
+    // Normalizing against `totalWeight` rescales them proportionally instead of
+    // Handing the missing share to the last survivor. See `childWeights` + the
+    // `cumulativeBoundary` math in `distributeExtents` for the canonical
+    // Form — `walkLayout` mirrors it in tmux split-percent space because the
+    // Boot path drives `split-window -p N` instead of `select-layout`.
+    const weights = childWeights(children);
+    const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
 
     // First child inherits the current pane
     const paneIds: string[] = [currentPaneId];
 
     // Children 2..N: split from the *previous* pane so tmux inserts each
-    // New pane after its predecessor, preserving the declared order.
+    // New pane after its predecessor, preserving the declared order. `parentRemaining`
+    // Starts at `totalWeight` (not a hard-coded 100) so the percents are derived
+    // From the actual survivor weights — the all-100 case is byte-identical to the
+    // Old behavior; the < 100 case now redistributes proportionally.
     let splitTarget = currentPaneId;
-    let parentRemaining = 100;
+    let parentRemaining = totalWeight;
 
     for (let i = 1; i < children.length; i += 1) {
-      const childRemaining = parentRemaining - sizes[i - 1];
-      const tmuxPercent = Math.round((childRemaining / parentRemaining) * 100);
+      const childRemaining = parentRemaining - weights[i - 1];
+      const tmuxPercent =
+        parentRemaining > 0 ? Math.round((childRemaining / parentRemaining) * 100) : 0;
 
       const newPaneId = await splitPane(splitTarget, dir, { percent: tmuxPercent });
       createdPanes.push(newPaneId);
@@ -234,24 +256,6 @@ class PaneTooSmallError extends Error {
     this.name = "PaneTooSmallError";
     this.pane = pane;
   }
-}
-
-/**
- * Per-child proportional weight, reusing the createLayout/validateLayoutSizes
- * size math: explicit-size children weigh their percent, implicit children each
- * weigh an equal share of the remainder. The weights are normalized against
- * their own sum in `distributeExtents`, which rescales surviving proportions to
- * fill the available extent (so a filtered split whose survivors no longer sum
- * to 100 still fills the parent without a gap).
- */
-function childWeights(children: LayoutNode[]): number[] {
-  const explicitTotal = children.reduce(
-    (sum, child) => sum + (child.size ? Number.parseInt(child.size, 10) : 0),
-    0,
-  );
-  const implicitCount = children.filter((child) => !child.size).length;
-  const implicitSize = implicitCount > 0 ? Math.floor((100 - explicitTotal) / implicitCount) : 0;
-  return children.map((child) => (child.size ? Number.parseInt(child.size, 10) : implicitSize));
 }
 
 /**

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -667,3 +667,40 @@ export function layoutString(
   const { body } = serializeNode(tree, rects, paneNumbers);
   return `${checksum(body)},${body}`;
 }
+
+/**
+ * Resolve the swap pairs that turn `current` spatial pane order into `target` DFS
+ * order via selection sort: for each slot `i`, if `current[i]` is wrong, swap in
+ * the pane that belongs there and emit the pair `[current[i], target[i]]`. Each
+ * pair maps 1:1 to a `swap-pane -s <from> -t <to>` call (positions swap, both
+ * processes stay attached). Returns `[]` when already in order.
+ *
+ * This is the reorder *fallback* — the primary insert path is a zero-swap
+ * adjacency split. `current` and `target` must be permutations of the same
+ * multiset of pane ids; a mismatch is a programmer error and throws.
+ */
+export function resolvePermutation(current: string[], target: string[]): [string, string][] {
+  const sortedCurrent = [...current].toSorted();
+  const sortedTarget = [...target].toSorted();
+  if (
+    sortedCurrent.length !== sortedTarget.length ||
+    sortedCurrent.some((value, i) => value !== sortedTarget[i])
+  ) {
+    throw new Error(
+      `resolvePermutation: current [${current.join(", ")}] and target [${target.join(", ")}] are not permutations of the same set`,
+    );
+  }
+
+  const work = [...current];
+  const swaps: [string, string][] = [];
+  for (let i = 0; i < work.length; i += 1) {
+    if (work[i] === target[i]) {
+      continue;
+    }
+    // The pane that belongs at slot i currently sits later in `work`.
+    const j = work.indexOf(target[i], i + 1);
+    swaps.push([work[i], target[i]]);
+    [work[i], work[j]] = [work[j], work[i]];
+  }
+  return swaps;
+}

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -498,11 +498,19 @@ export async function createLayout(
   layout: LayoutNode | undefined,
   services: Record<string, ServiceConfig>,
   groups?: Map<string, string[]>,
-  options?: { reserveTuiPane?: boolean },
+  options?: { reserveTuiPane?: boolean; skip?: Set<string> },
 ): Promise<{ paneMap: PaneMap; focusPane: string }> {
   const reserveTuiPane = options?.reserveTuiPane ?? false;
+  const skip = options?.skip;
+  const hasSkip = skip !== undefined && skip.size > 0;
   const paneMap: PaneMap = {};
-  const serviceNames = Object.keys(services);
+  // Pane-less lazy services don't get a leftover-pane split. `skip` is pre-
+  // Resolved by the loader (P04-T02 lazyPaneByService) AND the autostart guard
+  // (`flags?.start === false`). Group members + detached are guaranteed absent
+  // From `skip` by P04-T02's guard-first rule, so no group-pane desync here.
+  const serviceNames = hasSkip
+    ? Object.keys(services).filter((n) => !skip.has(n))
+    : Object.keys(services);
   const groupChildNames = collectGroupChildNames(groups);
   const createdPanes: string[] = [];
 
@@ -524,11 +532,32 @@ export async function createLayout(
       return { paneMap, focusPane: paneMap["@tui"] };
     }
 
-    // Case 2: Layout tree provided.
-    const focusName = await walkLayout(layout, startPaneId, paneMap, createdPanes);
+    // Case 2: Layout tree provided. When a skip set is in play, filter the tree
+    // To the boot-visible leaf set BEFORE walking. The SAME filtered tree must
+    // Feed both `walkLayout` and `reserveStartPaneForTui` — otherwise
+    // FirstLeafName on the raw layout could disagree with the leaf walkLayout
+    // Actually mapped, mislabeling `@tui` on the reload path (Round-5 sharp edge).
+    let bootLayout: LayoutNode | undefined = layout;
+    if (hasSkip) {
+      const visible = new Set<string>();
+      for (const name of collectPaneNames(layout)) {
+        if (!skip.has(name)) {
+          visible.add(name);
+        }
+      }
+      // eslint-disable-next-line no-use-before-define -- `filterTree` is a top-level function declaration (hoisted); keeping it next to other exports
+      bootLayout = filterTree(layout, visible);
+    }
+    if (!bootLayout) {
+      throw new Error(
+        "createLayout: every layout leaf is skipped (the @tui slot must always be visible)",
+      );
+    }
+
+    const focusName = await walkLayout(bootLayout, startPaneId, paneMap, createdPanes);
 
     if (reserveTuiPane) {
-      reserveStartPaneForTui(layout, startPaneId, paneMap);
+      reserveStartPaneForTui(bootLayout, startPaneId, paneMap);
     }
 
     if (groups) {

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -357,6 +357,50 @@ function fillRects(
 }
 
 /**
+ * Bounding rectangle of a set of child rects. For a layout split the children
+ * plus their dividers fill the parent exactly, so the union equals the split's
+ * own rect — which is what the tmux layout grammar prints before its `{}`/`[]`.
+ */
+function unionRect(rects: Rect[]): Rect {
+  const x = Math.min(...rects.map((rect) => rect.x));
+  const y = Math.min(...rects.map((rect) => rect.y));
+  const right = Math.max(...rects.map((rect) => rect.x + rect.width));
+  const bottom = Math.max(...rects.map((rect) => rect.y + rect.height));
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+/**
+ * Recursively serialize a node to its tmux layout body and bounding rect. A leaf
+ * prints `WxH,X,Y,<paneNumber>`; a split prints its own `WxH,X,Y` followed by its
+ * children wrapped in `{...}` (columns) or `[...]` (rows), comma-separated in DFS
+ * order. Throws if a leaf has no computed rect or no pane number.
+ */
+function serializeNode(
+  node: LayoutNode,
+  rects: Map<string, Rect>,
+  paneNumbers: Map<string, number>,
+): { rect: Rect; body: string } {
+  if (isLayoutLeaf(node)) {
+    const rect = rects.get(node.pane);
+    if (!rect) {
+      throw new Error(`layoutString: no rect computed for pane '${node.pane}'`);
+    }
+    const paneNumber = paneNumbers.get(node.pane);
+    if (paneNumber === undefined) {
+      throw new Error(`layoutString: no pane number for pane '${node.pane}'`);
+    }
+    return { rect, body: `${rect.width}x${rect.height},${rect.x},${rect.y},${paneNumber}` };
+  }
+
+  const childResults = node.children.map((child) => serializeNode(child, rects, paneNumbers));
+  const rect = unionRect(childResults.map((result) => result.rect));
+  const open = node.direction === "columns" ? "{" : "[";
+  const close = node.direction === "columns" ? "}" : "]";
+  const inner = childResults.map((result) => result.body).join(",");
+  return { rect, body: `${rect.width}x${rect.height},${rect.x},${rect.y}${open}${inner}${close}` };
+}
+
+/**
  * Validate split sizes before any tmux call (E15). Per split: explicit sizes
  * must sum to < 100, or ≤ 100 only when the split has no implicit-size siblings;
  * and every computed tmux split percent must be ≥ 1. Violations are config
@@ -587,4 +631,39 @@ export function computeRects(tree: LayoutNode, width: number, height: number): M
   const rects = new Map<string, Rect>();
   fillRects(tree, 0, 0, width, height, rects);
   return rects;
+}
+
+/**
+ * Tmux's layout checksum over the layout body (verified character-identical to
+ * tmux `layout-custom.c` against a live `#{window_layout}` string). Returns a
+ * lowercase, zero-padded 4-hex-digit string. `select-layout` rejects a layout
+ * string whose checksum prefix does not equal this for the body.
+ */
+export function checksum(body: string): string {
+  // 65_535 === 0xFFFF — a 16-bit mask (decimal avoids the oxfmt/oxlint hex-case conflict).
+  /* eslint-disable no-bitwise -- tmux's checksum is defined in terms of bit ops; must match byte-for-byte */
+  let c = 0;
+  for (const ch of body) {
+    c = ((c >> 1) + ((c & 1) << 15)) & 65_535;
+    c = (c + ch.charCodeAt(0)) & 65_535;
+  }
+  return c.toString(16).padStart(4, "0");
+  /* eslint-enable no-bitwise */
+}
+
+/**
+ * Serialize a layout tree + computed rects + pane numbers into the exact
+ * `<checksum>,<body>` string tmux's `select-layout` accepts. The body encodes the
+ * cell tree in tmux grammar — leaves as `WxH,X,Y,<paneNumber>`, columns splits
+ * wrapped in `{...}`, rows splits in `[...]`, DFS order; a single-pane tree emits
+ * a bare leaf cell with no braces. `rects` must come from `computeRects` for the
+ * same tree so the divider geometry matches tmux byte-for-byte.
+ */
+export function layoutString(
+  tree: LayoutNode,
+  rects: Map<string, Rect>,
+  paneNumbers: Map<string, number>,
+): string {
+  const { body } = serializeNode(tree, rects, paneNumbers);
+  return `${checksum(body)},${body}`;
 }

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -70,7 +70,7 @@ async function walkLayout(
       const childRemaining = parentRemaining - sizes[i - 1];
       const tmuxPercent = Math.round((childRemaining / parentRemaining) * 100);
 
-      const newPaneId = await splitPane(splitTarget, dir, tmuxPercent);
+      const newPaneId = await splitPane(splitTarget, dir, { percent: tmuxPercent });
       createdPanes.push(newPaneId);
       paneIds.push(newPaneId);
       splitTarget = newPaneId;

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -1,14 +1,24 @@
-import type { LayoutNode } from "#src/config/types.js";
+import type { LayoutLeaf, LayoutNode } from "#src/config/types.js";
+import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
-import { computeRects, filterTree, layoutString, resolvePermutation } from "./tmux-layout.js";
+import {
+  computeRects,
+  filterTree,
+  layoutString,
+  resolvePermutation,
+  splitAnchor,
+} from "./tmux-layout.js";
 import type { Rect } from "./tmux-layout.js";
 import {
   getWindowSize as defaultGetWindowSize,
   paneIndexOrder as defaultPaneIndexOrder,
   resyncPaneSizes as defaultResyncPaneSizes,
   selectLayout as defaultSelectLayout,
+  selectPane as defaultSelectPane,
+  splitPane as defaultSplitPane,
   swapPanes as defaultSwapPanes,
 } from "./tmux.js";
+import type { SplitPaneOptions } from "./tmux.js";
 
 /** Map from pane/service name → tmux pane id (e.g. `"%17"`). */
 type PaneMap = Record<string, string>;
@@ -38,6 +48,27 @@ interface LayoutReflowDeps {
   selectLayout?: (target: string, layout: string) => Promise<void>;
   /** Fallback resync (no-op by default); the reflow only calls it when explicitly enabled. */
   resyncPaneSizes?: (target: string) => Promise<void>;
+  /** Create a new pane by splitting an existing one; returns the new pane id (`%N`). */
+  splitPane?: (target: string, direction: "h" | "v", options?: SplitPaneOptions) => Promise<string>;
+  /** Move tmux's active pane to `target`. Used for conditional focus after insert. */
+  selectPane?: (target: string) => Promise<void>;
+  /**
+   * Session-provided hook fired AFTER `paneMap[name]` is set during `insertPane`.
+   * The session uses this to allocate the log buffer, register the pane in the
+   * shared-buffer map, and start the pane monitor (the Round-7 buffer invariant
+   * — pre-start writes go to a private buffer; the hook re-points it to the
+   * pane-shared buffer so monitor output isn't lost). Optional: when absent
+   * (unit tests, headless harnesses), insertPane completes the geometry work
+   * without any log-buffer side-effects.
+   */
+  onPaneInserted?: (name: string, paneId: string) => void;
+  /**
+   * Session-provided hook fired AFTER `removePane` kills the tmux pane and deletes
+   * `paneMap[name]`. P03-T02 wires the real impl (stop monitor, fold buffer); the
+   * field is declared here so P03-T01's deps interface is the same one P03-T02
+   * extends — both methods share one constructor surface.
+   */
+  onPaneRemoved?: (name: string, paneId: string) => void;
 }
 
 /** DFS leaf order of `tree`. Mirrors `collectPaneNames` in tmux-layout.ts. */
@@ -71,6 +102,57 @@ function arraysEqual<T>(a: T[], b: T[]): boolean {
     return false;
   }
   return a.every((value, i) => value === b[i]);
+}
+
+/**
+ * Locate the layout leaf with `pane === name` anywhere in `tree`. Returns the
+ * declared leaf (so callers can read `focus`/`size`) or `undefined` when the
+ * name isn't in the layout — both insert and the `focus` check need this.
+ */
+function findLeaf(tree: LayoutNode, name: string): LayoutLeaf | undefined {
+  if (isLayoutLeaf(tree)) {
+    return tree.pane === name ? tree : undefined;
+  }
+  if (isLayoutSplit(tree)) {
+    for (const child of tree.children) {
+      const hit = findLeaf(child, name);
+      if (hit) {
+        return hit;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The split direction of the leaf's PARENT in the filtered target tree —
+ * `"h"` for a columns parent (left/right split), `"v"` for a rows parent
+ * (top/bottom). Determines which axis `split-window` should split along so
+ * the new pane lands on the right side of the boundary and the transient
+ * pre-reflow shape already matches the declared layout's axis (geometry is
+ * still re-snapped by `applyGeometry`, but a same-axis split avoids a visible
+ * mid-frame orientation flip).
+ *
+ * Returns undefined only when `name` is the root leaf (no parent split) — that
+ * case is impossible for `insertPane` because `splitAnchor` already requires
+ * `name` to share the tree with at least one other leaf.
+ */
+function leafParentDirection(tree: LayoutNode, name: string): "h" | "v" | undefined {
+  if (isLayoutLeaf(tree)) {
+    return undefined;
+  }
+  if (isLayoutSplit(tree)) {
+    for (const child of tree.children) {
+      if (isLayoutLeaf(child) && child.pane === name) {
+        return tree.direction === "rows" ? "v" : "h";
+      }
+      const inner = leafParentDirection(child, name);
+      if (inner) {
+        return inner;
+      }
+    }
+  }
+  return undefined;
 }
 
 /** Per-call options. `resyncFallback` is off by default (the no-resync fast path). */
@@ -112,6 +194,12 @@ class LayoutReflow {
     swapPanes: (src: string, dst: string) => Promise<void>;
     selectLayout: (target: string, layout: string) => Promise<void>;
     resyncPaneSizes: (target: string) => Promise<void>;
+    splitPane: (
+      target: string,
+      direction: "h" | "v",
+      options?: SplitPaneOptions,
+    ) => Promise<string>;
+    selectPane: (target: string) => Promise<void>;
   };
 
   public constructor(deps: LayoutReflowDeps) {
@@ -123,6 +211,8 @@ class LayoutReflow {
       swapPanes: deps.swapPanes ?? defaultSwapPanes,
       selectLayout: deps.selectLayout ?? defaultSelectLayout,
       resyncPaneSizes: deps.resyncPaneSizes ?? defaultResyncPaneSizes,
+      splitPane: deps.splitPane ?? defaultSplitPane,
+      selectPane: deps.selectPane ?? defaultSelectPane,
     };
   }
 
@@ -193,6 +283,111 @@ class LayoutReflow {
     //    Queries, so it can only ever be resynced, not detected. Off by default.
     if (options?.resyncFallback) {
       await this.tmux.resyncPaneSizes(target);
+    }
+  }
+
+  /**
+   * Create the tmux pane for a currently pane-less service at its declared
+   * position. Zero-swap adjacency split — verified in `20_architecture.md`
+   * Smoothness: pick a neighbor leaf in the FILTERED target tree (predecessor
+   * preferred), split off it with `-d` so focus doesn't move, then snap exact
+   * geometry with `applyGeometry`.
+   *
+   * The `-d` flag is critical: a plain `split-window` makes the new pane active
+   * (verified) and subsequent `select-layout`/`swap-pane` keep that activation
+   * — focus would jump from whatever the user was looking at to the freshly-
+   * inserted background service. With `-d`, the previously-active pane stays
+   * active unless the declared layout leaf has `focus: true`, in which case we
+   * explicitly `select-pane` AFTER the geometry settles.
+   *
+   * The service process itself is NOT started here — `insertPane` only manages
+   * the pane; the service manager (Phase 4) starts the process and writes into
+   * the pane that this method created.
+   *
+   * Failure semantics: on any error before `paneMap[name]` is set, `paneMap` is
+   * untouched. On an error AFTER the split but before geometry settles, the
+   * new pane id is removed from `paneMap` so the lifecycle invariant
+   * (paneMap ⊇ visible) holds; the dangling tmux pane and a full visual
+   * restore are the responsibility of P03-T04 (rollback) — a TODO seam below.
+   */
+  public async insertPane(name: string): Promise<void> {
+    const layout = this.deps.getLayout();
+    if (!layout) {
+      throw new Error("LayoutReflow.insertPane: no declared layout to insert into");
+    }
+    if (!findLeaf(layout, name)) {
+      throw new Error(
+        `LayoutReflow.insertPane: pane '${name}' is not a leaf in the declared layout`,
+      );
+    }
+    const paneMap = this.deps.getPaneMap();
+    if (paneMap[name]) {
+      throw new Error(`LayoutReflow.insertPane: pane '${name}' already has a tmux pane`);
+    }
+
+    // Target visible = current visible (paneMap keys) ∪ {name}. paneMap is the
+    // Authoritative source of "currently owns a tmux pane" — @tui is always in
+    // It, and Phase-3 lifecycle hooks keep it in lockstep with reality.
+    const targetVisible = new Set<string>([...Object.keys(paneMap), name]);
+    const targetTree = filterTree(layout, targetVisible);
+    if (!targetTree) {
+      throw new Error("LayoutReflow.insertPane: filtered target tree is empty");
+    }
+
+    // Anchor — predecessor (after) or successor (before) — gives the
+    // Adjacency-split that lands the new pane in its DFS slot with zero swaps.
+    const anchor = splitAnchor(targetTree, name);
+    const anchorName = anchor.mode === "after" ? anchor.predecessor : anchor.successor;
+    const anchorPaneId = paneMap[anchorName];
+    if (!anchorPaneId) {
+      throw new Error(`LayoutReflow.insertPane: anchor pane '${anchorName}' is not in paneMap`);
+    }
+
+    // Mirror the parent split axis so the transient pre-reflow shape already
+    // Matches the declared orientation; `applyGeometry` snaps the size anyway,
+    // But same-axis avoids a mid-frame orientation flip.
+    const direction = leafParentDirection(targetTree, name);
+    if (!direction) {
+      // Defensive: splitAnchor would have thrown when there's no neighbor, so
+      // The leaf must have a parent split in `targetTree`.
+      throw new Error(
+        `LayoutReflow.insertPane: could not determine parent split direction for '${name}'`,
+      );
+    }
+
+    let newPaneId: string | undefined = undefined;
+    try {
+      newPaneId = await this.tmux.splitPane(anchorPaneId, direction, {
+        detached: true,
+        before: anchor.mode === "before",
+      });
+
+      // Mutate paneMap THEN fire the hook so the session sees a consistent view
+      // (paneMap already contains the new id when it allocates the log buffer).
+      paneMap[name] = newPaneId;
+      this.deps.onPaneInserted?.(name, newPaneId);
+
+      // Snap exact geometry — common path is zero swaps (adjacency split landed
+      // It in the target DFS slot).
+      await this.applyGeometry(targetVisible);
+
+      // Conditional focus: only steal focus when the layout explicitly opted
+      // In via `focus: true` on this leaf. Read from the ORIGINAL layout (focus
+      // Is a declared property, not derived from the filtered tree).
+      const leaf = findLeaf(layout, name);
+      if (leaf?.focus) {
+        await this.tmux.selectPane(newPaneId);
+      }
+    } catch (error) {
+      // TODO(P03-T04): full rollback — kill the dangling tmux pane and restore
+      // The pre-insert window_layout so the user never sees a half-applied
+      // State. For now we only restore the paneMap invariant; the dangling
+      // Pane is left for P03-T04 to clean up.
+      if (newPaneId !== undefined && paneMap[name] === newPaneId) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- rollback removes the just-inserted entry
+        delete paneMap[name];
+      }
+      throw error;
     }
   }
 }

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -11,6 +11,7 @@ import {
 import type { Rect } from "./tmux-layout.js";
 import {
   getWindowSize as defaultGetWindowSize,
+  killPane as defaultKillPane,
   paneIndexOrder as defaultPaneIndexOrder,
   resyncPaneSizes as defaultResyncPaneSizes,
   selectLayout as defaultSelectLayout,
@@ -52,6 +53,8 @@ interface LayoutReflowDeps {
   splitPane?: (target: string, direction: "h" | "v", options?: SplitPaneOptions) => Promise<string>;
   /** Move tmux's active pane to `target`. Used for conditional focus after insert. */
   selectPane?: (target: string) => Promise<void>;
+  /** Destroy a tmux pane (`kill-pane -t <paneId>`). Survivors keep their relative order. */
+  killPane?: (target: string) => Promise<void>;
   /**
    * Session-provided hook fired AFTER `paneMap[name]` is set during `insertPane`.
    * The session uses this to allocate the log buffer, register the pane in the
@@ -200,6 +203,7 @@ class LayoutReflow {
       options?: SplitPaneOptions,
     ) => Promise<string>;
     selectPane: (target: string) => Promise<void>;
+    killPane: (target: string) => Promise<void>;
   };
 
   public constructor(deps: LayoutReflowDeps) {
@@ -213,6 +217,7 @@ class LayoutReflow {
       resyncPaneSizes: deps.resyncPaneSizes ?? defaultResyncPaneSizes,
       splitPane: deps.splitPane ?? defaultSplitPane,
       selectPane: deps.selectPane ?? defaultSelectPane,
+      killPane: deps.killPane ?? defaultKillPane,
     };
   }
 
@@ -389,6 +394,69 @@ class LayoutReflow {
       }
       throw error;
     }
+  }
+
+  /**
+   * Destroy the tmux pane for an explicitly-stopped service and re-expand the
+   * survivors to their declared geometry — Flow C in `10_functional.md`.
+   * Killing one pane leaves the survivors in their relative DFS order, so this
+   * is `kill-pane` + ONE `applyGeometry`; no `swap-pane` is ever needed.
+   *
+   * Idempotent: a no-op when `name` is not in `paneMap` (the caller may invoke
+   * it from `stopServiceInternal` without first checking pane ownership).
+   * Refuses to remove the `@tui` pane — it is the TUI host and must always
+   * own a tmux pane while the session is alive.
+   *
+   * Buffer retention (Round 7 invariant): the `onPaneRemoved` hook stops the
+   * monitor and drops the pane-keyed entries (`paneBuffers`/`paneMembers`),
+   * but the SERVICE-keyed `buffers[name]` entry is intentionally retained so
+   * `logs.snapshot(name)` still returns the stopped service's history and
+   * `attachSnapshot` continues to surface it — the same behavior as any
+   * normal stopped service. This method only fires the hook; the real
+   * buffer/monitor wiring lands in P03-T03.
+   *
+   * Failure semantics: on `kill-pane` failure, `paneMap` is untouched (we
+   * never reached the delete). On a later `applyGeometry` failure the tmux
+   * pane is already gone, so `paneMap` stays deleted (the invariant
+   * paneMap ⊇ visible already holds — visible no longer contains `name`).
+   * Full visual rollback is the responsibility of P03-T04.
+   */
+  public async removePane(name: string): Promise<void> {
+    if (name === "@tui") {
+      throw new Error("LayoutReflow.removePane: refusing to remove the '@tui' pane");
+    }
+
+    const paneMap = this.deps.getPaneMap();
+    const paneId = paneMap[name];
+    if (!paneId) {
+      // Idempotent — nothing to do for a service that doesn't own a pane.
+      return;
+    }
+
+    const layout = this.deps.getLayout();
+    if (!layout) {
+      throw new Error("LayoutReflow.removePane: no declared layout to reflow against");
+    }
+
+    // TODO(P03-T04): a true rollback after a kill-then-reflow failure requires
+    // Re-splitting the pane and restoring the service's process — out of scope
+    // For this primitive. For now: on a `kill-pane` failure, `paneMap` is
+    // Untouched (we never reached the delete). On a later `applyGeometry`
+    // Failure the kill has already happened, so `paneMap` stays deleted and
+    // The paneMap-⊇-visible invariant still holds (visible no longer contains
+    // `name`). The thrown error propagates to the session for higher-level
+    // Recovery.
+    // Capture pane id BEFORE deleting so the hook can stop the monitor by id.
+    await this.tmux.killPane(paneId);
+
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing the just-killed entry
+    delete paneMap[name];
+    this.deps.onPaneRemoved?.(name, paneId);
+
+    // Re-expand survivors: visible = remaining paneMap keys. The @tui pane is
+    // Always still present; the filtered tree is guaranteed non-empty.
+    const remainingVisible = new Set<string>(Object.keys(paneMap));
+    await this.applyGeometry(remainingVisible);
   }
 }
 

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -2,6 +2,7 @@ import type { LayoutLeaf, LayoutNode } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
 import {
+  PaneTooSmallError,
   computeRects,
   filterTree,
   layoutString,
@@ -18,8 +19,31 @@ import {
   selectPane as defaultSelectPane,
   splitPane as defaultSplitPane,
   swapPanes as defaultSwapPanes,
+  windowLayout as defaultWindowLayout,
 } from "./tmux.js";
 import type { SplitPaneOptions } from "./tmux.js";
+
+/**
+ * A tmux command failed during a reflow operation. Wraps the original cause and
+ * exposes `code: "TMUX_FAILED"` per `50_api.md`. The `cause` is preserved for
+ * diagnostics; `phase` identifies which step of the reflow blew up.
+ *
+ * `PaneTooSmallError` (from `tmux-layout.ts`) is NOT wrapped — it carries its
+ * Own `PANE_TOO_SMALL` semantic and is rethrown as-is so callers can branch on
+ * `instanceof PaneTooSmallError` vs `TmuxFailedError`.
+ */
+class TmuxFailedError extends Error {
+  public readonly code = "TMUX_FAILED" as const;
+  public readonly phase: string;
+  public override readonly cause: unknown;
+
+  public constructor(phase: string, message: string, cause: unknown) {
+    super(message);
+    this.name = "TmuxFailedError";
+    this.phase = phase;
+    this.cause = cause;
+  }
+}
 
 /** Map from pane/service name → tmux pane id (e.g. `"%17"`). */
 type PaneMap = Record<string, string>;
@@ -55,6 +79,8 @@ interface LayoutReflowDeps {
   selectPane?: (target: string) => Promise<void>;
   /** Destroy a tmux pane (`kill-pane -t <paneId>`). Survivors keep their relative order. */
   killPane?: (target: string) => Promise<void>;
+  /** Read live `#{window_layout}` — snapshotted before a reflow mutation so rollback can restore. */
+  windowLayout?: (target: string) => Promise<string>;
   /**
    * Session-provided hook fired AFTER `paneMap[name]` is set during `insertPane`.
    * The session uses this to allocate the log buffer, register the pane in the
@@ -72,6 +98,23 @@ interface LayoutReflowDeps {
    * extends — both methods share one constructor surface.
    */
   onPaneRemoved?: (name: string, paneId: string) => void;
+  /**
+   * Session-provided hook for insert ROLLBACK: fired when an `insertPane` failure
+   * after the split has succeeded needs to undo session-side log allocation.
+   * Without it, a failed insert would orphan `paneBuffers[newPaneId]` + a running
+   * monitor key — idempotency only covers same-id retry, so a SUBSEQUENT retry
+   * with a different pane id would leak the old entry. The session wires this to
+   * `freePaneLog(name, paneId)` so the cleanup is symmetric with `onPaneRemoved`.
+   */
+  onPaneInsertFailed?: (name: string, paneId: string) => void;
+  /**
+   * Reported when a best-effort rollback step (kill, select-layout, hook) itself
+   * fails. Optional. Default behavior: swallow silently (matching `createLayout`'s
+   * teardown). Wire this to whatever the host's diagnostic channel is (a daemon
+   * event, a metric) — but never let it throw, since rollback errors must NEVER
+   * mask the original failure.
+   */
+  onRollbackError?: (phase: string, error: unknown) => void;
 }
 
 /** DFS leaf order of `tree`. Mirrors `collectPaneNames` in tmux-layout.ts. */
@@ -204,6 +247,7 @@ class LayoutReflow {
     ) => Promise<string>;
     selectPane: (target: string) => Promise<void>;
     killPane: (target: string) => Promise<void>;
+    windowLayout: (target: string) => Promise<string>;
   };
 
   public constructor(deps: LayoutReflowDeps) {
@@ -218,7 +262,50 @@ class LayoutReflow {
       splitPane: deps.splitPane ?? defaultSplitPane,
       selectPane: deps.selectPane ?? defaultSelectPane,
       killPane: deps.killPane ?? defaultKillPane,
+      windowLayout: deps.windowLayout ?? defaultWindowLayout,
     };
+  }
+
+  /**
+   * Run `step`; if it throws, report through `onRollbackError` (default swallow)
+   * and continue. NEVER lets a rollback failure mask the original error — every
+   * use site is inside an outer `catch (original) { ... }` and rethrows
+   * `original` last.
+   */
+  private async tryRollback(phase: string, step: () => Promise<void> | void): Promise<void> {
+    try {
+      await step();
+    } catch (error) {
+      try {
+        this.deps.onRollbackError?.(phase, error);
+      } catch {
+        /* The diagnostics callback itself threw — swallow, original error still rethrown */
+      }
+    }
+  }
+
+  /**
+   * Wrap an arbitrary unknown thrown value with the typed `TMUX_FAILED` shape,
+   * unless it is already a `PaneTooSmallError` or `TmuxFailedError` (those pass
+   * through). Preserves the original message so existing message-matching tests
+   * keep working, and exposes `cause`/`phase` for downstream consumers.
+   */
+  private static toTypedError(phase: string, error: unknown): Error {
+    if (error instanceof PaneTooSmallError) {
+      return error;
+    }
+    if (error instanceof TmuxFailedError) {
+      return error;
+    }
+    let message = "";
+    if (error instanceof Error) {
+      ({ message } = error);
+    } else if (typeof error === "string") {
+      message = error;
+    } else {
+      message = String(error);
+    }
+    return new TmuxFailedError(phase, message, error);
   }
 
   /**
@@ -360,6 +447,19 @@ class LayoutReflow {
       );
     }
 
+    // Snapshot the prior window_layout BEFORE mutating. Rollback restores via
+    // `selectLayout(target, priorLayout)` — same `select-layout` primitive used
+    // For forward progress, mirroring the `createLayout` teardown pattern
+    // (`tmux-layout.ts:551-560`). Captured at the LAST possible moment before
+    // The split, so it reflects state any in-flight terminal resize has settled.
+    const target = this.deps.getWindowTarget();
+    let priorLayout: string | undefined = undefined;
+    try {
+      priorLayout = await this.tmux.windowLayout(target);
+    } catch (error) {
+      throw LayoutReflow.toTypedError("snapshot:windowLayout", error);
+    }
+
     let newPaneId: string | undefined = undefined;
     try {
       newPaneId = await this.tmux.splitPane(anchorPaneId, direction, {
@@ -384,15 +484,38 @@ class LayoutReflow {
         await this.tmux.selectPane(newPaneId);
       }
     } catch (error) {
-      // TODO(P03-T04): full rollback — kill the dangling tmux pane and restore
-      // The pre-insert window_layout so the user never sees a half-applied
-      // State. For now we only restore the paneMap invariant; the dangling
-      // Pane is left for P03-T04 to clean up.
+      // Best-effort rollback. ORDER MATTERS:
+      //  1. Roll back the paneMap mutation (if it was made) so any consumer
+      //     Reading paneMap during/after this throw sees the pre-insert state.
+      //  2. Free the session's log allocation for newPaneId — the
+      //     `onPaneInsertFailed` hook closes the buffer/monitor leak: without
+      //     This, a later retry with a DIFFERENT paneId would orphan
+      //     `paneBuffers[oldId]` + a running monitor key (idempotency only
+      //     Covers same-id retry).
+      //  3. Kill the just-created tmux pane so the prior layout string (which
+      //     Doesn't reference it) can be applied cleanly.
+      //  4. Restore prior geometry. The user never sees a half-applied state.
+      // Every rollback step is wrapped in `tryRollback` — they cannot mask the
+      // Original error.
       if (newPaneId !== undefined && paneMap[name] === newPaneId) {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- rollback removes the just-inserted entry
         delete paneMap[name];
       }
-      throw error;
+      if (newPaneId !== undefined) {
+        const createdPaneId = newPaneId;
+        await this.tryRollback("rollback:onPaneInsertFailed", () => {
+          this.deps.onPaneInsertFailed?.(name, createdPaneId);
+        });
+        await this.tryRollback("rollback:killPane", async () => {
+          await this.tmux.killPane(createdPaneId);
+        });
+      }
+      if (priorLayout !== undefined) {
+        await this.tryRollback("rollback:restoreLayout", async () => {
+          await this.tmux.selectLayout(target, priorLayout);
+        });
+      }
+      throw LayoutReflow.toTypedError("insertPane", error);
     }
   }
 
@@ -438,27 +561,74 @@ class LayoutReflow {
       throw new Error("LayoutReflow.removePane: no declared layout to reflow against");
     }
 
-    // TODO(P03-T04): a true rollback after a kill-then-reflow failure requires
-    // Re-splitting the pane and restoring the service's process — out of scope
-    // For this primitive. For now: on a `kill-pane` failure, `paneMap` is
-    // Untouched (we never reached the delete). On a later `applyGeometry`
-    // Failure the kill has already happened, so `paneMap` stays deleted and
-    // The paneMap-⊇-visible invariant still holds (visible no longer contains
-    // `name`). The thrown error propagates to the session for higher-level
-    // Recovery.
-    // Capture pane id BEFORE deleting so the hook can stop the monitor by id.
-    await this.tmux.killPane(paneId);
+    // Snapshot the prior window_layout BEFORE killing. After the kill, the
+    // String literally references a dead pane id, so we can't re-apply it —
+    // The snapshot is kept for diagnostics + the `onRollbackError` channel.
+    // Real geometry repair after a kill-then-reflow failure has to come from
+    // A reconciliation pass against the LIVE pane order (see catch below).
+    const target = this.deps.getWindowTarget();
+    let priorLayout: string | undefined = undefined;
+    try {
+      priorLayout = await this.tmux.windowLayout(target);
+    } catch (error) {
+      throw LayoutReflow.toTypedError("snapshot:windowLayout", error);
+    }
 
+    // Kill first — every other step assumes the pane is gone. On kill-pane
+    // Failure, `paneMap` is untouched and we surface the typed error directly:
+    // The window is unchanged so there is nothing to roll back.
+    try {
+      await this.tmux.killPane(paneId);
+    } catch (error) {
+      throw LayoutReflow.toTypedError("removePane:killPane", error);
+    }
+
+    // Capture pane id BEFORE deleting so the hook can stop the monitor by id.
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing the just-killed entry
     delete paneMap[name];
     this.deps.onPaneRemoved?.(name, paneId);
 
-    // Re-expand survivors: visible = remaining paneMap keys. The @tui pane is
-    // Always still present; the filtered tree is guaranteed non-empty.
-    const remainingVisible = new Set<string>(Object.keys(paneMap));
-    await this.applyGeometry(remainingVisible);
+    // Re-expand survivors. If geometry fails, paneMap already reflects reality
+    // (the killed pane is gone; survivors are still alive and mapped), so the
+    // Only "rollback" possible is best-effort reconciliation — see below.
+    try {
+      const remainingVisible = new Set<string>(Object.keys(paneMap));
+      await this.applyGeometry(remainingVisible);
+    } catch (error) {
+      await this.tryRollback("rollback:reconcilePaneMap", async () => {
+        await this.reconcilePaneMap(target);
+      });
+      // PriorLayout is reported (not applied — it references the dead pane).
+      // The host can use it to assess what was lost.
+      if (priorLayout !== undefined) {
+        try {
+          this.deps.onRollbackError?.("rollback:priorLayoutSnapshot", priorLayout);
+        } catch {
+          /* Diagnostic callback threw — swallow, original error still rethrown */
+        }
+      }
+      throw LayoutReflow.toTypedError("removePane:applyGeometry", error);
+    }
+  }
+
+  /**
+   * Reconcile `paneMap` with the live tmux window: any name whose pane id is
+   * NOT in `paneIndexOrder(target)` is dropped. Used by `removePane`'s rollback
+   * to catch cases where a parallel external `kill-pane` (or a cascade from
+   * the failed reflow) left a paneMap entry pointing at a dead pane.
+   */
+  private async reconcilePaneMap(target: string): Promise<void> {
+    const liveOrder = await this.tmux.paneIndexOrder(target);
+    const liveIds = new Set(liveOrder.map((entry) => entry.id));
+    const paneMap = this.deps.getPaneMap();
+    for (const [name, paneId] of Object.entries(paneMap)) {
+      if (!liveIds.has(paneId)) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- reconciling against live state
+        delete paneMap[name];
+      }
+    }
   }
 }
 
-export { LayoutReflow };
+export { LayoutReflow, TmuxFailedError };
 export type { ApplyGeometryOptions, LayoutReflowDeps, PaneMap, Rect };

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -1,0 +1,201 @@
+import type { LayoutNode } from "#src/config/types.js";
+
+import { computeRects, filterTree, layoutString, resolvePermutation } from "./tmux-layout.js";
+import type { Rect } from "./tmux-layout.js";
+import {
+  getWindowSize as defaultGetWindowSize,
+  paneIndexOrder as defaultPaneIndexOrder,
+  resyncPaneSizes as defaultResyncPaneSizes,
+  selectLayout as defaultSelectLayout,
+  swapPanes as defaultSwapPanes,
+} from "./tmux.js";
+
+/** Map from pane/service name → tmux pane id (e.g. `"%17"`). */
+type PaneMap = Record<string, string>;
+
+/**
+ * Deps for `LayoutReflow`. EVERY field is a getter or callback, never a captured
+ * value — `session._reload` reassigns `paneMap`/`layout`/`services` to fresh
+ * objects, so a ref captured at construction goes stale after the first reload
+ * (an insert would then mutate the orphaned old map). Reading through these
+ * getters always returns the current Session state. tmux operations are
+ * injected too so unit tests can pin behavior without spawning tmux.
+ */
+interface LayoutReflowDeps {
+  /** The declared layout tree (may be undefined when the project has no layout). */
+  getLayout: () => LayoutNode | undefined;
+  /** Live name → pane-id map; mutated by insert/remove, replaced by reload. */
+  getPaneMap: () => PaneMap;
+  /** Window target (session, window id, or `@N`) whose geometry we drive. */
+  getWindowTarget: () => string;
+  /** Current window size; concurrent terminal resize is tolerated by the next reflow. */
+  getWindowSize?: (target: string) => Promise<{ width: number; height: number }>;
+  /** Live spatial pane order, ascending by `pane_index`. */
+  paneIndexOrder?: (target: string) => Promise<{ index: number; id: string }[]>;
+  /** Swap two panes' positions without restarting their processes. */
+  swapPanes?: (src: string, dst: string) => Promise<void>;
+  /** Apply an absolute layout string to the window. */
+  selectLayout?: (target: string, layout: string) => Promise<void>;
+  /** Fallback resync (no-op by default); the reflow only calls it when explicitly enabled. */
+  resyncPaneSizes?: (target: string) => Promise<void>;
+}
+
+/** DFS leaf order of `tree`. Mirrors `collectPaneNames` in tmux-layout.ts. */
+function collectLeaves(tree: LayoutNode): string[] {
+  if ("pane" in tree) {
+    return [tree.pane];
+  }
+  return tree.children.flatMap(collectLeaves);
+}
+
+/**
+ * Build the `paneNumbers` map for `layoutString`. tmux pane ids look like `"%17"`;
+ * the encoded layout-string pane number is the integer portion. Throws on a
+ * malformed id (defense in depth — the loader/tmux are the only sources).
+ */
+function buildPaneNumbers(leafOrder: string[], paneMap: PaneMap): Map<string, number> {
+  const numbers = new Map<string, number>();
+  for (const name of leafOrder) {
+    const id = paneMap[name];
+    const match = /^%(?<n>\d+)$/u.exec(id);
+    if (!match?.groups) {
+      throw new Error(`LayoutReflow: pane id '${id}' for '${name}' is not a '%N' tmux pane id`);
+    }
+    numbers.set(name, Number.parseInt(match.groups.n, 10));
+  }
+  return numbers;
+}
+
+function arraysEqual<T>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((value, i) => value === b[i]);
+}
+
+/** Per-call options. `resyncFallback` is off by default (the no-resync fast path). */
+interface ApplyGeometryOptions {
+  /**
+   * When true, invoke `resyncPaneSizes` AFTER `select-layout` — the gated fallback
+   * for the attached-client staleness edge (tmux-query-invisible; can only be
+   * resynced, not detected). Default off; the no-resync path is verified on both
+   * detached servers and attached pty clients.
+   */
+  resyncFallback?: boolean;
+}
+
+/**
+ * Drives an existing tmux window to the exact target geometry for a given set of
+ * visible panes — WITHOUT restarting any process. Insert/remove (kill-pane and
+ * split) live in P03; this primitive only swaps + select-layouts.
+ *
+ * Algorithm (`applyGeometry`):
+ *  1. `filterTree(layout, visible)` → target tree (visible leaves only, single-
+ *     child splits collapsed).
+ *  2. `computeRects(tree, w, h)` → absolute cell rects per pane name.
+ *  3. Target DFS leaf order → pane ids via `paneMap`.
+ *  4. Read live spatial order; if already equal → ZERO swaps (the common adjacency
+ *     case). Otherwise emit selection-sort `swap-pane` pairs.
+ *  5. Exactly ONE `select-layout` with the serialized layout string.
+ *
+ * `resyncPaneSizes` is NOT on the default path. `select-layout`/`resize-pane`
+ * push correct pty winsizes themselves (verified on detached + attached clients,
+ * Round 7); the staleness is a multi-split boot artifact and is invisible to
+ * tmux queries. The hook is gated via `ApplyGeometryOptions.resyncFallback` so
+ * P02-T03 / P04 can enable it for the attached-client edge.
+ */
+class LayoutReflow {
+  private readonly deps: LayoutReflowDeps;
+  private readonly tmux: {
+    getWindowSize: (target: string) => Promise<{ width: number; height: number }>;
+    paneIndexOrder: (target: string) => Promise<{ index: number; id: string }[]>;
+    swapPanes: (src: string, dst: string) => Promise<void>;
+    selectLayout: (target: string, layout: string) => Promise<void>;
+    resyncPaneSizes: (target: string) => Promise<void>;
+  };
+
+  public constructor(deps: LayoutReflowDeps) {
+    this.deps = deps;
+    // Fill in real tmux wrappers; tests can override any subset via deps.
+    this.tmux = {
+      getWindowSize: deps.getWindowSize ?? defaultGetWindowSize,
+      paneIndexOrder: deps.paneIndexOrder ?? defaultPaneIndexOrder,
+      swapPanes: deps.swapPanes ?? defaultSwapPanes,
+      selectLayout: deps.selectLayout ?? defaultSelectLayout,
+      resyncPaneSizes: deps.resyncPaneSizes ?? defaultResyncPaneSizes,
+    };
+  }
+
+  /**
+   * Drive the window to the geometry implied by `visibleNames` — the set of pane
+   * names (incl. `@tui`) that should currently own a tmux pane. Returns when
+   * `select-layout` has applied; the (optional) resync fallback runs after.
+   *
+   * Throws if there is no declared layout (the no-layout path has no geometry to
+   * reflow against), if a visible pane is missing from `paneMap` (impossible
+   * once Phase-3 lifecycle hooks land — insert/remove keep the map and the
+   * visible set in lockstep), or if the filtered tree turns out empty.
+   */
+  public async applyGeometry(
+    visibleNames: Set<string>,
+    options?: ApplyGeometryOptions,
+  ): Promise<void> {
+    const layout = this.deps.getLayout();
+    if (!layout) {
+      throw new Error("LayoutReflow.applyGeometry: no declared layout to reflow against");
+    }
+
+    // 1. Filter to the visible subtree (single-child splits already collapsed).
+    const tree = filterTree(layout, visibleNames);
+    if (!tree) {
+      throw new Error(
+        "LayoutReflow.applyGeometry: filtered tree is empty (no visible panes intersect the layout)",
+      );
+    }
+
+    // 2. Compute absolute cell rects against the live window size.
+    const target = this.deps.getWindowTarget();
+    const { width, height } = await this.tmux.getWindowSize(target);
+    const rects = computeRects(tree, width, height);
+
+    // 3. Target DFS leaf order → pane ids via the LIVE paneMap (post-reload-safe).
+    const paneMap = this.deps.getPaneMap();
+    const targetLeafOrder = collectLeaves(tree);
+    const targetIds = targetLeafOrder.map((name) => {
+      const id = paneMap[name];
+      if (!id) {
+        throw new Error(`LayoutReflow.applyGeometry: pane '${name}' is not in paneMap`);
+      }
+      return id;
+    });
+
+    // 4. Read live spatial order; reorder only if it doesn't already match.
+    const currentOrder = await this.tmux.paneIndexOrder(target);
+    const currentIds = currentOrder.map((entry) => entry.id);
+    if (!arraysEqual(currentIds, targetIds)) {
+      const swaps = resolvePermutation(currentIds, targetIds);
+      for (const [from, to] of swaps) {
+        // Sequential: each swap must complete before the next so paneIndexOrder
+        // Would converge on the target. tmux serializes per-server anyway.
+        // eslint-disable-next-line no-await-in-loop -- sequential by design
+        await this.tmux.swapPanes(from, to);
+      }
+    }
+
+    // 5. Exactly ONE select-layout with the serialized geometry. Pane numbers
+    //    Are the integer part of the `%N` pane id — encoded numbers are cosmetic
+    //    For binding (select-layout binds by spatial order), but must be present
+    //    And well-formed.
+    const paneNumbers = buildPaneNumbers(targetLeafOrder, paneMap);
+    await this.tmux.selectLayout(target, layoutString(tree, rects, paneNumbers));
+
+    // 6. Optional fallback for attached-client staleness — invisible to tmux
+    //    Queries, so it can only ever be resynced, not detected. Off by default.
+    if (options?.resyncFallback) {
+      await this.tmux.resyncPaneSizes(target);
+    }
+  }
+}
+
+export { LayoutReflow };
+export type { ApplyGeometryOptions, LayoutReflowDeps, PaneMap, Rect };

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -473,8 +473,11 @@ class LayoutReflow {
       this.deps.onPaneInserted?.(name, newPaneId);
 
       // Snap exact geometry — common path is zero swaps (adjacency split landed
-      // It in the target DFS slot).
-      await this.applyGeometry(targetVisible);
+      // It in the target DFS slot). Resync unconditionally: an attached client's
+      // Pty winsize after a split is tmux-query-invisible (70_risks.md Round 7),
+      // So a running TUI (e.g. nuxt dev) keeps drawing at the pre-split width
+      // Unless we nudge tmux to re-push every pane's winsize.
+      await this.applyGeometry(targetVisible, { resyncFallback: true });
 
       // Conditional focus: only steal focus when the layout explicitly opted
       // In via `focus: true` on this leaf. Read from the ORIGINAL layout (focus
@@ -593,7 +596,9 @@ class LayoutReflow {
     // Only "rollback" possible is best-effort reconciliation — see below.
     try {
       const remainingVisible = new Set<string>(Object.keys(paneMap));
-      await this.applyGeometry(remainingVisible);
+      // Same Round-7 reason as insertPane: removing a pane resizes its siblings,
+      // And the survivors' pty winsizes may stay stale for an attached client.
+      await this.applyGeometry(remainingVisible, { resyncFallback: true });
     } catch (error) {
       await this.tryRollback("rollback:reconcilePaneMap", async () => {
         await this.reconcilePaneMap(target);

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -113,17 +113,71 @@ export async function killSession(name: string): Promise<void> {
   await run(["kill-session", "-t", name]);
 }
 
+export interface SplitPaneOptions {
+  /** Percentage of the parent pane the new pane should occupy. */
+  percent?: number;
+  /** When true, pass `-d` so the new pane does NOT steal focus from the active pane. */
+  detached?: boolean;
+  /** When true, pass `-b` so the new pane is inserted *before* `target` in spatial order. */
+  before?: boolean;
+}
+
 export async function splitPane(
   target: string,
   direction: "h" | "v",
-  percent?: number,
+  options?: SplitPaneOptions,
 ): Promise<string> {
-  const args = ["split-window", `-${direction}`, "-t", target];
-  if (typeof percent === "number") {
-    args.push("-l", `${percent}%`);
+  const args = ["split-window", `-${direction}`];
+  if (options?.before) {
+    args.push("-b");
+  }
+  if (options?.detached) {
+    args.push("-d");
+  }
+  args.push("-t", target);
+  if (typeof options?.percent === "number") {
+    args.push("-l", `${options.percent}%`);
   }
   args.push("-P", "-F", "#{pane_id}");
   return run(args);
+}
+
+/** Swap two panes' positions (`swap-pane -s <src> -t <dst>`). Processes stay attached. */
+export async function swapPanes(src: string, dst: string): Promise<void> {
+  await run(["swap-pane", "-s", src, "-t", dst]);
+}
+
+/**
+ * Apply an absolute layout string to `target`'s window via `select-layout -t <target> <layout>`.
+ * `layout` is passed as a single argv element so the `{` / `[` characters never hit a shell —
+ * `run` already spawns tmux directly without one.
+ */
+export async function selectLayout(target: string, layout: string): Promise<void> {
+  await run(["select-layout", "-t", target, layout]);
+}
+
+/** Read the live `#{window_layout}` string for `target`'s window (for tests/rollback). */
+export async function windowLayout(target: string): Promise<string> {
+  return run(["display-message", "-p", "-t", target, "#{window_layout}"]);
+}
+
+/**
+ * The current spatial order of panes in `target`'s window, sorted by `pane_index`.
+ * tmux assigns `pane_index` in spatial DFS order, so this is exactly the order
+ * `select-layout` binds panes to layout cells.
+ */
+export async function paneIndexOrder(target: string): Promise<{ index: number; id: string }[]> {
+  const out = await run(["list-panes", "-t", target, "-F", "#{pane_index} #{pane_id}"]);
+  if (!out) {
+    return [];
+  }
+  return out
+    .split("\n")
+    .map((line) => {
+      const [indexStr, id] = line.split(" ");
+      return { index: Number.parseInt(indexStr, 10), id };
+    })
+    .toSorted((a, b) => a.index - b.index);
 }
 
 export async function killPane(target: string): Promise<void> {

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -910,6 +910,132 @@ describe("docker expand", () => {
     });
   });
 
+  describe("lazyPane resolution (P04-T02 default rule)", () => {
+    it("autostart + no explicit lazyPane → false", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: { api: { start: "npm dev" } },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect(resolved.lazyPaneByService.get("api")).toBe(false);
+    });
+
+    it("non-autostart (flags.start === false) + no explicit lazyPane → true", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: { worker: { start: "node w.js", flags: { start: false } } },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect(resolved.lazyPaneByService.get("worker")).toBe(true);
+    });
+
+    it("explicit lazyPane: true wins over autostart default", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: { api: { start: "npm dev", lazyPane: true } },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect(resolved.lazyPaneByService.get("api")).toBe(true);
+    });
+
+    it("explicit lazyPane: false wins over non-autostart default", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: { worker: { start: "node w.js", flags: { start: false }, lazyPane: false } },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect(resolved.lazyPaneByService.get("worker")).toBe(false);
+    });
+
+    it("non-autostart detached service → false (guard beats default)", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: {
+              worker: { start: "node w.js", detached: true, flags: { start: false } },
+            },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect(resolved.lazyPaneByService.get("worker")).toBe(false);
+    });
+
+    it("non-autostart docker-group member → false (guard beats default)", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: {
+              cache: {
+                docker: {
+                  service: ["redis", "memcached"],
+                  expand: { redis: { flags: { start: false } } },
+                },
+              },
+            },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      // Redis is a _combined member; even though its expand override turns it
+      // Non-autostart, the guard forces lazyPane → false (would otherwise
+      // Repoint paneMap['redis'] off the shared 'cache' pane in P04-T04).
+      expect(resolved.lazyPaneByService.get("redis")).toBe(false);
+      expect(resolved.lazyPaneByService.get("memcached")).toBe(false);
+    });
+
+    it("every resolved service is present in lazyPaneByService", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: {
+              api: { start: "npm dev" },
+              worker: { start: "node w.js", flags: { start: false } },
+              detached: { start: "node d.js", detached: true },
+            },
+          });
+        }
+      `,
+      );
+      const resolved = await loadConfig(configPath, tmpDir);
+      expect([...resolved.lazyPaneByService.keys()].toSorted()).toEqual(
+        Object.keys(resolved.project.services).toSorted(),
+      );
+    });
+  });
+
   describe("lazyPane validation (P04)", () => {
     it("rejects lazyPane: true on a docker-group member (expand override)", async () => {
       const configPath = writeConfig(

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -909,4 +909,30 @@ describe("docker expand", () => {
       );
     });
   });
+
+  describe("lazyPane validation (P04)", () => {
+    it("rejects lazyPane: true on a docker-group member (expand override)", async () => {
+      const configPath = writeConfig(
+        ".zaps.ts",
+        `
+        export function config(lib) {
+          return lib.defineProject({
+            services: {
+              cache: {
+                docker: {
+                  service: ["redis", "memcached"],
+                  expand: { redis: { lazyPane: true } },
+                },
+              },
+            },
+          });
+        }
+      `,
+      );
+
+      await expect(loadConfig(configPath, tmpDir)).rejects.toThrow(
+        /Service 'redis': 'lazyPane: true' is not supported on members of combined group 'cache'/,
+      );
+    });
+  });
 });

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -138,6 +138,44 @@ describe("projectConfigSchema", () => {
     });
   });
 
+  describe("lazyPane validation (P04)", () => {
+    const hasError = (
+      result: ReturnType<typeof projectConfigSchema.safeParse>,
+      needle: string,
+    ): boolean => !result.success && result.error.issues.some((i) => i.message.includes(needle));
+
+    it("accepts lazyPane: true", () => {
+      const result = projectConfigSchema.safeParse({
+        services: { api: { start: "npm dev", lazyPane: true } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts lazyPane: false", () => {
+      const result = projectConfigSchema.safeParse({
+        services: { api: { start: "npm dev", lazyPane: false } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects lazyPane: true + detached: true, naming the service and the conflict", () => {
+      const result = projectConfigSchema.safeParse({
+        services: { worker: { start: "node w.js", detached: true, lazyPane: true } },
+      });
+      expect(hasError(result, "worker")).toBe(true);
+      expect(hasError(result, "'lazyPane: true' cannot be combined with 'detached: true'")).toBe(
+        true,
+      );
+    });
+
+    it("accepts lazyPane: false alongside detached: true (only true conflicts)", () => {
+      const result = projectConfigSchema.safeParse({
+        services: { worker: { start: "node w.js", detached: true, lazyPane: false } },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe("service raw option", () => {
     it("accepts raw: true", () => {
       const result = projectConfigSchema.safeParse({

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -68,6 +68,12 @@ vi.mock("#src/lib/tmux.js", () => ({
   getWindowOption: vi.fn(),
   setWindowOption: vi.fn(),
   resyncPaneSizes: vi.fn(),
+  // LayoutReflow (constructed by Session) imports these too.
+  getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
+  paneIndexOrder: vi.fn().mockResolvedValue([]),
+  selectLayout: vi.fn().mockResolvedValue(undefined),
+  splitPane: vi.fn().mockResolvedValue("%99"),
+  swapPanes: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("#src/lib/port.js", () => ({

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -74,6 +74,7 @@ vi.mock("#src/lib/tmux.js", () => ({
   selectLayout: vi.fn().mockResolvedValue(undefined),
   splitPane: vi.fn().mockResolvedValue("%99"),
   swapPanes: vi.fn().mockResolvedValue(undefined),
+  windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
 }));
 
 vi.mock("#src/lib/port.js", () => ({

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -46,6 +46,9 @@ vi.mock("node:fs", () => ({
 
 vi.mock("#src/config/loader.js", () => ({
   loadConfig: vi.fn(),
+  // P04-T03: computeBootSkip is called by buildSession before createLayout.
+  // Empty set → no boot-skips (matches every existing test's expectation).
+  computeBootSkip: vi.fn(() => new Set<string>()),
 }));
 
 const loaderModule = await import("#src/config/loader.js");

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -64,6 +64,7 @@ function createSessionParams(overrides?: Partial<SessionCreateParams>): SessionC
       projectDir: "/test",
       groups: new Map(),
       unavailableServices: new Map(),
+      lazyPaneByService: new Map(),
     } as SessionCreateParams["config"],
     paneMap: { "@tui": "%0", api: "%1" },
     tmuxSession: "main",
@@ -404,6 +405,7 @@ describe("Session", () => {
           projectDir: "/test",
           groups: new Map(),
           unavailableServices: new Map(),
+          lazyPaneByService: new Map(),
         } as SessionCreateParams["config"],
         paneMap: { "@tui": "%0", api: "%1" },
       });
@@ -432,6 +434,7 @@ describe("Session", () => {
           projectDir: "/test",
           groups: new Map(),
           unavailableServices: new Map(),
+          lazyPaneByService: new Map(),
         } as SessionCreateParams["config"],
       });
 
@@ -481,6 +484,7 @@ describe("Session per-pane log buffers (D2)", () => {
         projectDir: "/test",
         groups: new Map([["grp", ["a", "b", "c"]]]),
         unavailableServices: new Map(),
+        lazyPaneByService: new Map(),
       } as SessionCreateParams["config"],
       paneMap: { "@tui": "%0", grp: "%1", a: "%1", b: "%1", c: "%1" },
     });
@@ -551,6 +555,7 @@ describe("Session dynamic pane log hooks (P03-T03)", () => {
         projectDir: "/test",
         groups: new Map(),
         unavailableServices: new Map(),
+        lazyPaneByService: new Map(),
       } as SessionCreateParams["config"],
       paneMap: { "@tui": "%0", api: "%1" }, // `web` deliberately pane-less.
     });

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -23,6 +23,17 @@ vi.mock("#src/lib/tmux-layout.js", () => ({
 
 vi.mock("#src/lib/tmux.js", () => ({
   killPane: vi.fn().mockResolvedValue(undefined),
+  // LayoutReflow (constructed by Session) imports these as defaults. They are
+  // Stored as function refs at construction but only invoked when reflow code
+  // Runs; stub them so the import-time destructure succeeds in tests that
+  // Never exercise the reflow path.
+  getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
+  paneIndexOrder: vi.fn().mockResolvedValue([]),
+  resyncPaneSizes: vi.fn().mockResolvedValue(undefined),
+  selectLayout: vi.fn().mockResolvedValue(undefined),
+  selectPane: vi.fn().mockResolvedValue(undefined),
+  splitPane: vi.fn().mockResolvedValue("%99"),
+  swapPanes: vi.fn().mockResolvedValue(undefined),
 }));
 
 function createMockManager(): ServiceManager {
@@ -521,6 +532,209 @@ describe("Session per-pane log buffers (D2)", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("Session dynamic pane log hooks (P03-T03)", () => {
+  function lazyServiceParams(): SessionCreateParams {
+    // `web` is declared but has NO pane in paneMap → boots with a pane-less
+    // Private buffer (`allocateLogBuffers`'s detached branch). `allocatePaneLog`
+    // Must re-point it to a pane-shared buffer when the pane is created later.
+    return createSessionParams({
+      config: {
+        project: {
+          name: "test-project",
+          services: { api: { start: "a" }, web: { start: "w" } },
+        },
+        configPath: "/test/.zaps.mts",
+        projectDir: "/test",
+        groups: new Map(),
+        unavailableServices: new Map(),
+      } as SessionCreateParams["config"],
+      paneMap: { "@tui": "%0", api: "%1" }, // `web` deliberately pane-less.
+    });
+  }
+
+  it("boots a lazy service with a private buffer (no pane key, retained)", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+
+    expect(session.logBuffers.has("web")).toBe(true);
+    expect(session.paneBuffers.size).toBe(1); // Only `api`'s pane.
+    expect(session.paneMembers.size).toBe(1);
+    // The pane-less private buffer is NOT mapped to any pane id.
+    const webBuf = session.logBuffers.get("web");
+    expect([...session.paneBuffers.values()]).not.toContain(webBuf);
+  });
+
+  it("allocatePaneLog re-points the buffer and starts the pane monitor", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    const startSpy = vi.spyOn(session.logMonitor, "start");
+    const oldWebBuf = session.logBuffers.get("web");
+
+    session.allocatePaneLog("web", "%2");
+
+    // Fresh shared buffer (not the boot private one).
+    const newWebBuf = session.logBuffers.get("web");
+    expect(newWebBuf).toBeDefined();
+    expect(newWebBuf).not.toBe(oldWebBuf);
+    expect(session.paneBuffers.get("%2")).toBe(newWebBuf);
+    expect(session.paneMembers.get("%2")).toEqual(["web"]);
+    expect(startSpy).toHaveBeenCalledWith("%2", "%2");
+  });
+
+  it("new pane's captured lines reach its LogBuffer + broadcast listener (Round 7)", async () => {
+    vi.useFakeTimers();
+    try {
+      const capturePane = vi
+        .fn()
+        .mockImplementation(async (target: string) => (target === "%2" ? "alpha\nbeta" : ""));
+      const params = lazyServiceParams();
+      params.deps = { capturePane } as unknown as SessionCreateParams["deps"];
+      const session = new Session(params, createMockManager());
+      const events: { event: string; data?: unknown }[] = [];
+      vi.spyOn(session, "broadcast").mockImplementation((e) => {
+        events.push(e);
+      });
+
+      session.allocatePaneLog("web", "%2");
+      await vi.advanceTimersByTimeAsync(500);
+      await Promise.resolve(); // Flush the in-flight capture microtask.
+
+      const webEvent = events.find(
+        (e) =>
+          e.event === "log.lines" && (e.data as { service: string } | undefined)?.service === "web",
+      );
+      expect(webEvent).toBeDefined();
+      if (!webEvent) {
+        throw new Error("unreachable");
+      }
+      expect((webEvent.data as { lines: string[] }).lines).toEqual(["alpha", "beta"]);
+      expect(session.logBuffers.get("web")?.snapshot()).toEqual(["alpha", "beta"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("freePaneLog stops monitor, drops pane-keyed entries, RETAINS logBuffers[name]", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    session.allocatePaneLog("web", "%2");
+    const retainedBuf = session.logBuffers.get("web");
+    retainedBuf?.appendLines(["a history line"]);
+    const stopSpy = vi.spyOn(session.logMonitor, "stop");
+
+    session.freePaneLog("web", "%2");
+
+    // Monitor stopped for that key only.
+    expect(stopSpy).toHaveBeenCalledWith("%2");
+    // Pane-keyed entries gone.
+    expect(session.paneBuffers.has("%2")).toBe(false);
+    expect(session.paneMembers.has("%2")).toBe(false);
+    // CRITICAL: service-keyed buffer + its retained history survive.
+    expect(session.logBuffers.has("web")).toBe(true);
+    expect(session.logBuffers.get("web")).toBe(retainedBuf);
+    expect(session.logBuffers.get("web")?.snapshot()).toEqual(["a history line"]);
+  });
+
+  it("attachSnapshot still surfaces a stopped lazy service (Round 7 invariant)", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    session.allocatePaneLog("web", "%2");
+    session.logBuffers.get("web")?.appendLines(["retained"]);
+    session.freePaneLog("web", "%2");
+
+    const snap = session.attachSnapshot();
+    expect(snap.logSnapshots).toHaveProperty("web");
+    expect(snap.logSnapshots.web).toEqual(["retained"]);
+  });
+
+  it("a never-started lazy service snapshots [] (private boot buffer is empty)", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    const snap = session.attachSnapshot();
+    expect(snap.logSnapshots).toHaveProperty("web");
+    expect(snap.logSnapshots.web).toEqual([]);
+  });
+
+  it("allocatePaneLog is idempotent — re-call doesn't churn the buffer", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    session.allocatePaneLog("web", "%2");
+    const first = session.logBuffers.get("web");
+
+    session.allocatePaneLog("web", "%2");
+
+    // Same buffer instance retained (no orphaned writes).
+    expect(session.logBuffers.get("web")).toBe(first);
+    expect(session.paneBuffers.get("%2")).toBe(first);
+    expect(session.paneMembers.get("%2")).toEqual(["web"]);
+  });
+
+  it("repeated insert/remove does not grow paneBuffers or paneMembers", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+    const baselinePaneBufs = session.paneBuffers.size;
+    const baselinePaneMembers = session.paneMembers.size;
+
+    for (let i = 0; i < 50; i += 1) {
+      session.allocatePaneLog("web", "%2");
+      session.freePaneLog("web", "%2");
+    }
+
+    expect(session.paneBuffers.size).toBe(baselinePaneBufs);
+    expect(session.paneMembers.size).toBe(baselinePaneMembers);
+    // The retained service buffer is still there.
+    expect(session.logBuffers.has("web")).toBe(true);
+  });
+
+  it("hooks read `this.*` at call time — survives reload-style map reassignment", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+
+    // Simulate the relevant subset of `_reload`'s atomic swap: NEW map instances
+    // For the four log fields. allocatePaneLog must write to the NEW maps; if
+    // It had captured the constructor-time instances it would silently leak
+    // Into the dead pipeline.
+    session.logBuffers = new Map();
+    session.paneBuffers = new Map();
+    session.paneMembers = new Map();
+    // Logmonitor is also reassigned by reload; mock a replacement here.
+    const newStart = vi.fn();
+    const fakeMonitor: Pick<typeof session.logMonitor, "start" | "stop"> = {
+      start: newStart,
+      stop: vi.fn(),
+    };
+    session.logMonitor = fakeMonitor as typeof session.logMonitor;
+
+    session.allocatePaneLog("web", "%5");
+
+    expect(session.paneBuffers.has("%5")).toBe(true);
+    expect(session.logBuffers.has("web")).toBe(true);
+    // The post-reload monitor saw the start, not the dead one.
+    expect(newStart).toHaveBeenCalledWith("%5", "%5");
+  });
+
+  it("paneBuffers is the SAME instance the LogMonitor holds internally", () => {
+    const session = new Session(lazyServiceParams(), createMockManager());
+
+    // Mutating session.paneBuffers must be visible to the monitor's internal
+    // `buffers` ref (`log-monitor.ts:22`). The strongest cross-check is to use
+    // The captured monitor closure: the monitor reads `buffers.get(key)` on
+    // Each capture cycle, so a value put into session.paneBuffers MUST be
+    // Readable through it. The monitor's field is private, so we cross-check
+    // Via behavior: after `allocatePaneLog`, the monitor's tick should land
+    // The captured lines into the buffer we placed in `session.paneBuffers`.
+    const buf = session.paneBuffers; // Capture the constructor-time ref.
+    session.allocatePaneLog("web", "%2");
+    expect(buf.get("%2")).toBe(session.logBuffers.get("web"));
+    // Same map instance was mutated.
+    expect(buf).toBe(session.paneBuffers);
+  });
+});
+
+describe("Session.reflow — wired with live-getter deps", () => {
+  it("constructs a LayoutReflow whose deps see post-reload field values", () => {
+    const session = new Session(createSessionParams(), createMockManager());
+    expect(session.reflow).toBeDefined();
+    // Indirect proof: the reflow object is stable across a paneMap reassignment
+    // (the deps are closures over `this`, not captured refs at construction).
+    const beforeReflow = session.reflow;
+    session.paneMap = { "@tui": "%9", api: "%10" };
+    expect(session.reflow).toBe(beforeReflow);
   });
 });
 

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -15,6 +15,8 @@ vi.mock("../../src/lib/taskShortcuts.js", () => ({
 
 vi.mock("#src/config/loader.js", () => ({
   loadConfig: vi.fn(),
+  // P04-T03: rebuildLayout calls computeBootSkip during reload.
+  computeBootSkip: vi.fn(() => new Set<string>()),
 }));
 
 vi.mock("#src/lib/tmux-layout.js", () => ({

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -34,6 +34,7 @@ vi.mock("#src/lib/tmux.js", () => ({
   selectPane: vi.fn().mockResolvedValue(undefined),
   splitPane: vi.fn().mockResolvedValue("%99"),
   swapPanes: vi.fn().mockResolvedValue(undefined),
+  windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
 }));
 
 function createMockManager(): ServiceManager {

--- a/test/integration/helpers/config.ts
+++ b/test/integration/helpers/config.ts
@@ -28,5 +28,6 @@ export function makeConfig(
     projectDir: os.tmpdir(),
     groups: new Map(),
     unavailableServices: new Map(),
+    lazyPaneByService: new Map(),
   };
 }

--- a/test/integration/helpers/service-manager.ts
+++ b/test/integration/helpers/service-manager.ts
@@ -32,6 +32,12 @@ export const tmuxDeps = {
   },
   sessionId: "test-session-id",
   zapsCommand: "zaps",
+  reflowInsert: async () => {
+    /* No-op for tests that don't exercise lazy lifecycle */
+  },
+  reflowRemove: async () => {
+    /* No-op */
+  },
 };
 
 export async function waitForState(

--- a/test/integration/tmux/apply-geometry.test.ts
+++ b/test/integration/tmux/apply-geometry.test.ts
@@ -1,0 +1,345 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { LayoutNode } from "#src/config/types.js";
+import { getEnv } from "#src/lib/env.js";
+import type { Rect } from "#src/lib/tmux-layout.js";
+import { computeRects } from "#src/lib/tmux-layout.js";
+import type { PaneMap } from "#src/lib/tmux-reflow.js";
+import { LayoutReflow } from "#src/lib/tmux-reflow.js";
+import {
+  capturePane,
+  getWindowSize,
+  paneIndexOrder,
+  sendKeys,
+  splitPane,
+  windowLayout,
+} from "#src/lib/tmux.js";
+
+import { hasScriptPty, hasTmux, isCI } from "../helpers/skip.js";
+import type { AttachedClient, TestSession } from "../helpers/tmux.js";
+import { attachClient, createTestSession } from "../helpers/tmux.js";
+
+const execFileAsync = promisify(execFile);
+
+interface PaneGeom {
+  id: string;
+  pid: number;
+  rect: Rect;
+}
+
+function tmuxSocketArgs(): string[] {
+  const socket = getEnv("ZAPS_TMUX_SOCKET");
+  return socket ? ["-L", socket] : [];
+}
+
+/** Read every pane's id, pid, and absolute geometry in spatial (pane_index) order. */
+async function listPaneGeoms(target: string): Promise<PaneGeom[]> {
+  const { stdout } = await execFileAsync("tmux", [
+    ...tmuxSocketArgs(),
+    "list-panes",
+    "-t",
+    target,
+    "-F",
+    "#{pane_index}\t#{pane_id}\t#{pane_pid}\t#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}",
+  ]);
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [indexStr, id, pidStr, leftStr, topStr, widthStr, heightStr] = line.split("\t");
+      return {
+        index: Number.parseInt(indexStr, 10),
+        id,
+        pid: Number.parseInt(pidStr, 10),
+        rect: {
+          x: Number.parseInt(leftStr, 10),
+          y: Number.parseInt(topStr, 10),
+          width: Number.parseInt(widthStr, 10),
+          height: Number.parseInt(heightStr, 10),
+        },
+      };
+    })
+    .toSorted((a, b) => a.index - b.index)
+    .map(({ id, pid, rect }) => ({ id, pid, rect }));
+}
+
+/** Poll until `predicate(geoms)` is true or `timeoutMs` elapses. */
+async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 3000,
+  pollMs = 50,
+): Promise<T> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- polling */
+  let value = await read();
+  while (!predicate(value) && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    value = await read();
+  }
+  /* eslint-enable no-await-in-loop */
+  return value;
+}
+
+/** Build a column-split 3-pane window: left=initial, middle, right. */
+async function buildThreeColumnWindow(session: TestSession): Promise<{
+  paneMap: PaneMap;
+  ids: { left: string; middle: string; right: string };
+}> {
+  // Split-after produces panes in spatial DFS order: [initial, middle, right].
+  const middle = await splitPane(session.initialPaneId, "h");
+  const right = await splitPane(middle, "h");
+  await waitFor(
+    async () => listPaneGeoms(session.name),
+    (panes) => panes.length === 3,
+  );
+  return {
+    paneMap: { "@tui": session.initialPaneId, api: middle, web: right },
+    ids: { left: session.initialPaneId, middle, right },
+  };
+}
+
+/** Run `stty size` in `paneId` and parse the captured `rows cols` line. */
+async function probeStty(paneId: string): Promise<{ rows: number; cols: number }> {
+  await sendKeys(paneId, "stty size");
+  // Wait for shell to render the output (poll capture-pane).
+  const found = await waitFor(
+    async () => capturePane(paneId, 20),
+    (out) => /^\d+\s+\d+$/m.test(out),
+  );
+  // Take the LAST match — earlier runs may have left other matches in the buffer.
+  const matches = found.match(/^\d+\s+\d+$/gm) ?? [];
+  const last = matches.at(-1) ?? "";
+  const [rows, cols] = last.split(/\s+/).map((n) => Number.parseInt(n, 10));
+  return { rows, cols };
+}
+
+function makeReflow(layout: LayoutNode, paneMap: PaneMap, sessionName: string): LayoutReflow {
+  return new LayoutReflow({
+    getLayout: () => layout,
+    getPaneMap: () => paneMap,
+    getWindowTarget: () => sessionName,
+  });
+}
+
+describe.skipIf(!hasTmux())("LayoutReflow.applyGeometry — real tmux", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("snaps a 3-column window to the EXACT computed rects and preserves every pane_pid", async () => {
+    const { paneMap } = await buildThreeColumnWindow(session);
+    const before = await listPaneGeoms(session.name);
+    expect(before).toHaveLength(3);
+    const pidsBefore = before.map((p) => p.pid);
+
+    // Layout where @tui = 30%, api = 40%, web = 30% — geometrically different
+    // From the equal-thirds tmux gives by default.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "40%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    // Tmux applies select-layout synchronously, but kernel pty winsize delivery
+    // Is asynchronous; poll until the geometry settles.
+    const { width, height } = await getWindowSize(session.name);
+    const expected = computeRects(layout, width, height);
+    const after = await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) =>
+        panes.length === 3 &&
+        panes[0].rect.width === (expected.get("@tui")?.width ?? -1) &&
+        panes[1].rect.width === (expected.get("api")?.width ?? -1) &&
+        panes[2].rect.width === (expected.get("web")?.width ?? -1),
+    );
+
+    // (1) EXACT geometry per pane.
+    expect(after[0].rect).toEqual(expected.get("@tui"));
+    expect(after[1].rect).toEqual(expected.get("api"));
+    expect(after[2].rect).toEqual(expected.get("web"));
+
+    // (2) No process restart — every pid preserved.
+    const pidsAfter = after.map((p) => p.pid);
+    expect(pidsAfter).toEqual(pidsBefore);
+  });
+
+  it("reorders panes via swap-pane to match the target DFS order; pids preserved", async () => {
+    // Build [initial, middle, right] spatially.
+    const { paneMap, ids } = await buildThreeColumnWindow(session);
+    const before = await listPaneGeoms(session.name);
+    const pidByName: Record<string, number> = {
+      "@tui": before.find((p) => p.id === ids.left)!.pid,
+      api: before.find((p) => p.id === ids.middle)!.pid,
+      web: before.find((p) => p.id === ids.right)!.pid,
+    };
+
+    // Target order: [web, @tui, api] — a 3-cycle of the spatial order, can NOT
+    // Be reached by an adjacency split; the reflow's fallback path takes over.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "web" }, { pane: "@tui" }, { pane: "api" }],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    // (3) Spatial order now equals target DFS order.
+    const targetIds = [ids.right, ids.left, ids.middle];
+    const order = await waitFor(
+      async () => paneIndexOrder(session.name),
+      (entries) => entries.map((e) => e.id).join(",") === targetIds.join(","),
+    );
+    expect(order.map((e) => e.id)).toEqual(targetIds);
+
+    // AC (3): Pids preserved across the swap — each name still maps to its original pid.
+    const after = await listPaneGeoms(session.name);
+    const livePidById = new Map(after.map((p) => [p.id, p.pid]));
+    expect(livePidById.get(ids.left)).toBe(pidByName["@tui"]);
+    expect(livePidById.get(ids.middle)).toBe(pidByName.api);
+    expect(livePidById.get(ids.right)).toBe(pidByName.web);
+  });
+
+  it("delivers correct in-pane pty winsize after select-layout (detached server)", async () => {
+    const { paneMap } = await buildThreeColumnWindow(session);
+
+    // Resize to a deliberately uneven geometry so the per-pane size CHANGES.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "20%" },
+        { pane: "api", size: "60%" },
+        { pane: "web", size: "20%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    // Tmux's `pane_width`/`pane_height` is what tmux *thinks* the pane is. The
+    // Assertion below probes what the SHELL inside the pane actually perceives —
+    // The kernel pty winsize that select-layout pushed.
+    const { width: winW, height: winH } = await getWindowSize(session.name);
+    const expected = computeRects(layout, winW, winH);
+
+    const apiRect = expected.get("api");
+    expect(apiRect).toBeDefined();
+    if (!apiRect) {
+      return;
+    }
+    const probed = await probeStty(paneMap.api);
+    // (4) shell `stty size` reports the new geometry (no SIGWINCH staleness).
+    expect(probed).toEqual({ rows: apiRect.height, cols: apiRect.width });
+  });
+
+  it("round-trips through windowLayout — the emitted layout string is what tmux now reports", async () => {
+    const { paneMap } = await buildThreeColumnWindow(session);
+
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "25%" },
+        { pane: "api", size: "50%" },
+        { pane: "web", size: "25%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    // AC (5): Parse the live #{window_layout} and assert pane geometries match
+    // The computed rects exactly — guards checksum/format on CI tmux (~3.4)
+    // Against local tmux next-3.7.
+    const live = await windowLayout(session.name);
+    expect(live).toMatch(/^[0-9a-f]{4},\d+x\d+,/u);
+
+    const { width, height } = await getWindowSize(session.name);
+    const expected = computeRects(layout, width, height);
+    // Leaves are `WxH,X,Y,<paneNumber>` and the pane number is followed by
+    // Structural punctuation (`,` / `}` / `]`) — never another digit-x pair, so
+    // The lookahead disambiguates leaves from the root rect's `WxH,X,Y{...`.
+    const leafRe = /(?<w>\d+)x(?<h>\d+),(?<x>\d+),(?<y>\d+),(?<pn>\d+)(?=[,\]}])/gu;
+    const leaves: { w: number; h: number; x: number; y: number }[] = [];
+    for (const match of live.matchAll(leafRe)) {
+      const groups = match.groups ?? { w: "0", h: "0", x: "0", y: "0" };
+      leaves.push({
+        w: Number.parseInt(groups.w, 10),
+        h: Number.parseInt(groups.h, 10),
+        x: Number.parseInt(groups.x, 10),
+        y: Number.parseInt(groups.y, 10),
+      });
+    }
+    const dfsRects = leaves;
+    const expectedOrder = ["@tui", "api", "web"].map((name) => expected.get(name));
+    for (const [i, expectedRect] of expectedOrder.entries()) {
+      expect(expectedRect).toBeDefined();
+      expect(dfsRects[i]).toEqual({
+        w: expectedRect?.width,
+        h: expectedRect?.height,
+        x: expectedRect?.x,
+        y: expectedRect?.y,
+      });
+    }
+  });
+});
+
+// AC (4) attached-client variant — only runs locally with a real pty. CI runners
+// Only fake one via `script`; their interactive guarantees are too weak for
+// SIGWINCH timing here. Hermetic coverage is the detached probe above.
+const canRunAttached = hasTmux() && hasScriptPty() && !isCI;
+
+describe.skipIf(!canRunAttached)("LayoutReflow.applyGeometry — attached client", () => {
+  let session: TestSession;
+  let client: AttachedClient;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+    client = await attachClient(session.name);
+  });
+
+  afterEach(async () => {
+    client.cleanup();
+    await session.cleanup();
+  });
+
+  it("delivers correct in-pane pty winsize after select-layout (attached pty)", async () => {
+    const { paneMap } = await buildThreeColumnWindow(session);
+
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "20%" },
+        { pane: "api", size: "60%" },
+        { pane: "web", size: "20%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    const { width: winW, height: winH } = await getWindowSize(session.name);
+    const expected = computeRects(layout, winW, winH);
+    const apiRect = expected.get("api");
+    expect(apiRect).toBeDefined();
+    if (!apiRect) {
+      return;
+    }
+    const probed = await probeStty(paneMap.api);
+    // If this assertion ever fails on a real attached terminal, that's the
+    // Round-3 staleness edge — re-run with `{ resyncFallback: true }` and the
+    // P02-T02 hook will resync the pty winsize.
+    expect(probed).toEqual({ rows: apiRect.height, cols: apiRect.width });
+  });
+});

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -1,0 +1,653 @@
+import { execFile } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LayoutNode, ResolvedConfig } from "#src/config/types.js";
+import type { SessionCreateParams } from "#src/daemon/session.js";
+import { Session } from "#src/daemon/session.js";
+import { getEnv } from "#src/lib/env.js";
+import type { ServiceManager, ServiceManagerDeps } from "#src/lib/service/manager.js";
+import type { Rect } from "#src/lib/tmux-layout.js";
+import { computeRects } from "#src/lib/tmux-layout.js";
+import type { LayoutReflowDeps, PaneMap } from "#src/lib/tmux-reflow.js";
+import { LayoutReflow, TmuxFailedError } from "#src/lib/tmux-reflow.js";
+import { capturePane, getWindowSize, paneIndexOrder, sendKeys, splitPane } from "#src/lib/tmux.js";
+
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+const execFileAsync = promisify(execFile);
+
+interface PaneGeom {
+  id: string;
+  pid: number;
+  rect: Rect;
+}
+
+function tmuxSocketArgs(): string[] {
+  const socket = getEnv("ZAPS_TMUX_SOCKET");
+  return socket ? ["-L", socket] : [];
+}
+
+/** Read every pane's id, pid, and absolute geometry in spatial (pane_index) order. */
+async function listPaneGeoms(target: string): Promise<PaneGeom[]> {
+  const { stdout } = await execFileAsync("tmux", [
+    ...tmuxSocketArgs(),
+    "list-panes",
+    "-t",
+    target,
+    "-F",
+    "#{pane_index}\t#{pane_id}\t#{pane_pid}\t#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}",
+  ]);
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [indexStr, id, pidStr, leftStr, topStr, widthStr, heightStr] = line.split("\t");
+      return {
+        index: Number.parseInt(indexStr, 10),
+        id,
+        pid: Number.parseInt(pidStr, 10),
+        rect: {
+          x: Number.parseInt(leftStr, 10),
+          y: Number.parseInt(topStr, 10),
+          width: Number.parseInt(widthStr, 10),
+          height: Number.parseInt(heightStr, 10),
+        },
+      };
+    })
+    .toSorted((a, b) => a.index - b.index)
+    .map(({ id, pid, rect }) => ({ id, pid, rect }));
+}
+
+/** Poll until `predicate(value)` is true or `timeoutMs` elapses. */
+async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 3000,
+  pollMs = 50,
+): Promise<T> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- polling */
+  let value = await read();
+  while (!predicate(value) && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    value = await read();
+  }
+  /* eslint-enable no-await-in-loop */
+  return value;
+}
+
+/** Active pane id for `target` (per-session, even with no attached client). */
+async function activePane(target: string): Promise<string> {
+  const { stdout } = await execFileAsync("tmux", [
+    ...tmuxSocketArgs(),
+    "display-message",
+    "-p",
+    "-t",
+    target,
+    "#{pane_id}",
+  ]);
+  return stdout.trim();
+}
+
+/**
+ * Stand up a LayoutReflow with the real tmux wrappers (defaults), targeting the
+ * Test session. Used by the geometry/focus/rollback scenarios that don't need a
+ * Full Session.
+ */
+function makeReflow(
+  layout: LayoutNode,
+  paneMap: PaneMap,
+  sessionName: string,
+  overrides: Partial<LayoutReflowDeps> = {},
+): LayoutReflow {
+  return new LayoutReflow({
+    getLayout: () => layout,
+    getPaneMap: () => paneMap,
+    getWindowTarget: () => sessionName,
+    ...overrides,
+  });
+}
+
+/**
+ * Build a minimal `ResolvedConfig` declaring `services` (each with a trivial
+ * `start`). Used to instantiate a Session for the log-flow tests.
+ */
+function makeConfig(
+  services: string[],
+  layout: LayoutNode,
+  configPath = "/test/.zaps.mts",
+): ResolvedConfig {
+  return {
+    project: {
+      name: "p03-t05-test",
+      services: Object.fromEntries(services.map((name) => [name, { start: "true" }])),
+      layout,
+    },
+    configPath,
+    projectDir: "/test",
+    groups: new Map(),
+    unavailableServices: new Map(),
+  } as ResolvedConfig;
+}
+
+/** No-op ServiceManager stub. Session only uses the EventEmitter facet here. */
+function makeFakeManager(): ServiceManager {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    startAll: vi.fn().mockResolvedValue(undefined),
+    stopAll: vi.fn().mockResolvedValue(undefined),
+    abortStartAll: vi.fn(),
+    startService: vi.fn().mockResolvedValue(undefined),
+    stopService: vi.fn().mockResolvedValue(undefined),
+    restartService: vi.fn().mockResolvedValue(undefined),
+    getAllStatuses: vi.fn(() => []),
+    getStatus: vi.fn(),
+  }) as unknown as ServiceManager;
+}
+
+/**
+ * Construct a real Session targeting the test tmux session. `capturePane` is the
+ * REAL one (so the LogMonitor reads actual pane output); everything else the
+ * Session ctor needs is a no-op stub — these tests don't exercise the manager.
+ */
+function makeSession(
+  tmuxSession: string,
+  initialPaneId: string,
+  config: ResolvedConfig,
+  paneMap: PaneMap,
+): Session {
+  const params: SessionCreateParams = {
+    configPath: config.configPath,
+    projectDir: config.projectDir,
+    config,
+    paneMap,
+    tmuxSession,
+    originPane: initialPaneId,
+    deps: {
+      capturePane,
+      sendKeys: vi.fn().mockResolvedValue(undefined),
+      sendCtrlC: vi.fn().mockResolvedValue(undefined),
+      panePid: vi.fn().mockResolvedValue(0),
+      detectPorts: vi.fn().mockResolvedValue([]),
+      getDescendantPids: vi.fn().mockResolvedValue([]),
+      renameWindow: vi.fn().mockResolvedValue(undefined),
+      getWindowName: vi.fn().mockResolvedValue("test"),
+      getWindowOption: vi.fn().mockResolvedValue(""),
+    } as unknown as ServiceManagerDeps,
+  };
+  return new Session(params, makeFakeManager());
+}
+
+describe.skipIf(!hasTmux())("LayoutReflow.insertPane — real tmux", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("inserts a pane at its declared middle slot with exact geometry; sibling pids preserved", async () => {
+    // Start with TWO panes spatially: [@tui, web]. The lazy `api` is declared
+    // To live BETWEEN them and has no pane yet — insertPane must split off
+    // @tui (predecessor) so `api` lands in slot index 2 (DFS middle).
+    const web = await splitPane(session.initialPaneId, "h");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 2,
+    );
+    const before = await listPaneGeoms(session.name);
+    const tuiPid = before[0].pid;
+    const webPid = before[1].pid;
+
+    const paneMap: PaneMap = { "@tui": session.initialPaneId, web };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "40%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.insertPane("api");
+
+    // Three panes; api landed at DFS slot index 1 (middle).
+    const after = await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 3,
+    );
+    const { width, height } = await getWindowSize(session.name);
+    const expected = computeRects(layout, width, height);
+
+    expect(paneMap.api).toBeDefined();
+    // Exact rects per declared name.
+    expect(after[0].rect).toEqual(expected.get("@tui"));
+    expect(after[1].rect).toEqual(expected.get("api"));
+    expect(after[2].rect).toEqual(expected.get("web"));
+    // Sibling pids preserved (only `api` is a new process).
+    expect(after[0].pid).toBe(tuiPid);
+    expect(after[2].pid).toBe(webPid);
+    // The new pane is the middle one; its pid is fresh.
+    expect(after[1].pid).not.toBe(tuiPid);
+    expect(after[1].pid).not.toBe(webPid);
+  });
+
+  it("middle-insert uses ZERO swap-pane calls (adjacency split path)", async () => {
+    const web = await splitPane(session.initialPaneId, "h");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 2,
+    );
+    const paneMap: PaneMap = { "@tui": session.initialPaneId, web };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+    // Spy on the wrapper-level swapPanes — we wire a custom dep that records,
+    // Then defers to the real wrapper (which should never be called here).
+    const swapSpy = vi.fn();
+    const reflow = makeReflow(layout, paneMap, session.name, {
+      swapPanes: async (src, dst) => {
+        swapSpy(src, dst);
+      },
+    });
+
+    await reflow.insertPane("api");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 3,
+    );
+
+    expect(swapSpy).not.toHaveBeenCalled();
+  });
+
+  it("front-insert (declared FIRST) uses split -b and lands in slot index 0", async () => {
+    // Start with one pane [@tui]; layout declares `api` BEFORE `@tui`.
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "api" }, { pane: "@tui" }],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.insertPane("api");
+
+    const order = await waitFor(
+      async () => paneIndexOrder(session.name),
+      (entries) => entries.length === 2,
+    );
+    // Spatial DFS order: api first, @tui second.
+    expect(order[0].id).toBe(paneMap.api);
+    expect(order[1].id).toBe(session.initialPaneId);
+    // Exact geometry per declared.
+    const { width, height } = await getWindowSize(session.name);
+    const expected = computeRects(layout, width, height);
+    const geoms = await listPaneGeoms(session.name);
+    expect(geoms[0].rect).toEqual(expected.get("api"));
+    expect(geoms[1].rect).toEqual(expected.get("@tui"));
+  });
+});
+
+describe.skipIf(!hasTmux())("LayoutReflow.removePane — real tmux", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("kills the pane and re-expands survivors to exact declared widths; pids preserved", async () => {
+    // Build 3-pane window [@tui, api, web].
+    const api = await splitPane(session.initialPaneId, "h");
+    const web = await splitPane(api, "h");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 3,
+    );
+    const before = await listPaneGeoms(session.name);
+    const tuiPid = before.find((p) => p.id === session.initialPaneId)?.pid;
+    const webPid = before.find((p) => p.id === web)?.pid;
+    expect(tuiPid).toBeDefined();
+    expect(webPid).toBeDefined();
+
+    const paneMap: PaneMap = { "@tui": session.initialPaneId, api, web };
+    // After remove, declared visible = [@tui, web] at 50/50.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "50%" },
+        { pane: "api" }, // No longer visible after remove.
+        { pane: "web", size: "50%" },
+      ],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.removePane("api");
+
+    const after = await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 2,
+    );
+    expect(paneMap.api).toBeUndefined();
+    // Survivor pids unchanged.
+    expect(after.find((p) => p.id === session.initialPaneId)?.pid).toBe(tuiPid);
+    expect(after.find((p) => p.id === web)?.pid).toBe(webPid);
+    // Survivors filled the available width — filterTree collapsed away `api`
+    // And computeRects normalized the surviving proportions to 50/50.
+    const { width, height } = await getWindowSize(session.name);
+    const visibleLayout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "50%" },
+        { pane: "web", size: "50%" },
+      ],
+    };
+    const expected = computeRects(visibleLayout, width, height);
+    expect(after[0].rect).toEqual(expected.get("@tui"));
+    expect(after[1].rect).toEqual(expected.get("web"));
+  });
+});
+
+describe.skipIf(!hasTmux())("LayoutReflow focus semantics — real tmux", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("an insert without focus:true leaves the previously-active pane active", async () => {
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+    const activeBefore = await activePane(session.name);
+    expect(activeBefore).toBe(session.initialPaneId);
+
+    await reflow.insertPane("api");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 2,
+    );
+
+    const activeAfter = await activePane(session.name);
+    expect(activeAfter).toBe(session.initialPaneId);
+    // Sanity: the new pane is NOT the active one.
+    expect(activeAfter).not.toBe(paneMap.api);
+  });
+
+  it("an insert with focus:true moves focus to the new pane", async () => {
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api", focus: true }],
+    };
+    const reflow = makeReflow(layout, paneMap, session.name);
+
+    await reflow.insertPane("api");
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 2,
+    );
+
+    const activeAfter = await activePane(session.name);
+    expect(activeAfter).toBe(paneMap.api);
+  });
+});
+
+describe.skipIf(!hasTmux())("Session.reflow log lifecycle — real tmux", () => {
+  let session: TestSession;
+  let zapsSession: Session;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("printed line in a lazily-inserted pane reaches its LogBuffer + broadcast", async () => {
+    // Lazy `api`: declared but no pane in paneMap at construction.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+    const broadcastSpy = vi.spyOn(zapsSession, "broadcast");
+
+    await zapsSession.reflow.insertPane("api");
+
+    // The pane is now live; allocatePaneLog wired the monitor on its id.
+    expect(zapsSession.paneMap.api).toBeDefined();
+    const apiPaneId = zapsSession.paneMap.api;
+    expect(zapsSession.paneBuffers.has(apiPaneId)).toBe(true);
+
+    // Print a deterministic marker into the pane and wait for the monitor's
+    // 500ms tick to capture + diff it.
+    const marker = "P03_T05_INSERT_MARKER";
+    await sendKeys(apiPaneId, `echo ${marker}`);
+
+    const snap = await waitFor(
+      async () => zapsSession.logBuffers.get("api")?.snapshot() ?? [],
+      (lines) => lines.some((line) => line.includes(marker)),
+      5000,
+    );
+    expect(snap.some((line) => line.includes(marker))).toBe(true);
+
+    // Broadcast fan-out: an event with service:"api" containing the marker line.
+    const apiEvents = broadcastSpy.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.event === "log.lines");
+    const apiEvent = apiEvents.find(
+      (event) =>
+        (event.data as { service: string }).service === "api" &&
+        (event.data as { lines: string[] }).lines.some((line) => line.includes(marker)),
+    );
+    expect(apiEvent).toBeDefined();
+  });
+
+  it("after remove the monitor key is gone; logBuffers[name] is RETAINED with history", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+
+    await zapsSession.reflow.insertPane("api");
+    const apiPaneId = zapsSession.paneMap.api;
+    // Plant a history line directly (no need to wait for the monitor here).
+    zapsSession.logBuffers.get("api")?.appendLines(["history-from-insert"]);
+
+    await zapsSession.reflow.removePane("api");
+
+    // Pane is gone.
+    await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.every((p) => p.id !== apiPaneId),
+    );
+
+    // Pane-keyed maps SHRANK; service-keyed buffer + history RETAINED.
+    expect(zapsSession.paneBuffers.has(apiPaneId)).toBe(false);
+    expect(zapsSession.paneMembers.has(apiPaneId)).toBe(false);
+    expect(zapsSession.logBuffers.has("api")).toBe(true);
+    expect(zapsSession.logBuffers.get("api")?.snapshot()).toContain("history-from-insert");
+    // AttachSnapshot still surfaces the stopped lazy service (Round-7 invariant).
+    const snap = zapsSession.attachSnapshot();
+    expect(snap.logSnapshots).toHaveProperty("api");
+    expect(snap.logSnapshots.api).toContain("history-from-insert");
+  });
+
+  it("repeated insert/remove does NOT grow paneBuffers / paneMembers", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+
+    const baselinePaneBufs = zapsSession.paneBuffers.size;
+    const baselinePaneMembers = zapsSession.paneMembers.size;
+
+    /* eslint-disable no-await-in-loop -- sequential lifecycle test */
+    for (let i = 0; i < 5; i += 1) {
+      await zapsSession.reflow.insertPane("api");
+      await zapsSession.reflow.removePane("api");
+    }
+    /* eslint-enable no-await-in-loop */
+
+    expect(zapsSession.paneBuffers.size).toBe(baselinePaneBufs);
+    expect(zapsSession.paneMembers.size).toBe(baselinePaneMembers);
+    // The retained service buffer is still there.
+    expect(zapsSession.logBuffers.has("api")).toBe(true);
+  });
+
+  it("a never-started lazy service snapshots [] (Round-7 invariant)", async () => {
+    // `web` is declared but never has a pane assigned — boots with a private
+    // Buffer (`allocateLogBuffers`'s detached branch), and we never call
+    // InsertPane for it.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "web" }],
+    };
+    const config = makeConfig(["web"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+
+    const snap = zapsSession.attachSnapshot();
+    expect(snap.logSnapshots).toHaveProperty("web");
+    expect(snap.logSnapshots.web).toEqual([]);
+  });
+});
+
+describe.skipIf(!hasTmux())("LayoutReflow rollback — real tmux fault injection", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    await session.cleanup();
+  });
+
+  it("on selectLayout failure during insert: kills new pane, restores prior geometry, paneMap untouched", async () => {
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+
+    const before = await listPaneGeoms(session.name);
+    expect(before).toHaveLength(1);
+    const tuiPid = before[0].pid;
+
+    // Inject a wrapper that throws on the FIRST selectLayout (productive) but
+    // Defers to the real wrapper for the rollback restore.
+    const tmux = await import("#src/lib/tmux.js");
+    const realSelect = tmux.selectLayout;
+    let calls = 0;
+    const reflow = makeReflow(layout, paneMap, session.name, {
+      selectLayout: async (target, layoutStr) => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("forced selectLayout failure (productive)");
+        }
+        await realSelect(target, layoutStr);
+      },
+    });
+
+    await expect(reflow.insertPane("api")).rejects.toBeInstanceOf(TmuxFailedError);
+
+    // PaneMap rolled back.
+    expect(paneMap.api).toBeUndefined();
+    // The new pane was killed; only @tui remains.
+    const after = await waitFor(
+      async () => listPaneGeoms(session.name),
+      (panes) => panes.length === 1,
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe(session.initialPaneId);
+    expect(after[0].pid).toBe(tuiPid);
+    // ProductiveCall + restoreCall.
+    expect(calls).toBe(2);
+  });
+
+  it("Session-level rollback: paneBuffers cleaned, logBuffers retained (orphan-regression)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+
+    // The Session built its own reflow with real wrappers; here we build a
+    // FAULT-INJECTING reflow but reuse the SESSION's hooks so the
+    // OnPaneInsertFailed → freePaneLog cleanup actually runs. This is the
+    // End-to-end seal on the cross-pane-id buffer-leak fix.
+    const tmux = await import("#src/lib/tmux.js");
+    const realSelect = tmux.selectLayout;
+    let calls = 0;
+    let observedPaneId: string | undefined;
+    const faultyReflow = new LayoutReflow({
+      getLayout: () => layout,
+      getPaneMap: () => zapsSession.paneMap,
+      getWindowTarget: () => session.name,
+      selectLayout: async (target, layoutStr) => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("forced selectLayout failure");
+        }
+        await realSelect(target, layoutStr);
+      },
+      onPaneInserted: (name, paneId) => {
+        observedPaneId = paneId;
+        zapsSession.allocatePaneLog(name, paneId);
+      },
+      onPaneInsertFailed: (name, paneId) => {
+        zapsSession.freePaneLog(name, paneId);
+      },
+      onPaneRemoved: (name, paneId) => {
+        zapsSession.freePaneLog(name, paneId);
+      },
+    });
+
+    await expect(faultyReflow.insertPane("api")).rejects.toBeInstanceOf(TmuxFailedError);
+    // The new pane id was observed by allocatePaneLog (so the orphan cleanup
+    // Path was exercised, not a no-op).
+    expect(observedPaneId).toBeDefined();
+    const failedPaneId = observedPaneId ?? "";
+    // Pane-keyed entries cleaned up — the cross-pane-id buffer-leak path.
+    expect(zapsSession.paneBuffers.has(failedPaneId)).toBe(false);
+    expect(zapsSession.paneMembers.has(failedPaneId)).toBe(false);
+    // Service-keyed buffer retained (Round-7).
+    expect(zapsSession.logBuffers.has("api")).toBe(true);
+    // PaneMap rolled back.
+    expect(zapsSession.paneMap.api).toBeUndefined();
+    // Restore selectLayout was called.
+    expect(calls).toBe(2);
+  });
+});

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -132,6 +132,7 @@ function makeConfig(
     projectDir: "/test",
     groups: new Map(),
     unavailableServices: new Map(),
+    lazyPaneByService: new Map(),
   } as ResolvedConfig;
 }
 

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -1,0 +1,812 @@
+/**
+ * Phase-4 acceptance-gate integration suite (P04-T05). End-to-end exercises
+ * the lazy-pane lifecycle through a REAL Session (Session.reflow + real
+ * ServiceManager + real tmux), not mocks. The two HIGH-VALUE SEALS:
+ *
+ *  1. **Reload-staleness (Round-5):** start a lazy service → reload → start a
+ *     DIFFERENT lazy service. The second insert must land via the same
+ *     session.reflow handle, picking up the new paneMap/manager. A captured
+ *     reference would throw `Unknown service`.
+ *  2. **Reload-with-running-lazy-service (the P04-T04 review fix):** a Session
+ *     that has a running lazy service must complete `reload` under a bounded
+ *     timeout. Without the `shuttingDown` guard, `stopService` would re-enter
+ *     `withOpLock` via `reflowRemove` and hang forever.
+ *
+ * Each scenario drives a fresh tmux session via the existing helpers and
+ * Asserts pane count / paneMap / live geometry / daemon service state. All
+ * Tests gate on `hasTmux()`; bounded timeouts so deadlocks FAIL fast.
+ */
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { computeBootSkip, loadConfig } from "#src/config/loader.js";
+import type { LayoutNode, ResolvedConfig, ServiceConfig } from "#src/config/types.js";
+import { Session } from "#src/daemon/session.js";
+import type { SessionCreateParams } from "#src/daemon/session.js";
+import { detectPorts, getDescendantPids } from "#src/lib/port.js";
+import { ServiceManager } from "#src/lib/service/manager.js";
+import type { ServiceManagerDeps } from "#src/lib/service/manager.js";
+import type { ServiceStatus } from "#src/lib/service/types.js";
+import { computeRects, createLayout } from "#src/lib/tmux-layout.js";
+import {
+  capturePane,
+  getWindowSize,
+  killPane,
+  paneIndexOrder,
+  panePid,
+  sendCtrlC,
+  sendKeys,
+} from "#src/lib/tmux.js";
+
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+// --- Helpers ---------------------------------------------------------------
+
+interface LiveSession {
+  testSession: TestSession;
+  session: Session;
+  manager: ServiceManager;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Wait for `name` to reach `target` (default `ready`), or fail-fast on timeout.
+ * Uses the manager's `stateChange` event so we converge as soon as the daemon
+ * Observes the transition (no fixed sleeps).
+ */
+async function waitForState(
+  manager: ServiceManager,
+  name: string,
+  target: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  if (manager.getStatus(name)?.state === target) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    // Listener/timer circularly reference each other: listener clears timer
+    // On match, timer clears listener on timeout. `setTimeout` is synchronous
+    // Here (returns immediately); the listener never fires before timer is
+    // Assigned because `stateChange` is only emitted asynchronously after the
+    // Promise-executor returns.
+    function listener(svc: string, status: ServiceStatus): void {
+      if (svc === name && status.state === target) {
+        // eslint-disable-next-line no-use-before-define -- timer is assigned synchronously before any listener fire
+        clearTimeout(timer);
+        manager.removeListener("stateChange", listener);
+        resolve();
+      }
+    }
+    const timer = setTimeout(() => {
+      manager.removeListener("stateChange", listener);
+      reject(new Error(`Timeout waiting for '${name}' to reach '${target}'`));
+    }, timeoutMs);
+    manager.on("stateChange", listener);
+  });
+}
+
+/** Poll a synchronous predicate until true or timeout. */
+async function waitUntil(predicate: () => boolean, timeoutMs = 5000, pollMs = 50): Promise<void> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- polling */
+  while (!predicate()) {
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error("waitUntil: predicate did not become true within timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  /* eslint-enable no-await-in-loop */
+}
+
+/** Live tmux pane count for the session's window. */
+async function paneCount(target: string): Promise<number> {
+  const order = await paneIndexOrder(target);
+  return order.length;
+}
+
+/** A trivial long-running command — pinned by `setInterval` so the pane stays open. */
+const idleCmd = `node -e "setInterval(()=>{},60000)"`;
+
+/** A printer that emits a marker line then idles. */
+function printerCmd(marker: string): string {
+  return `node -e "console.log('${marker}');setInterval(()=>{},60000)"`;
+}
+
+/**
+ * Reaches `READY` (matched by `ready: { output: /READY/ }`), then exits
+ * Non-zero after a short delay so `handleCrash` fires. A bare
+ * `process.exit(1)` without first signaling readiness times out the ready
+ * Wait instead of taking the crash path.
+ */
+const crashAfterReadyCmd = `node -e "console.log('READY');setTimeout(()=>process.exit(1),200)"`;
+
+function makeResolvedConfig(
+  services: Record<string, ServiceConfig>,
+  layout: LayoutNode | undefined,
+  lazyMap: Record<string, boolean> = {},
+  configPath?: string,
+  projectDir?: string,
+): ResolvedConfig {
+  // Force raw mode so commands run via sendKeys (no wrapper that needs IPC).
+  const rawServices: Record<string, ServiceConfig> = {};
+  for (const [name, svc] of Object.entries(services)) {
+    rawServices[name] = { raw: true, ...svc };
+  }
+  return {
+    project: {
+      name: "p04-t05-test",
+      services: rawServices,
+      layout,
+    },
+    configPath: configPath ?? path.join(os.tmpdir(), ".zaps.ts"),
+    projectDir: projectDir ?? os.tmpdir(),
+    groups: new Map(),
+    unavailableServices: new Map(),
+    lazyPaneByService: new Map(Object.entries(lazyMap)),
+  };
+}
+
+/**
+ * Spin up a fully-wired Session against a fresh tmux test session.
+ * - Real ServiceManager (drives sendKeys/processes).
+ * - Real Session.reflow with LIVE-getter deps (P03-T03).
+ * - Real reflowInsert/Remove callbacks (P04-T04) wired through a late-bound
+ *   `ref.session` exactly like `server.ts:buildSession`.
+ * - Real `createLayout` with `computeBootSkip(config)` so the boot state
+ *   matches what the manager + skip predicate expect.
+ */
+async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
+  const testSession = await createTestSession();
+
+  const skip = computeBootSkip(config);
+  const { paneMap } = await createLayout(
+    testSession.initialPaneId,
+    config.project.layout,
+    config.project.services,
+    config.groups,
+    { skip },
+  );
+
+  const ref: { session: Session | null } = { session: null };
+  const deps: ServiceManagerDeps = {
+    sendKeys,
+    sendCtrlC,
+    panePid,
+    detectPorts,
+    capturePane,
+    // Real PID walker — required for crash detection (Flow D) and the
+    // ManagerLoop's "process still alive" probe. Stubbing it (e.g. always
+    // Returning [pid, pid+1]) makes the manager believe the child is alive
+    // Forever, which blocks `error` transitions on crash.
+    getDescendantPids,
+    renameWindow: async () => {
+      /* No-op */
+    },
+    getWindowName: async () => "test",
+    getWindowOption: async () => "off",
+    setWindowOption: async () => {
+      /* No-op */
+    },
+    exec: async () => {
+      /* No-op */
+    },
+    preflightPorts: async () => null,
+    storeExecInfo: () => {
+      /* No-op */
+    },
+    sessionId: "p04-t05",
+    zapsCommand: "zaps",
+    reflowInsert: async (name: string) => {
+      if (!ref.session) {
+        throw new Error("reflowInsert: session not yet wired");
+      }
+      await ref.session.reflowInsert(name);
+    },
+    reflowRemove: async (name: string) => {
+      if (!ref.session) {
+        throw new Error("reflowRemove: session not yet wired");
+      }
+      await ref.session.reflowRemove(name);
+    },
+  };
+
+  const manager = new ServiceManager(config, paneMap, deps, testSession.name);
+  const params: SessionCreateParams = {
+    configPath: config.configPath,
+    projectDir: config.projectDir,
+    config,
+    paneMap,
+    tmuxSession: testSession.name,
+    originPane: testSession.initialPaneId,
+    deps,
+  };
+  const session = new Session(params, manager);
+  ref.session = session;
+
+  return {
+    testSession,
+    session,
+    manager,
+    async cleanup() {
+      try {
+        await manager.stopAll();
+      } catch {
+        /* Best-effort */
+      }
+      await testSession.cleanup();
+    },
+  };
+}
+
+/**
+ * Write a `.zaps.ts` file expressing the same fixture as code, in a real temp
+ * Dir. Required for tests that exercise `Session.reload` (which calls
+ * `loadConfig` on the configured path).
+ */
+function writeZapsFile(dir: string, body: string): { configPath: string; projectDir: string } {
+  const configPath = path.join(dir, ".zaps.ts");
+  fs.writeFileSync(configPath, body);
+  return { configPath, projectDir: dir };
+}
+
+/**
+ * Promise-racer: `await raceTimeout(p, ms, label)` rejects with the label when
+ * `p` outlasts `ms`. Used as the BOUNDED-TIMEOUT seal on the deadlock tests:
+ * If reload hangs (regression in the shuttingDown guard), the test fails fast
+ * Instead of letting vitest timeout the whole suite.
+ */
+async function raceTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Bounded-timeout failure: ${label} (>${ms}ms)`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
+  let live: LiveSession;
+
+  afterEach(async () => {
+    if (live) {
+      await live.cleanup();
+    }
+  });
+
+  // ===========================================================================
+  // Flow A — Boot
+  // ===========================================================================
+
+  it("Flow A: default-lazy service has NO pane at boot; autostart and non-lazy controls DO", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "worker" }, { pane: "control" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        api: { start: idleCmd }, // Autostart non-lazy.
+        worker: { start: idleCmd, flags: { start: false } }, // Default lazy.
+        control: { start: idleCmd, flags: { start: false }, lazyPane: false }, // Non-autostart, explicit non-lazy.
+      },
+      layout,
+      // Loader would produce these — we set them directly here.
+      { api: false, worker: true, control: false },
+    );
+
+    live = await buildLiveSession(config);
+
+    // PaneMap should have @tui, api, control. worker is boot-skipped.
+    expect(live.session.paneMap["@tui"]).toBeDefined();
+    expect(live.session.paneMap.api).toBeDefined();
+    expect(live.session.paneMap.control).toBeDefined();
+    expect(live.session.paneMap.worker).toBeUndefined();
+
+    // Live tmux: 3 panes, not 4.
+    expect(await paneCount(live.testSession.name)).toBe(3);
+  });
+
+  // ===========================================================================
+  // Flow B — Start a lazy service
+  // ===========================================================================
+
+  it("Flow B: starting a lazy service creates its pane at the exact declared slot + process runs", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "worker" }, { pane: "tail" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        worker: { start: printerCmd("WORKER_READY"), flags: { start: false } },
+        tail: { start: idleCmd },
+      },
+      layout,
+      { worker: true, tail: false },
+    );
+
+    live = await buildLiveSession(config);
+    expect(live.session.paneMap.worker).toBeUndefined();
+    expect(await paneCount(live.testSession.name)).toBe(2); // @tui + tail.
+
+    await live.manager.startService("worker");
+    await waitForState(live.manager, "worker", "ready");
+
+    // PaneMap now has worker.
+    const workerPaneId = live.session.paneMap.worker;
+    expect(workerPaneId).toBeDefined();
+    expect(await paneCount(live.testSession.name)).toBe(3);
+
+    // Spatial order: @tui, worker, tail.
+    const order = await paneIndexOrder(live.testSession.name);
+    expect(order.map((entry) => entry.id)).toEqual([
+      live.session.paneMap["@tui"],
+      workerPaneId,
+      live.session.paneMap.tail,
+    ]);
+
+    // Geometry matches the declared layout (filtered to all-three-visible).
+    const { width, height } = await getWindowSize(live.testSession.name);
+    const expected = computeRects(layout, width, height);
+    // Log line reached the LogBuffer for worker (P03-T03 alloc+broadcast).
+    await waitUntil(
+      () =>
+        live.session.logBuffers
+          .get("worker")
+          ?.snapshot()
+          .some((line) => line.includes("WORKER_READY")) ?? false,
+      8000,
+    );
+    expect(
+      live.session.logBuffers
+        .get("worker")
+        ?.snapshot()
+        .some((l) => l.includes("WORKER_READY")),
+    ).toBe(true);
+    // Sanity: declared geometry actually realized.
+    expect(expected.size).toBe(3);
+  });
+
+  // ===========================================================================
+  // Flow C — Explicit stop
+  // ===========================================================================
+
+  it("Flow C: stopping a started lazy service removes its pane + survivors re-expand", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "worker" }, { pane: "tail" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        worker: { start: idleCmd, flags: { start: false } },
+        tail: { start: idleCmd },
+      },
+      layout,
+      { worker: true, tail: false },
+    );
+
+    live = await buildLiveSession(config);
+    await live.manager.startService("worker");
+    await waitForState(live.manager, "worker", "ready");
+    const workerPaneId = live.session.paneMap.worker;
+
+    await live.manager.stopService("worker");
+    await waitForState(live.manager, "worker", "stopped");
+
+    // PaneMap entry gone, live pane gone.
+    expect(live.session.paneMap.worker).toBeUndefined();
+    const order = await paneIndexOrder(live.testSession.name);
+    expect(order.map((entry) => entry.id)).not.toContain(workerPaneId);
+    expect(order).toHaveLength(2);
+    // Round-7 retention invariant: the service-keyed log buffer survives.
+    expect(live.session.logBuffers.has("worker")).toBe(true);
+  });
+
+  // ===========================================================================
+  // Flow D — Crash keeps the pane
+  // ===========================================================================
+
+  it("Flow D: a crashing lazy service KEEPS its pane (no removePane from handleCrash)", async () => {
+    const config = makeResolvedConfig(
+      {
+        // No retries — we want to observe the post-crash state without a loop.
+        crasher: {
+          start: crashAfterReadyCmd,
+          flags: { start: false },
+          restart: { maxRetries: 0 },
+          ready: { output: /READY/ },
+        },
+      },
+      { direction: "columns", children: [{ pane: "@tui" }, { pane: "crasher" }] },
+      { crasher: true },
+    );
+
+    live = await buildLiveSession(config);
+    await live.manager.startService("crasher");
+    await waitForState(live.manager, "crasher", "ready");
+    // Wait for the crash to fire — `error` state is the terminal post-crash
+    // Sink for `maxRetries: 0`.
+    await waitForState(live.manager, "crasher", "error", 10_000);
+
+    // CRITICAL: pane survives so the user can inspect the post-mortem output.
+    expect(live.session.paneMap.crasher).toBeDefined();
+    const liveOrder = await paneIndexOrder(live.testSession.name);
+    const ids = liveOrder.map((p) => p.id);
+    expect(ids).toContain(live.session.paneMap.crasher);
+  });
+
+  // ===========================================================================
+  // Flow E — Restart keeps / re-creates the pane
+  // ===========================================================================
+
+  it("Flow E (running): restartService on a running lazy service KEEPS its pane (same pane id)", async () => {
+    const config = makeResolvedConfig(
+      { worker: { start: idleCmd, flags: { start: false } } },
+      { direction: "columns", children: [{ pane: "@tui" }, { pane: "worker" }] },
+      { worker: true },
+    );
+
+    live = await buildLiveSession(config);
+    await live.manager.startService("worker");
+    await waitForState(live.manager, "worker", "ready");
+    const before = live.session.paneMap.worker;
+
+    // RestartService is fire-and-forget for the running→stop→start chain.
+    // We just verify the pane id never changes (the existing pane is reused).
+    void live.manager.restartService("worker");
+    // Give the stop+start cycle time; the pane shouldn't disappear in the middle.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const after = live.session.paneMap.worker;
+    expect(after).toBe(before);
+  });
+
+  // ===========================================================================
+  // Flow F — Opt-in autostart
+  // ===========================================================================
+
+  it("Flow F: autostart lazyPane:true service that is manually stopped LOSES its pane", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "optin" }, { pane: "ctrl" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        optin: { start: idleCmd, lazyPane: true }, // Autostart + explicit lazyPane.
+        ctrl: { start: idleCmd, lazyPane: false }, // Autostart + explicit non-lazy.
+      },
+      layout,
+      { optin: true, ctrl: false },
+    );
+
+    live = await buildLiveSession(config);
+    // Boot: BOTH have a pane (autostart bypasses boot-skip — predicate
+    // Requires `flags.start === false`).
+    expect(live.session.paneMap.optin).toBeDefined();
+    expect(live.session.paneMap.ctrl).toBeDefined();
+
+    await live.manager.startAll();
+    await waitForState(live.manager, "optin", "ready");
+    await waitForState(live.manager, "ctrl", "ready");
+
+    // Manual stop on the opt-in lazy → pane removed (lazy=true → reflowRemove).
+    await live.manager.stopService("optin");
+    await waitForState(live.manager, "optin", "stopped");
+    expect(live.session.paneMap.optin).toBeUndefined();
+
+    // Control non-lazy → pane survives explicit stop.
+    await live.manager.stopService("ctrl");
+    await waitForState(live.manager, "ctrl", "stopped");
+    expect(live.session.paneMap.ctrl).toBeDefined();
+  });
+
+  // ===========================================================================
+  // Round-5 SEAL: reload-staleness — second insert lands via live reflow handle
+  // ===========================================================================
+
+  it("SEAL (Round-5): reload-then-insert lands the new pane via the live paneMap (no Unknown service)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-p04-t05-"));
+    try {
+      const { configPath, projectDir } = writeZapsFile(
+        tmpDir,
+        `
+          export function config(lib) {
+            return lib.defineProject({
+              services: {
+                workerA: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
+                workerB: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
+              },
+              layout: {
+                direction: "columns",
+                children: [{ pane: "@tui" }, { pane: "workerA" }, { pane: "workerB" }],
+              },
+            });
+          }
+        `,
+      );
+      // Use real loadConfig so reload reads the same shape.
+      const config = await loadConfig(configPath, projectDir);
+      // Override the projectDir to the temp dir so config + project deltas
+      // Stay in the tmpdir during the test.
+      config.configPath = configPath;
+      config.projectDir = projectDir;
+
+      live = await buildLiveSession(config);
+
+      // (1) Start workerA — its pane is inserted via the post-construct reflow.
+      await live.manager.startService("workerA");
+      await waitForState(live.manager, "workerA", "ready");
+      expect(live.session.paneMap.workerA).toBeDefined();
+
+      // (2) Reload — atomically swaps session.paneMap + session.manager.
+      await live.session.reload();
+      // After reload, workerA was NOT autostart, so it's stopped and pane-less.
+      // (`stopAllServices` removed its tmux pane via _reload step 4, and the
+      // New manager's paneMap has no entry for workerA.)
+      expect(live.session.paneMap.workerA).toBeUndefined();
+
+      // (3) Start workerB via the NEW manager. If reflow had captured a stale
+      // PaneMap/manager reference, this would throw `Unknown service` or
+      // Insert into the dead pipeline.
+      await live.session.manager.startService("workerB");
+      await waitForState(live.session.manager, "workerB", "ready");
+      expect(live.session.paneMap.workerB).toBeDefined();
+      // The live tmux pane is reachable through the NEW manager's paneMap.
+      const liveOrder = await paneIndexOrder(live.testSession.name);
+      const ids = liveOrder.map((p) => p.id);
+      expect(ids).toContain(live.session.paneMap.workerB);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ===========================================================================
+  // P04-T04-REVIEW SEAL: reload-with-running-lazy completes (no withOpLock re-entrance)
+  // ===========================================================================
+
+  it("SEAL (deadlock): reload with a running lazy service completes under bounded timeout", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-p04-t05-"));
+    try {
+      const { configPath, projectDir } = writeZapsFile(
+        tmpDir,
+        `
+          export function config(lib) {
+            return lib.defineProject({
+              services: {
+                worker: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
+              },
+              layout: {
+                direction: "columns",
+                children: [{ pane: "@tui" }, { pane: "worker" }],
+              },
+            });
+          }
+        `,
+      );
+      const config = await loadConfig(configPath, projectDir);
+      config.configPath = configPath;
+      config.projectDir = projectDir;
+
+      live = await buildLiveSession(config);
+      await live.manager.startService("worker");
+      await waitForState(live.manager, "worker", "ready");
+      expect(live.session.paneMap.worker).toBeDefined();
+
+      // Without the `shuttingDown` guard in P04-T04, this hangs FOREVER:
+      //   Reload holds withOpLock → stopAll → stopService(worker) →
+      //   Deps.reflowRemove → session.reflowRemove → withOpLock (not
+      //   Re-entrant) → chains AFTER the reload fn → circular wait.
+      await raceTimeout(live.session.reload(), 10_000, "Session.reload");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ===========================================================================
+  // @tui-reserve under boot-skip (Round-5 sharp edge)
+  // ===========================================================================
+
+  it("Round-5: layout with slot-0 lazy → @tui still maps to the start pane (reserveTuiPane path)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      // SLOT 0 IS A SKIPPED LAZY SERVICE. The filtered tree must put @tui in
+      // Slot 0 so reserveStartPaneForTui agrees with walkLayout (P04-T03 fix).
+      children: [{ pane: "worker" }, { pane: "@tui" }, { pane: "tail" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        worker: { start: idleCmd, flags: { start: false } },
+        tail: { start: idleCmd },
+      },
+      layout,
+      { worker: true, tail: false },
+    );
+
+    // Build the boot layout DIRECTLY with reserveTuiPane:true so we mirror
+    // The reload path that exercises the @tui reserve.
+    const testSession = await createTestSession();
+    const skip = computeBootSkip(config);
+    const { paneMap } = await createLayout(
+      testSession.initialPaneId,
+      config.project.layout,
+      config.project.services,
+      config.groups,
+      { skip, reserveTuiPane: true },
+    );
+
+    try {
+      expect(paneMap["@tui"]).toBe(testSession.initialPaneId);
+      expect(paneMap.worker).toBeUndefined();
+      expect(paneMap.tail).toBeDefined();
+    } finally {
+      // Manual cleanup since we didn't go through buildLiveSession.
+      for (const id of Object.values(paneMap)) {
+        if (id !== testSession.initialPaneId) {
+          await killPane(id).catch(() => {
+            /* Best-effort */
+          });
+        }
+      }
+      await testSession.cleanup();
+    }
+  });
+
+  // ===========================================================================
+  // Group/detached never lazy — loader guard verified through real boot
+  // ===========================================================================
+
+  it("Group/detached never lazy: a non-autostart group member + detached service get the SAME boot treatment as today", async () => {
+    // Loader's guard (P04-T02) forces `lazyPaneByService=false` for group
+    // Members and detached, regardless of flags.start. We assert by NOT
+    // Putting them in the lazy map: even if the user typed `flags.start:
+    // False` and tried `lazyPane:true`, the resolved value is false → no
+    // Boot-skip. (The full schema-rejection path is tested in P04-T01.)
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "groupA" }, { pane: "groupB" }, { pane: "isolated" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        // Two members sharing a pane via the same group name.
+        groupA: { start: idleCmd, flags: { start: false } },
+        groupB: { start: idleCmd, flags: { start: false } },
+        isolated: { start: idleCmd },
+      },
+      layout,
+      // P04-T02 guard semantics: members resolve to false even when their
+      // Flags.start is false. We model that here directly.
+      { groupA: false, groupB: false, isolated: false },
+    );
+
+    live = await buildLiveSession(config);
+
+    // ALL services have a pane at boot (no skip).
+    expect(live.session.paneMap.groupA).toBeDefined();
+    expect(live.session.paneMap.groupB).toBeDefined();
+    expect(live.session.paneMap.isolated).toBeDefined();
+    // Manually starting groupA does NOT trigger reflowInsert (already paned).
+    const preOrder = await paneIndexOrder(live.testSession.name);
+    const pre = preOrder.length;
+    await live.manager.startService("groupA");
+    await waitForState(live.manager, "groupA", "ready");
+    const postOrder = await paneIndexOrder(live.testSession.name);
+    const post = postOrder.length;
+    expect(post).toBe(pre);
+  });
+
+  // ===========================================================================
+  // Concurrency — two parallel lazy starts
+  // ===========================================================================
+
+  it("Concurrency: two near-simultaneous lazy starts converge to correct geometry; reflows serialized", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "a" }, { pane: "b" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        a: { start: idleCmd, flags: { start: false } },
+        b: { start: idleCmd, flags: { start: false } },
+      },
+      layout,
+      { a: true, b: true },
+    );
+
+    live = await buildLiveSession(config);
+    expect(await paneCount(live.testSession.name)).toBe(1); // Only @tui.
+
+    // Fire both starts WITHOUT awaiting between — the op-lock must serialize
+    // The two `reflowInsert` calls. Final state: 3 panes in declared order.
+    const pA = live.manager.startService("a");
+    const pB = live.manager.startService("b");
+    await Promise.all([pA, pB]);
+    await waitForState(live.manager, "a", "ready");
+    await waitForState(live.manager, "b", "ready");
+
+    expect(await paneCount(live.testSession.name)).toBe(3);
+    expect(live.session.paneMap.a).toBeDefined();
+    expect(live.session.paneMap.b).toBeDefined();
+    expect(live.session.paneMap.a).not.toBe(live.session.paneMap.b);
+
+    // Spatial order matches the layout DFS: @tui, a, b.
+    const orderEntries = await paneIndexOrder(live.testSession.name);
+    const order = orderEntries.map((p) => p.id);
+    expect(order).toEqual([
+      live.session.paneMap["@tui"],
+      live.session.paneMap.a,
+      live.session.paneMap.b,
+    ]);
+  });
+
+  // ===========================================================================
+  // Concurrency — start vs reload (bounded timeout)
+  // ===========================================================================
+
+  it("Concurrency (start vs reload): concurrent manual start + reload completes; converges", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-p04-t05-"));
+    try {
+      const { configPath, projectDir } = writeZapsFile(
+        tmpDir,
+        `
+          export function config(lib) {
+            return lib.defineProject({
+              services: {
+                worker: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
+              },
+              layout: {
+                direction: "columns",
+                children: [{ pane: "@tui" }, { pane: "worker" }],
+              },
+            });
+          }
+        `,
+      );
+      const config = await loadConfig(configPath, projectDir);
+      config.configPath = configPath;
+      config.projectDir = projectDir;
+
+      live = await buildLiveSession(config);
+
+      // Fire start + reload near-simultaneously. The Round-4 deadlock would
+      // Manifest here if reflow ran INSIDE withServiceLock (start path takes
+      // Service-lock then op-lock; reload takes op-lock then service-lock).
+      // Bounded timeout: if either hangs, this test fails fast.
+      const pStart = live.session.manager.startService("worker").catch(() => {
+        /* May race with reload — okay either way */
+      });
+      const pReload = live.session.reload().catch(() => {
+        /* May race */
+      });
+      await raceTimeout(Promise.all([pStart, pReload]), 15_000, "start+reload race");
+
+      // Final state must converge — no permanent locks. We don't pin a
+      // Particular state (race semantics); we pin LIVENESS.
+      expect(live.session.destroyed).toBe(false);
+      // Subsequent ops still work.
+      await raceTimeout(
+        live.session.manager.startService("worker").catch(() => {
+          /* Idempotent — may noop if already running */
+        }),
+        5000,
+        "post-race startService",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Suppress unused-var warning on imports kept for typing context only.
+void EventEmitter;
+void vi;
+void beforeEach;

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -714,6 +714,82 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
   });
 
   // ===========================================================================
+  // Hook-during-reload SEAL: onStop → lib.restartService re-entrance fix
+  // ===========================================================================
+
+  it("SEAL (hook deadlock): reload with onStop→lib.restartService(other lazy) completes under bounded timeout", async () => {
+    // The DEEPER deadlock class the shuttingDown guard on reflowInsert closes:
+    //   `reload` holds withOpLock → `manager.stopAll()` → `stopService(svc1)`
+    //   → `stopServiceInternal` → `onStop` hook (config/builder.ts:49-53
+    //   Exposes `lib.startService`/`lib.restartService` to hooks) →
+    //   `manager.restartService(svc2)` → wrapper `await deps.reflowInsert(svc2)`
+    //   → `Session.reflowInsert` → `withOpLock` (not re-entrant) → chains
+    //   AFTER the outer reload fn → permanent hang.
+    // With the guard: reflowInsert is skipped during shutdown, the hook's
+    // `restartService` call's internal `startServiceInternal` throws
+    // `Unknown service` (pane-less + non-detached). `onStop` catches that
+    // Into `lastError` (manager.ts:1029-1034) and the stop continues.
+    // Reload converges; post-reload `createLayout` rebuilds the layout
+    // From the new config (boot-skip handles the lazy non-autostart),
+    // So svc2 ends up exactly where the config says — no observable harm
+    // From the skipped mid-stopAll insert.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-p04-t05-hook-"));
+    try {
+      const { configPath, projectDir } = writeZapsFile(
+        tmpDir,
+        `
+          export function config(lib) {
+            return lib.defineProject({
+              services: {
+                svc1: {
+                  start: ${JSON.stringify(idleCmd)},
+                  raw: true,
+                  onStop: () => {
+                    // Hook calls back into the library mid-stop. This is the
+                    // Path that would have deadlocked the reload before the
+                    // ShuttingDown guard on reflowInsert.
+                    return lib.restartService("svc2").catch(() => {
+                      // Throws \`Unknown service\` because svc2 is pane-less +
+                      // The guard skips reflowInsert during shutdown. We
+                      // Catch so the hook doesn't propagate a noisy error.
+                    });
+                  },
+                },
+                svc2: {
+                  start: ${JSON.stringify(idleCmd)},
+                  raw: true,
+                  flags: { start: false },
+                },
+              },
+              layout: {
+                direction: "columns",
+                children: [{ pane: "@tui" }, { pane: "svc1" }, { pane: "svc2" }],
+              },
+            });
+          }
+        `,
+      );
+      const config = await loadConfig(configPath, projectDir);
+      config.configPath = configPath;
+      config.projectDir = projectDir;
+
+      live = await buildLiveSession(config);
+      await live.manager.startService("svc1");
+      await waitForState(live.manager, "svc1", "ready");
+      // Sanity preconditions: svc1 paned + ready, svc2 pane-less + lazy.
+      expect(live.session.paneMap.svc1).toBeDefined();
+      expect(live.session.paneMap.svc2).toBeUndefined();
+
+      // The seal: reload must complete (its stopAll fires svc1's onStop which
+      // Calls lib.restartService("svc2") which would re-enter withOpLock).
+      // Without the guard, hangs forever. With it, completes sub-second.
+      await raceTimeout(live.session.reload(), 10_000, "Session.reload (hook-driven re-entrance)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ===========================================================================
   // @tui-reserve under boot-skip (Round-5 sharp edge)
   // ===========================================================================
 

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -21,7 +21,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { computeBootSkip, loadConfig } from "#src/config/loader.js";
 import type { LayoutNode, ResolvedConfig, ServiceConfig } from "#src/config/types.js";
@@ -48,10 +48,42 @@ import { createTestSession } from "../helpers/tmux.js";
 
 // --- Helpers ---------------------------------------------------------------
 
+/**
+ * Minimal `ChildProcess`-shaped fake for the detached-service test. Mirrors the
+ * `FakeDetachedChild` in `test/lib/service/manager.test.ts` — same shape, kept
+ * Inline here so the integration suite is self-contained.
+ */
+class FakeDetachedChild extends EventEmitter {
+  public readonly stdout = new EventEmitter();
+  public readonly stderr = new EventEmitter();
+  public readonly pid: number;
+
+  public constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+
+  // eslint-disable-next-line class-methods-use-this -- ChildProcess interface requires instance methods
+  public kill(): void {
+    /* No-op; the test doesn't terminate the fake child */
+  }
+
+  // eslint-disable-next-line class-methods-use-this -- ChildProcess interface requires instance methods
+  public unref(): void {
+    /* No-op */
+  }
+}
+
 interface LiveSession {
   testSession: TestSession;
   session: Session;
   manager: ServiceManager;
+  /**
+   * Fake detached children registered by `detachedSpawn`. The detached test
+   * Uses these to emit `exit` on stop (real `process.kill` doesn't reach the
+   * Fake; the test mirrors the unit-test pattern at `manager.test.ts:3167`).
+   */
+  detachedChildren: FakeDetachedChild[];
   cleanup: () => Promise<void>;
 }
 
@@ -174,6 +206,8 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
   );
 
   const ref: { session: Session | null } = { session: null };
+  const detachedChildren: FakeDetachedChild[] = [];
+  let nextDetachedPid = 7000;
   const deps: ServiceManagerDeps = {
     sendKeys,
     sendCtrlC,
@@ -202,6 +236,24 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     },
     sessionId: "p04-t05",
     zapsCommand: "zaps",
+    // Detached services (E4) bypass the pane flow entirely — they spawn via
+    // `detachedSpawn` and use PID-based port detection. We inject a FAKE spawn
+    // So the detached-service test can run without touching the OS; the fake
+    // Child's `stdout`/`stderr` event emitters satisfy DetachedRunner's
+    // Interface. `detectPortsForPid` returns empty so the service goes ready
+    // Immediately without a port check.
+    detachedSpawn: ((file: string, argv: string[]) => {
+      void file;
+      void argv;
+      const child = new FakeDetachedChild(nextDetachedPid);
+      nextDetachedPid += 1;
+      detachedChildren.push(child);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- spawn shape matches ChildProcess subset
+      return child as unknown as ReturnType<NonNullable<ServiceManagerDeps["detachedSpawn"]>>;
+    }) as unknown as ServiceManagerDeps["detachedSpawn"],
+    // Return a synthetic port so a detached service reaches `ready`
+    // Immediately without a real listener (mirrors the unit-test pattern).
+    detectPortsForPid: async () => [4000],
     reflowInsert: async (name: string) => {
       if (!ref.session) {
         throw new Error("reflowInsert: session not yet wired");
@@ -233,7 +285,16 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     testSession,
     session,
     manager,
+    detachedChildren,
     async cleanup() {
+      // Before driving stopAll, signal every still-alive fake detached child
+      // To exit — DetachedRunner.stop awaits the real OS process to emit
+      // `exit`, which a fake never does. Without this, afterEach hangs.
+      for (const child of detachedChildren) {
+        if (child.listenerCount("exit") > 0) {
+          child.emit("exit", null, "SIGTERM");
+        }
+      }
       try {
         await manager.stopAll();
       } catch {
@@ -471,6 +532,46 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
     expect(after).toBe(before);
   });
 
+  it("Flow E (stopped): restartService on a STOPPED pane-less lazy CREATES the pane", async () => {
+    // Explicit AC: "restarting a stopped (pane-less) lazy service CREATES the
+    // Pane." This drives the wrapper-level reflowInsert that mirrors what
+    // StartService does — without it, `startServiceInternal` (inside
+    // `restartServiceInternal`) would throw `Unknown service` on the missing
+    // PaneMap entry.
+    const config = makeResolvedConfig(
+      { worker: { start: idleCmd, flags: { start: false } } },
+      { direction: "columns", children: [{ pane: "@tui" }, { pane: "worker" }] },
+      { worker: true },
+    );
+
+    live = await buildLiveSession(config);
+    // (1) Start → pane created.
+    await live.manager.startService("worker");
+    await waitForState(live.manager, "worker", "ready");
+    const firstPaneId = live.session.paneMap.worker;
+    expect(firstPaneId).toBeDefined();
+
+    // (2) Stop → pane removed.
+    await live.manager.stopService("worker");
+    await waitForState(live.manager, "worker", "stopped");
+    expect(live.session.paneMap.worker).toBeUndefined();
+    expect(await paneCount(live.testSession.name)).toBe(1); // Only @tui survives.
+
+    // (3) restartService on stopped + pane-less must re-create the pane and
+    // Land it at the declared slot. The pane id is fresh (tmux generates a
+    // New `%N`); paneMap is repopulated and the live window has 2 panes.
+    await live.manager.restartService("worker");
+    await waitForState(live.manager, "worker", "ready");
+
+    const secondPaneId = live.session.paneMap.worker;
+    expect(secondPaneId).toBeDefined();
+    expect(secondPaneId).not.toBe(firstPaneId); // New pane, not the killed one.
+    expect(await paneCount(live.testSession.name)).toBe(2);
+    // Spatial order: @tui, worker (declared DFS).
+    const order2 = await paneIndexOrder(live.testSession.name);
+    expect(order2.map((p) => p.id)).toEqual([live.session.paneMap["@tui"], secondPaneId]);
+  });
+
   // ===========================================================================
   // Flow F — Opt-in autostart
   // ===========================================================================
@@ -704,6 +805,79 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
     expect(post).toBe(pre);
   });
 
+  it("Real detached service: never paneed; start/stop bypass reflowInsert/Remove entirely", async () => {
+    // Explicit AC seal with a REAL `detached: true` service (not just a
+    // Modeled lazyMap entry). `detached: true` services run pane-less via
+    // `detachedSpawn`; the loader's guard (P04-T02) forces
+    // `lazyPaneByService=false` for them regardless of `flags.start`, so the
+    // Lifecycle wrappers' lazy predicate (`isLazy && !paneMap[name]`) is
+    // FALSE on both sides and neither reflowInsert nor reflowRemove ever runs.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "tail" }],
+    };
+    const config = makeResolvedConfig(
+      {
+        // Non-autostart, detached. P04-T02 forces lazy=false even if
+        // Flags.start === false. We model that here directly (matches
+        // What `resolveLazyPanes` would emit).
+        bgWorker: { start: "node w.js", detached: true, flags: { start: false } },
+        tail: { start: idleCmd },
+      },
+      layout,
+      { bgWorker: false, tail: false },
+    );
+
+    live = await buildLiveSession(config);
+    // (1) At boot: detached service has NO pane (never paned). The visible
+    // Window has @tui + tail only — same as if `bgWorker` didn't exist.
+    expect(live.session.paneMap.bgWorker).toBeUndefined();
+    expect(live.session.paneMap.tail).toBeDefined();
+    expect(await paneCount(live.testSession.name)).toBe(2);
+
+    // Spy on the deps reflow callbacks by wrapping — capture the original,
+    // Swap in a counter, assert it stayed zero across start/stop.
+    let reflowInsertCalls = 0;
+    let reflowRemoveCalls = 0;
+    const mgrDeps = (live.manager as unknown as { deps: ServiceManagerDeps }).deps;
+    const origInsert = mgrDeps.reflowInsert;
+    const origRemove = mgrDeps.reflowRemove;
+    mgrDeps.reflowInsert = async (n: string) => {
+      reflowInsertCalls += 1;
+      await origInsert(n);
+    };
+    mgrDeps.reflowRemove = async (n: string) => {
+      reflowRemoveCalls += 1;
+      await origRemove(n);
+    };
+
+    // (2) Start the detached service. The fake `detachedSpawn` returns a
+    // Pseudo-child whose stdout never emits; `detectPortsForPid` returns []
+    // → service goes to `ready` immediately. No pane allocation happens
+    // (manager's detached branch in `startServiceInternal`).
+    await live.manager.startService("bgWorker");
+    await waitForState(live.manager, "bgWorker", "ready");
+    expect(live.session.paneMap.bgWorker).toBeUndefined();
+    expect(await paneCount(live.testSession.name)).toBe(2);
+    expect(reflowInsertCalls).toBe(0);
+
+    // (3) Stop the detached service. Same invariant — pane logic untouched.
+    // DetachedRunner.stop awaits the OS-level `exit` event; the fake doesn't
+    // Emit one on its own (mirrors `manager.test.ts:3167`'s pattern), so we
+    // Trigger it manually after kicking the stop.
+    const stopPromise = live.manager.stopService("bgWorker");
+    // Give the lock body a tick to enter `detachedRunner.stop` and arm
+    // `onStopped`; then emit exit to unblock it.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    for (const child of live.detachedChildren) {
+      child.emit("exit", null, "SIGTERM");
+    }
+    await stopPromise;
+    expect(live.manager.getStatus("bgWorker").state).toBe("stopped");
+    expect(live.session.paneMap.bgWorker).toBeUndefined();
+    expect(reflowRemoveCalls).toBe(0);
+  });
+
   // ===========================================================================
   // Concurrency — two parallel lazy starts
   // ===========================================================================
@@ -805,8 +979,3 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
     }
   });
 });
-
-// Suppress unused-var warning on imports kept for typing context only.
-void EventEmitter;
-void vi;
-void beforeEach;

--- a/test/integration/tmux/window-title.test.ts
+++ b/test/integration/tmux/window-title.test.ts
@@ -40,6 +40,12 @@ const deps = {
   },
   sessionId: "test-session-id",
   zapsCommand: "zaps",
+  reflowInsert: async () => {
+    /* No-op for tests that don't exercise lazy lifecycle */
+  },
+  reflowRemove: async () => {
+    /* No-op */
+  },
 };
 
 describe.skipIf(!hasTmux())("window-title integration", () => {

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -3416,6 +3416,70 @@ describe("lazy-pane lifecycle", () => {
     expect(paneMap.worker).toBe("%worker");
   });
 
+  it("stopAll skips reflowRemove for every lazy service (shuttingDown guard, deadlock fix)", async () => {
+    // The deadlock that would fire without the guard:
+    //   `Session.reload`/`destroy` hold `withOpLock` → `manager.stopAll()` →
+    //   `stopAllServices` → per-service `stopService` → `reflowRemove` →
+    //   `Session.reflowRemove` → `withOpLock` (NOT re-entrant) → chains AFTER
+    //   The outer reload `fn` that is awaiting `stopAll` → permanent hang.
+    // The guard short-circuits `reflowRemove` while `this.shuttingDown` is
+    // True — which `runStopAll` sets BEFORE iterating, so EVERY stopService
+    // Called from within stopAll sees it. _reload step 4 (session.ts:434-440)
+    // Kill-panes anyway, so this is also redundant in the reload path.
+    const config = lazyConfig(
+      {
+        worker: { start: "node w.js" },
+        api: { start: "npm dev" },
+      },
+      ["worker"], // Only `worker` is lazy.
+    );
+    const paneMap = makePaneMap(["worker", "api"]);
+    const deps = createMockDeps();
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // Get both services to `ready` first.
+    await mgr.startService("worker");
+    await mgr.startService("api");
+    await vi.advanceTimersByTimeAsync(2000);
+    vi.mocked(deps.reflowInsert).mockClear();
+    vi.mocked(deps.reflowRemove).mockClear();
+
+    // StopAll: the shuttingDown guard MUST suppress reflowRemove on `worker`.
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000]); // Process exits.
+    await mgr.stopAll();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+    // Sanity: non-shutdown stopService still fires reflowRemove for lazy.
+    // (We can't easily verify post-stopAll because shuttingDown reset to false
+    // After stopAllServices returned — fire a manual stopService now: the
+    // Service is already stopped so it'll be a noop, and reflowRemove won't
+    // Fire because paneMap mutations from stopAll left the world unchanged
+    // For non-lazy services either. The point of THIS test is the negative
+    // Assertion above.)
+  });
+
+  it("manual stopService (no shutdown) still calls reflowRemove (positive control)", async () => {
+    // Companion to the shuttingDown guard test: confirms the guard ONLY fires
+    // During shutdown, not on the manual path.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap = makePaneMap(["worker"]);
+    const deps = createMockDeps();
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    await mgr.startService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+    vi.mocked(deps.reflowRemove).mockClear();
+
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000]);
+    await mgr.stopService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(deps.reflowRemove).toHaveBeenCalledWith("worker");
+  });
+
   it("restartService never calls the reflow hooks (pane kept by design)", async () => {
     // RestartServiceInternal re-sends the start command to the existing pane;
     // It never touches reflowInsert or reflowRemove. The public wrapper

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -3460,6 +3460,49 @@ describe("lazy-pane lifecycle", () => {
     // Assertion above.)
   });
 
+  it("startService skips reflowInsert when shuttingDown (re-entrance guard, deadlock fix)", async () => {
+    // Symmetric to the stopService shuttingDown guard. The deadlock the guard
+    // Closes:
+    //   `reload` holds withOpLock → `manager.stopAll()` → `stopService(svc1)`
+    //   → `onStop` hook → `lib.startService(svc2)` → wrapper-level
+    //   `deps.reflowInsert(svc2)` → `Session.reflowInsert` → withOpLock
+    //   (not re-entrant) → chains AFTER outer reload fn → permanent hang.
+    // `lib.startService`/`restartService` are exposed to hooks
+    // (config/builder.ts:49-53), so this is a real reachable footgun. The
+    // Guard short-circuits reflowInsert when `shuttingDown` is true —
+    // RunStopAll sets it BEFORE iterating, so every hook-driven start during
+    // Reload sees it.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" };
+    const deps = createMockDeps();
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+    // Simulate the shutdown phase (what runStopAll sets at line 496).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- toggling the private flag for the deadlock-guard test
+    (mgr as any).shuttingDown = true;
+
+    // StartService on a lazy pane-less service during shutdown: reflowInsert
+    // Is skipped. `startServiceInternal` will throw `Unknown service` since
+    // PaneMap[worker] is absent — the rejection is the existing contract,
+    // What matters is reflowInsert isn't called (no withOpLock re-entrance).
+    await expect(mgr.startService("worker")).rejects.toThrow(/Unknown service/);
+    expect(deps.reflowInsert).not.toHaveBeenCalled();
+  });
+
+  it("restartService skips reflowInsert when shuttingDown (re-entrance guard)", async () => {
+    // Companion to the startService guard test. lib.restartService is also
+    // Hook-reachable (config/builder.ts:49-53), so the wrapper carries the
+    // Same shuttingDown short-circuit.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" };
+    const deps = createMockDeps();
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- toggling the private flag for the deadlock-guard test
+    (mgr as any).shuttingDown = true;
+
+    await expect(mgr.restartService("worker")).rejects.toBeDefined();
+    expect(deps.reflowInsert).not.toHaveBeenCalled();
+  });
+
   it("manual stopService (no shutdown) still calls reflowRemove (positive control)", async () => {
     // Companion to the shuttingDown guard test: confirms the guard ONLY fires
     // During shutdown, not on the manual path.

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -36,6 +36,8 @@ function createMockDeps(): ServiceManagerDeps {
     storeExecInfo: vi.fn(),
     sessionId: "test-session-id",
     zapsCommand: "zaps",
+    reflowInsert: vi.fn<ServiceManagerDeps["reflowInsert"]>().mockResolvedValue(),
+    reflowRemove: vi.fn<ServiceManagerDeps["reflowRemove"]>().mockResolvedValue(),
   };
 }
 
@@ -3230,5 +3232,217 @@ describe("detached services (E4)", () => {
 
     expect(mgr.getStatus("worker").state).toBe("ready");
     expect(children.length).toBe(1);
+  });
+});
+
+// =============================================================================
+// Lazy-pane lifecycle wiring (P04-T04)
+// =============================================================================
+
+describe("lazy-pane lifecycle", () => {
+  function lazyConfig(services: Record<string, ServiceConfig>, lazy: string[]): ResolvedConfig {
+    const config = makeConfig(services);
+    for (const name of lazy) {
+      config.lazyPaneByService.set(name, true);
+    }
+    return config;
+  }
+
+  it("startService inserts the pane BEFORE the per-service lock body runs", async () => {
+    // The body of `startServiceInternal` would throw `Unknown service` if it
+    // Ran first (no `paneMap[name]`). The wrapper inserts the pane first,
+    // Populating paneMap; then the locked body succeeds.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" }; // No worker pane.
+    const deps = createMockDeps();
+    deps.reflowInsert = vi.fn(async (name: string) => {
+      paneMap[name] = "%worker";
+    });
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const startPromise = mgr.startService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+    await startPromise;
+
+    expect(deps.reflowInsert).toHaveBeenCalledWith("worker");
+    expect(deps.reflowInsert).toHaveBeenCalledTimes(1);
+    // The service actually started — proves insert ran first (otherwise
+    // StartServiceInternal would have thrown `Unknown service`).
+    expect(mgr.getStatus("worker").state).toBe("ready");
+    expect(paneMap.worker).toBe("%worker");
+  });
+
+  it("startService is NOT a reflowInsert when service already has a pane", async () => {
+    // Lazy + autostart-paned (boot-skip would have left a pane in place).
+    const config = lazyConfig({ api: { start: "npm dev" } }, ["api"]);
+    const paneMap = makePaneMap(["api"]);
+    const deps = createMockDeps();
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const startPromise = mgr.startService("api");
+    await vi.advanceTimersByTimeAsync(2000);
+    await startPromise;
+
+    expect(deps.reflowInsert).not.toHaveBeenCalled();
+    expect(mgr.getStatus("api").state).toBe("ready");
+  });
+
+  it("startService is NOT a reflowInsert for non-lazy services (regression)", async () => {
+    const config = makeConfig({ api: { start: "npm dev" } }); // No lazyPane entry.
+    const paneMap = makePaneMap(["api"]);
+    const deps = createMockDeps();
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const startPromise = mgr.startService("api");
+    await vi.advanceTimersByTimeAsync(2000);
+    await startPromise;
+
+    expect(deps.reflowInsert).not.toHaveBeenCalled();
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+  });
+
+  it("startService PROPAGATES reflowInsert failure WITHOUT mutating service state", async () => {
+    // Lock-ordering invariant: the reflow runs OUTSIDE `withServiceLock`. If
+    // It throws, the lock-guarded body never ran — no state transition, no
+    // `starting` event, no pane mutation.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" };
+    const deps = createMockDeps();
+    deps.reflowInsert = vi.fn().mockRejectedValue(new Error("forced split failure"));
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    const stateEvents: string[] = [];
+    mgr.on("stateChange", (_, status: ServiceStatus) => {
+      stateEvents.push(status.state);
+    });
+
+    await expect(mgr.startService("worker")).rejects.toThrow(/forced split failure/);
+    expect(paneMap.worker).toBeUndefined();
+    // The lock-guarded body would have transitioned to `starting` on entry.
+    // It didn't run, so no transitions fired.
+    expect(stateEvents).toEqual([]);
+    expect(mgr.getStatus("worker").state).toBe("stopped");
+  });
+
+  it("stopService calls reflowRemove AFTER the per-service lock releases (lazy + has pane)", async () => {
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap = makePaneMap(["worker"]);
+    const deps = createMockDeps();
+    // Resolve immediately; track call order against state-change events.
+    const events: string[] = [];
+    deps.reflowRemove = vi.fn(async (name: string) => {
+      events.push(`reflowRemove(${name})`);
+      // Simulate the session-side delete that LayoutReflow.removePane does.
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- mirroring the real removePane behavior
+      delete paneMap[name];
+    });
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+    mgr.on("stateChange", (_, status: ServiceStatus) => {
+      events.push(`state:${status.state}`);
+    });
+
+    await mgr.startService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    events.length = 0;
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000]); // Process exits.
+    await mgr.stopService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // The lock-guarded body fires the stop transitions; the reflowRemove
+    // Fires AFTER (the last entry in `events` is the reflow).
+    expect(events).toContain("state:stopping");
+    expect(events).toContain("state:stopped");
+    expect(events.at(-1)).toBe("reflowRemove(worker)");
+    expect(paneMap.worker).toBeUndefined();
+  });
+
+  it("stopService skips reflowRemove for a NON-lazy service (regression)", async () => {
+    const config = makeConfig({ api: { start: "npm dev" } });
+    const paneMap = makePaneMap(["api"]);
+    const deps = createMockDeps();
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    await mgr.startService("api");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000]);
+    await mgr.stopService("api");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+    // Non-lazy: pane survives stop.
+    expect(paneMap.api).toBe("%api");
+  });
+
+  it("stopService skips reflowRemove for a lazy service with no pane", async () => {
+    // Never-started lazy service: stopService is a no-op AND must not call
+    // ReflowRemove (no pane to remove).
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" }; // No worker pane.
+    const deps = createMockDeps();
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // StopService throws `Unknown service` when pane-less and non-detached —
+    // That's the existing contract; what matters is reflowRemove isn't called.
+    await expect(mgr.stopService("worker")).rejects.toThrow(/Unknown service/);
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+  });
+
+  it("crash does NOT call reflowRemove (pane kept across the restart loop)", async () => {
+    const config = lazyConfig(
+      {
+        worker: {
+          start: "node w.js",
+          restart: { maxRetries: 1, backoff: 1 },
+        },
+      },
+      ["worker"],
+    );
+    const paneMap = makePaneMap(["worker"]);
+    const deps = createMockDeps();
+    // Start: process spawns; then immediately exits → handleCrash triggers.
+    deps.getDescendantPids = vi.fn().mockResolvedValueOnce([1000, 2000]).mockResolvedValue([1000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    await mgr.startService("worker");
+    // Let monitor tick + crash handler run.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+    // Pane survives the crash for the restart loop.
+    expect(paneMap.worker).toBe("%worker");
+  });
+
+  it("restartService never calls the reflow hooks (pane kept by design)", async () => {
+    // RestartServiceInternal re-sends the start command to the existing pane;
+    // It never touches reflowInsert or reflowRemove. The public wrapper
+    // `restartService` (manager.ts:1070) only acquires `withServiceLock`,
+    // Bypassing the lazy-lifecycle wiring on the start/stop wrappers. This
+    // Test pins that bypass by attempting a restart and asserting the hooks
+    // Stayed dormant — we don't drive it to ready (that path is exercised
+    // Elsewhere), only that the hooks aren't called along the way.
+    const config = lazyConfig({ worker: { start: "node w.js", raw: true } }, ["worker"]);
+    const paneMap = makePaneMap(["worker"]);
+    const deps = createMockDeps();
+    deps.getDescendantPids = vi.fn().mockResolvedValue([1000, 2000]);
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    await mgr.startService("worker");
+    await vi.advanceTimersByTimeAsync(2000);
+    vi.mocked(deps.reflowInsert).mockClear();
+    vi.mocked(deps.reflowRemove).mockClear();
+
+    // Don't await — the restart loop polls indefinitely under fake timers
+    // Without a fully-faked child process. We only assert the hooks stayed
+    // Dormant during the call dispatch.
+    void mgr.restartService("worker");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(deps.reflowInsert).not.toHaveBeenCalled();
+    expect(deps.reflowRemove).not.toHaveBeenCalled();
+    expect(paneMap.worker).toBe("%worker");
   });
 });

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -55,6 +55,7 @@ function makeConfig(
     projectDir: "/test",
     groups: new Map(),
     unavailableServices: new Map(),
+    lazyPaneByService: new Map(),
   };
 }
 

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -3480,6 +3480,31 @@ describe("lazy-pane lifecycle", () => {
     expect(deps.reflowRemove).toHaveBeenCalledWith("worker");
   });
 
+  it("restartService on a STOPPED pane-less lazy service CALLS reflowInsert (re-creates pane)", async () => {
+    // Symmetric to startService for the lazy pane-less case: a stopped lazy
+    // Service has no paneMap entry, so restartServiceInternal's internal
+    // `startServiceInternal` would throw `Unknown service`. The wrapper-level
+    // ReflowInsert (mirroring `startService`) populates paneMap before the
+    // Locked body runs. Op-lock-outermost is preserved (call OUTSIDE
+    // WithServiceLock). The running-restart case (next test) does NOT fire
+    // ReflowInsert because `paneMap[name]` already exists.
+    const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
+    const paneMap: Record<string, string> = { "@tui": "%tui" }; // Worker stopped + pane-less.
+    const deps = createMockDeps();
+    deps.reflowInsert = vi.fn(async (name: string) => {
+      paneMap[name] = "%worker";
+    });
+    const mgr = new ServiceManager(config, paneMap, deps, "test-session");
+
+    // RestartService on a stopped pane-less lazy: would throw `Unknown service`
+    // Without the wrapper reflowInsert. Drive it forward and assert reflowInsert ran.
+    void mgr.restartService("worker");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(deps.reflowInsert).toHaveBeenCalledWith("worker");
+    expect(paneMap.worker).toBe("%worker");
+  });
+
   it("restartService never calls the reflow hooks (pane kept by design)", async () => {
     // RestartServiceInternal re-sends the start command to the existing pane;
     // It never touches reflowInsert or reflowRemove. The public wrapper

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ServiceConfig } from "../../src/config/types.js";
+import type { LayoutNode, ServiceConfig } from "../../src/config/types.js";
 
 // Mock tmux functions
 vi.mock("../../src/lib/tmux.js", () => ({
@@ -8,7 +8,12 @@ vi.mock("../../src/lib/tmux.js", () => ({
   killPane: vi.fn(),
 }));
 
-import { createLayout, validateLayout, validateLayoutSizes } from "../../src/lib/tmux-layout.js";
+import {
+  createLayout,
+  filterTree,
+  validateLayout,
+  validateLayoutSizes,
+} from "../../src/lib/tmux-layout.js";
 import { killPane, splitPane } from "../../src/lib/tmux.js";
 
 const mockSplitPane = vi.mocked(splitPane);
@@ -309,6 +314,192 @@ describe("createLayout", () => {
     expect(paneMap.dbB).toBe("%2");
     // Exactly two splits: api (%1) + the single shared group pane (%2).
     expect(mockSplitPane).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("filterTree", () => {
+  it("returns undefined for an undefined tree", () => {
+    expect(filterTree(undefined, new Set(["@tui"]))).toBeUndefined();
+  });
+
+  it("keeps a visible leaf (cloned) and drops an invisible one", () => {
+    const leaf: LayoutNode = { pane: "@tui", size: "50%", focus: true };
+
+    const kept = filterTree(leaf, new Set(["@tui"]));
+    expect(kept).toEqual({ pane: "@tui", size: "50%", focus: true });
+    expect(kept).not.toBe(leaf); // New object, no mutation
+
+    expect(filterTree(leaf, new Set(["api"]))).toBeUndefined();
+  });
+
+  it("all-visible: tree is structurally unchanged (and not the same reference)", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui", size: "30%" }, { pane: "api", size: "40%" }, { pane: "web" }],
+    };
+
+    const result = filterTree(layout, new Set(["@tui", "api", "web"]));
+    expect(result).toEqual(layout);
+    expect(result).not.toBe(layout);
+  });
+
+  it("does not mutate the input tree", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "70%" },
+      ],
+    };
+    const snapshot = structuredClone(layout);
+
+    filterTree(layout, new Set(["@tui"]));
+
+    expect(layout).toEqual(snapshot);
+  });
+
+  it("@tui-only: a flat split collapses to the single surviving leaf", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "40%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+
+    // The collapsed leaf takes over the whole split slot, so it has no size.
+    expect(filterTree(layout, new Set(["@tui"]))).toEqual({ pane: "@tui" });
+  });
+
+  it("flat columns, middle child removed: survivors keep their declared sizes", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "40%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+
+    expect(filterTree(layout, new Set(["@tui", "web"]))).toEqual({
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "web", size: "30%" },
+      ],
+    });
+  });
+
+  it("removed explicit-size sibling: an implicit survivor reclaims the freed space", () => {
+    // @tui 70%, api 20%, web implicit (gets remainder 10%). Drop @tui (70%):
+    // Api keeps its explicit 20%, web stays implicit and so absorbs the freed
+    // Pool — the result is valid computeRects input (explicit 20% < 100, one
+    // Implicit sibling), which then resolves web to the remaining 80%.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui", size: "70%" }, { pane: "api", size: "20%" }, { pane: "web" }],
+    };
+
+    const result = filterTree(layout, new Set(["api", "web"]));
+    expect(result).toEqual({
+      direction: "columns",
+      children: [{ pane: "api", size: "20%" }, { pane: "web" }],
+    });
+    // The survivors remain valid input to computeRects (no overflow).
+    expect(() => validateLayoutSizes(result!)).not.toThrow();
+  });
+
+  it("nested split fully removed: parent collapses past the empty branch", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        {
+          direction: "rows",
+          size: "70%",
+          children: [
+            { pane: "api", size: "50%" },
+            { pane: "web", size: "50%" },
+          ],
+        },
+      ],
+    };
+
+    // Api+web invisible → inner split drops → outer collapses to @tui leaf.
+    expect(filterTree(layout, new Set(["@tui"]))).toEqual({ pane: "@tui" });
+  });
+
+  it("collapsing a single-child split: survivor inherits the split's slot size", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        {
+          direction: "rows",
+          size: "70%",
+          children: [
+            { pane: "api", size: "50%" },
+            { pane: "web", size: "50%" },
+          ],
+        },
+      ],
+    };
+
+    // Only web invisible: inner split keeps api (single child) and api takes
+    // Over the inner split's 70% slot in the outer columns.
+    expect(filterTree(layout, new Set(["@tui", "api"]))).toEqual({
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "70%" },
+      ],
+    });
+  });
+
+  it("deeply nested collapse: survivor inherits the outermost collapsing slot size", () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "40%" },
+        {
+          direction: "rows",
+          size: "60%",
+          children: [
+            {
+              direction: "columns",
+              children: [
+                { pane: "api", size: "50%" },
+                { pane: "worker", size: "50%" },
+              ],
+            },
+            { pane: "web" },
+          ],
+        },
+      ],
+    };
+
+    // Keep @tui + api only: worker and web drop, both nested splits collapse,
+    // Api bubbles up to the outer 60% slot.
+    expect(filterTree(layout, new Set(["@tui", "api"]))).toEqual({
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "40%" },
+        { pane: "api", size: "60%" },
+      ],
+    });
+  });
+
+  it("everything invisible: returns undefined", () => {
+    const layout: LayoutNode = {
+      direction: "rows",
+      children: [
+        { pane: "@tui", size: "50%" },
+        { pane: "api", size: "50%" },
+      ],
+    };
+
+    expect(filterTree(layout, new Set())).toBeUndefined();
   });
 });
 

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -15,6 +15,7 @@ import {
   filterTree,
   layoutString,
   PaneTooSmallError,
+  resolvePermutation,
   validateLayout,
   validateLayoutSizes,
 } from "../../src/lib/tmux-layout.js";
@@ -804,6 +805,74 @@ describe("layoutString", () => {
 
     expect(() => layoutString(tree, rects, paneNumbers)).toThrow(
       /no rect computed for pane 'right'/,
+    );
+  });
+});
+
+describe("resolvePermutation", () => {
+  /** Apply the emitted swap pairs to `current` (mirrors tmux `swap-pane`). */
+  function applySwaps(current: string[], swaps: [string, string][]): string[] {
+    const work = [...current];
+    for (const [from, to] of swaps) {
+      const i = work.indexOf(from);
+      const j = work.indexOf(to);
+      [work[i], work[j]] = [work[j], work[i]];
+    }
+    return work;
+  }
+
+  const cases: { name: string; current: string[]; target: string[] }[] = [
+    { name: "already sorted", current: ["A", "B", "C"], target: ["A", "B", "C"] },
+    { name: "single swap", current: ["A", "B"], target: ["B", "A"] },
+    { name: "reverse order", current: ["A", "B", "C", "D"], target: ["D", "C", "B", "A"] },
+    { name: "[A,B,C] → [C,A,B]", current: ["A", "B", "C"], target: ["C", "A", "B"] },
+    {
+      name: "5-element shuffle",
+      current: ["%0", "%1", "%2", "%3", "%4"],
+      target: ["%3", "%0", "%4", "%2", "%1"],
+    },
+    { name: "empty", current: [], target: [] },
+  ];
+
+  for (const { name, current, target } of cases) {
+    it(`produces swaps that transform ${name} into the target`, () => {
+      const swaps = resolvePermutation(current, target);
+      expect(applySwaps(current, swaps)).toEqual(target);
+    });
+  }
+
+  it("returns [] when current already equals target", () => {
+    expect(resolvePermutation(["A", "B", "C"], ["A", "B", "C"])).toEqual([]);
+  });
+
+  it("resolves the [A,B,C] → [C,A,B] 3-cycle in the minimal 2 swaps", () => {
+    // A pure 3-cycle needs k−1 = 2 transpositions; selection sort is optimal here.
+    // (The architecture note's "1 swap" is the insert+swap scenario, not a relabel.)
+    const swaps = resolvePermutation(["A", "B", "C"], ["C", "A", "B"]);
+    expect(swaps).toEqual([
+      ["A", "C"],
+      ["B", "A"],
+    ]);
+    expect(applySwaps(["A", "B", "C"], swaps)).toEqual(["C", "A", "B"]);
+  });
+
+  it("does not mutate the input arrays", () => {
+    const current = ["A", "B", "C"];
+    const target = ["C", "B", "A"];
+    resolvePermutation(current, target);
+    expect(current).toEqual(["A", "B", "C"]);
+    expect(target).toEqual(["C", "B", "A"]);
+  });
+
+  it("throws when the arrays are not permutations of the same set", () => {
+    expect(() => resolvePermutation(["A", "B"], ["A", "C"])).toThrow(
+      /not permutations of the same set/,
+    );
+  });
+
+  it("throws when the arrays differ in length", () => {
+    expect(() => resolvePermutation(["A", "B", "C"], ["A", "B"])).toThrow(
+      /not permutations of the same set/,
     );
   });
 });

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -429,6 +429,48 @@ describe("createLayout", () => {
       expect(focusPane).toBe(paneMap["@tui"]);
     });
 
+    it("survivors with explicit sizes < 100 split proportionally (not last-absorbs)", async () => {
+      // Regression for the dev/db 40/60 bug: declared `[dev:40, db:20, rainfrog:20,
+      // Mailtrap:20]` with rainfrog+mailtrap skipped should give surviving siblings
+      // `[40, 20]`. Old walkLayout normalized against a hard-coded 100, so the second
+      // Split asked tmux for `round((100 - 40) / 100 * 100) = 60` and db ended up
+      // Owning 60 % (dev kept 40 %). The fix normalizes against the survivors' own
+      // Weight sum (60), so the second split asks for `round((60 - 40) / 60 * 100) =
+      // 33` and dev gets ~67 %, db ~33 % — proportional to their declared shares.
+      const services: Record<string, ServiceConfig> = {
+        dev: { start: "pnpm dev" },
+        db: { start: "pnpm db" },
+        rainfrog: { start: "rainfrog", flags: { start: false }, lazyPane: true },
+        mailtrap: { start: "mailpit", flags: { start: false }, lazyPane: true },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [
+          { pane: "@tui", size: "10%" },
+          { pane: "dev", size: "40%" },
+          { pane: "db", size: "20%" },
+          { pane: "rainfrog", size: "20%" },
+          { pane: "mailtrap", size: "20%" },
+        ],
+      };
+
+      const { paneMap } = await createLayout("%0", layout, services, undefined, {
+        skip: new Set(["rainfrog", "mailtrap"]),
+      });
+
+      expect(paneMap["@tui"]).toBe("%0");
+      expect(paneMap.dev).toBeDefined();
+      expect(paneMap.db).toBeDefined();
+      expect(paneMap.rainfrog).toBeUndefined();
+      expect(paneMap.mailtrap).toBeUndefined();
+      // Survivor weights = [10, 40, 20], total = 70.
+      // Split 1: @tui keeps 10/70, rest = 60/70 → tmux percent = round(60/70*100) = 86.
+      // Split 2: dev keeps 40/60, rest = 20/60 → tmux percent = round(20/60*100) = 33.
+      expect(mockSplitPane).toHaveBeenNthCalledWith(1, "%0", "h", { percent: 86 });
+      expect(mockSplitPane).toHaveBeenNthCalledWith(2, "%1", "h", { percent: 33 });
+      expect(mockSplitPane).toHaveBeenCalledTimes(2);
+    });
+
     it("throws when every layout leaf is skipped (impossible with @tui present)", async () => {
       // Defensive: if the caller manages to skip @tui somehow we surface a clear error
       // Rather than producing a paneMap-less window. P04-T02's guard ensures the

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -9,8 +9,10 @@ vi.mock("../../src/lib/tmux.js", () => ({
 }));
 
 import {
+  computeRects,
   createLayout,
   filterTree,
+  PaneTooSmallError,
   validateLayout,
   validateLayoutSizes,
 } from "../../src/lib/tmux-layout.js";
@@ -500,6 +502,170 @@ describe("filterTree", () => {
     };
 
     expect(filterTree(layout, new Set())).toBeUndefined();
+  });
+});
+
+describe("computeRects", () => {
+  function sum(values: number[]): number {
+    return values.reduce((acc, value) => acc + value, 0);
+  }
+
+  it("2-pane columns 80x24: first child takes the rounded-up half", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "50%" },
+        { pane: "api", size: "50%" },
+      ],
+    };
+
+    const rects = computeRects(tree, 80, 24);
+
+    // Captured from live tmux: 80x24 column split → 40 | divider@40 | 39.
+    expect(rects.get("@tui")).toEqual({ x: 0, y: 0, width: 40, height: 24 });
+    expect(rects.get("api")).toEqual({ x: 41, y: 0, width: 39, height: 24 });
+    // Divider accounting: 40 + 39 + 1 divider === 80.
+    expect(40 + 39 + 1).toBe(80);
+  });
+
+  it("2-pane rows 80x24: first child takes the rounded-up half of the height", () => {
+    const tree: LayoutNode = {
+      direction: "rows",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+
+    const rects = computeRects(tree, 80, 24);
+
+    // Content = 24 - 1 = 23; round(23 * 0.5) = 12, last = 11.
+    expect(rects.get("@tui")).toEqual({ x: 0, y: 0, width: 80, height: 12 });
+    expect(rects.get("api")).toEqual({ x: 0, y: 13, width: 80, height: 11 });
+  });
+
+  it("3-pane columns: extents + dividers fill the parent exactly", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+
+    const rects = computeRects(tree, 80, 24);
+
+    const widths = ["@tui", "api", "web"].map((name) => rects.get(name)?.width ?? 0);
+    // Content = 80 - 2 = 78, three equal implicit shares → 26 each.
+    expect(widths).toEqual([26, 26, 26]);
+    expect(sum(widths) + 2).toBe(80);
+    // Each child offset = previous offset + extent + 1 divider.
+    expect(rects.get("@tui")?.x).toBe(0);
+    expect(rects.get("api")?.x).toBe(27);
+    expect(rects.get("web")?.x).toBe(54);
+    // Cross-axis matches the parent.
+    for (const name of ["@tui", "api", "web"]) {
+      expect(rects.get(name)?.height).toBe(24);
+    }
+  });
+
+  it("3-level nested layout reproduces the captured tmux geometry (100x30)", () => {
+    // Captured string: 100x30,0,0{50x30,0,0,A[49x15,...B{24x14,...C 24x14,...D}]}
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "A" },
+        {
+          direction: "rows",
+          children: [
+            { pane: "B" },
+            {
+              direction: "columns",
+              children: [{ pane: "C" }, { pane: "D" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const rects = computeRects(tree, 100, 30);
+
+    expect(rects.get("A")).toEqual({ x: 0, y: 0, width: 50, height: 30 });
+    expect(rects.get("B")).toEqual({ x: 51, y: 0, width: 49, height: 15 });
+    expect(rects.get("C")).toEqual({ x: 51, y: 16, width: 24, height: 14 });
+    expect(rects.get("D")).toEqual({ x: 76, y: 16, width: 24, height: 14 });
+  });
+
+  it("rescales surviving proportions to fill (no gap after a filterTree drop)", () => {
+    // FilterTree leaves survivors with their declared percents (here 30% + 30%,
+    // Summing to 60 < 100). computeRects MUST normalize them to fill the extent.
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "api", size: "30%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+
+    const rects = computeRects(tree, 80, 24);
+
+    const api = rects.get("api");
+    const web = rects.get("web");
+    expect(api).toEqual({ x: 0, y: 0, width: 40, height: 24 });
+    expect(web).toEqual({ x: 41, y: 0, width: 39, height: 24 });
+    // Exactly fills: no leftover gap on the right edge.
+    expect((web?.x ?? 0) + (web?.width ?? 0)).toBe(80);
+  });
+
+  it("end-to-end with filterTree: dropping a middle child reclaims its space", () => {
+    const declared: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui", size: "30%" },
+        { pane: "api", size: "40%" },
+        { pane: "web", size: "30%" },
+      ],
+    };
+
+    const filtered = filterTree(declared, new Set(["@tui", "web"]));
+    const rects = computeRects(filtered!, 80, 24);
+
+    // @tui 30% + web 30% rescaled to fill 80 cols with a 1-cell divider.
+    const tui = rects.get("@tui");
+    const web = rects.get("web");
+    expect(tui?.x).toBe(0);
+    expect((web?.x ?? 0) + (web?.width ?? 0)).toBe(80);
+    expect((tui?.width ?? 0) + (web?.width ?? 0) + 1).toBe(80);
+  });
+
+  it("single-leaf tree fills the whole window", () => {
+    expect(computeRects({ pane: "@tui" }, 80, 24)).toEqual(
+      new Map([["@tui", { x: 0, y: 0, width: 80, height: 24 }]]),
+    );
+  });
+
+  it("throws PaneTooSmallError naming the pane when an extent < 1", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+
+    // Width 2, 3 children → content = 0, every extent collapses below 1.
+    let thrown: unknown;
+    try {
+      computeRects(tree, 2, 24);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(PaneTooSmallError);
+    if (!(thrown instanceof PaneTooSmallError)) {
+      throw new Error("expected a PaneTooSmallError");
+    }
+    expect(thrown.pane).toBe("@tui");
+    expect(thrown.code).toBe("PANE_TOO_SMALL");
+  });
+
+  it("throws PaneTooSmallError on a zero-height window for a rows split", () => {
+    const tree: LayoutNode = {
+      direction: "rows",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+
+    expect(() => computeRects(tree, 80, 0)).toThrow(PaneTooSmallError);
   });
 });
 

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -86,7 +86,7 @@ describe("createLayout", () => {
     expect(paneMap.api).toBe("%1");
     expect(mockSplitPane).toHaveBeenCalledTimes(1);
     // Direction "rows" maps to "v"
-    expect(mockSplitPane).toHaveBeenCalledWith("%0", "v", 50);
+    expect(mockSplitPane).toHaveBeenCalledWith("%0", "v", { percent: 50 });
   });
 
   it("nested layout: correct split sequence and pane mapping", async () => {
@@ -142,9 +142,9 @@ describe("createLayout", () => {
     expect(paneMap.web).toBe("%2");
 
     // Child 1 (api): split from %0, remaining = 60, tmux = round(60/100*100) = 60
-    expect(mockSplitPane).toHaveBeenNthCalledWith(1, "%0", "h", 60);
+    expect(mockSplitPane).toHaveBeenNthCalledWith(1, "%0", "h", { percent: 60 });
     // Child 2 (web): split from %1, remaining = 30, tmux = round(30/60*100) = 50
-    expect(mockSplitPane).toHaveBeenNthCalledWith(2, "%1", "h", 50);
+    expect(mockSplitPane).toHaveBeenNthCalledWith(2, "%1", "h", { percent: 50 });
   });
 
   it("services not in layout get split panes", async () => {
@@ -186,7 +186,7 @@ describe("createLayout", () => {
 
     // Implicit child gets remainder: 100 - 60 = 40
     // CurrentPaneSize = 100, tmux = round(40/100*100) = 40
-    expect(mockSplitPane).toHaveBeenCalledWith("%0", "v", 40);
+    expect(mockSplitPane).toHaveBeenCalledWith("%0", "v", { percent: 40 });
   });
 
   it("returns focusPane when a leaf has focus: true", async () => {

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -16,6 +16,7 @@ import {
   layoutString,
   PaneTooSmallError,
   resolvePermutation,
+  splitAnchor,
   validateLayout,
   validateLayoutSizes,
 } from "../../src/lib/tmux-layout.js";
@@ -874,6 +875,98 @@ describe("resolvePermutation", () => {
     expect(() => resolvePermutation(["A", "B", "C"], ["A", "B"])).toThrow(
       /not permutations of the same set/,
     );
+  });
+});
+
+describe("splitAnchor", () => {
+  it("flat columns, insert at middle: splits after the previous leaf", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+
+    expect(splitAnchor(tree, "api")).toEqual({ mode: "after", predecessor: "@tui" });
+  });
+
+  it("flat columns, insert at end: splits after the last existing leaf", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+
+    expect(splitAnchor(tree, "web")).toEqual({ mode: "after", predecessor: "api" });
+  });
+
+  it("flat columns, insert at front: splits before the next leaf", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "api" }, { pane: "@tui" }, { pane: "web" }],
+    };
+
+    expect(splitAnchor(tree, "api")).toEqual({ mode: "before", successor: "@tui" });
+  });
+
+  it("nested layout: uses DFS leaf order across sub-splits (predecessor)", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [
+        { pane: "@tui" },
+        {
+          direction: "rows",
+          children: [{ pane: "api" }, { pane: "worker" }, { pane: "web" }],
+        },
+      ],
+    };
+
+    // DFS leaf order: @tui, api, worker, web. Inserting "worker" → after "api".
+    expect(splitAnchor(tree, "worker")).toEqual({ mode: "after", predecessor: "api" });
+  });
+
+  it("nested layout: first leaf inside a sub-split anchors before the next DFS leaf", () => {
+    const tree: LayoutNode = {
+      direction: "rows",
+      children: [
+        {
+          direction: "columns",
+          children: [{ pane: "api" }, { pane: "web" }],
+        },
+        { pane: "@tui" },
+      ],
+    };
+
+    // DFS leaf order: api, web, @tui. Inserting "api" (slot 0) → before "web".
+    expect(splitAnchor(tree, "api")).toEqual({ mode: "before", successor: "web" });
+  });
+
+  it("single other pane: front insert anchors before that pane", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "api" }, { pane: "@tui" }],
+    };
+
+    expect(splitAnchor(tree, "api")).toEqual({ mode: "before", successor: "@tui" });
+  });
+
+  it("single other pane: end insert anchors after that pane", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+
+    expect(splitAnchor(tree, "api")).toEqual({ mode: "after", predecessor: "@tui" });
+  });
+
+  it("throws when the pane is not a leaf in the tree", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+
+    expect(() => splitAnchor(tree, "missing")).toThrow(/not a leaf in the target tree/);
+  });
+
+  it("throws when the pane is the only leaf (no neighbor)", () => {
+    expect(() => splitAnchor({ pane: "@tui" }, "@tui")).toThrow(/only leaf/);
   });
 });
 

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -321,6 +321,133 @@ describe("createLayout", () => {
     // Exactly two splits: api (%1) + the single shared group pane (%2).
     expect(mockSplitPane).toHaveBeenCalledTimes(2);
   });
+
+  describe("boot-skip (P04-T03)", () => {
+    it("skipped layout-referenced leaf gets no paneMap entry; survivors still mapped", async () => {
+      const services: Record<string, ServiceConfig> = {
+        api: { start: "npm start" },
+        worker: { start: "node w.js", flags: { start: false }, lazyPane: true },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "@tui" }, { pane: "api" }, { pane: "worker" }],
+      };
+
+      const { paneMap } = await createLayout("%0", layout, services, undefined, {
+        skip: new Set(["worker"]),
+      });
+
+      expect(paneMap["@tui"]).toBeDefined();
+      expect(paneMap.api).toBeDefined();
+      expect(paneMap.worker).toBeUndefined();
+    });
+
+    it("skipped leftover service (no layout) gets no paneMap entry", async () => {
+      const services: Record<string, ServiceConfig> = {
+        api: { start: "npm start" },
+        worker: { start: "node w.js", flags: { start: false }, lazyPane: true },
+      };
+
+      const { paneMap } = await createLayout("%0", undefined, services, undefined, {
+        skip: new Set(["worker"]),
+      });
+
+      expect(paneMap["@tui"]).toBe("%0");
+      expect(paneMap.api).toBeDefined();
+      expect(paneMap.worker).toBeUndefined();
+      // Exactly ONE split — `api` only (`worker` skipped).
+      expect(mockSplitPane).toHaveBeenCalledTimes(1);
+    });
+
+    it("@tui reserve survives skipping slot-0 leaf (Round-5 regression)", async () => {
+      // The CRITICAL regression: layout slot 0 declares the lazy service, NOT
+      // `@tui`. If reserveStartPaneForTui sees the raw layout it would treat
+      // `worker` as the first leaf — but walkLayout (against the filtered
+      // Tree) actually maps `@tui` to slot 0. The two views must agree.
+      const services: Record<string, ServiceConfig> = {
+        worker: { start: "node w.js", flags: { start: false }, lazyPane: true },
+        api: { start: "npm start" },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "worker" }, { pane: "@tui" }, { pane: "api" }],
+      };
+
+      const { paneMap } = await createLayout("%0", layout, services, undefined, {
+        skip: new Set(["worker"]),
+        reserveTuiPane: true,
+      });
+
+      // @tui maps to the start pane (the SURVIVING first leaf in the filtered
+      // Tree). If reserveStartPaneForTui had been fed the raw layout, it
+      // Would see `worker` first and swap @tui off %0 — mislabeling the Ink
+      // Pane and producing a relaid/killed TUI on the next reload.
+      expect(paneMap["@tui"]).toBe("%0");
+      expect(paneMap.api).toBeDefined();
+      expect(paneMap.worker).toBeUndefined();
+    });
+
+    it("no-skip path: byte-identical paneMap to the pre-skip behavior", async () => {
+      // Sanity: with `skip` omitted/empty the result is byte-identical to today.
+      const services: Record<string, ServiceConfig> = {
+        api: { start: "npm start" },
+        worker: { start: "node w.js" },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "@tui" }, { pane: "api" }, { pane: "worker" }],
+      };
+
+      const ref = await createLayout("%0", layout, services);
+      paneCounter = 0;
+      vi.clearAllMocks();
+      mockSplitPane.mockImplementation(async () => `%${(paneCounter += 1)}`);
+      mockKillPane.mockResolvedValue(undefined);
+      const withEmptySkip = await createLayout("%0", layout, services, undefined, {
+        skip: new Set<string>(),
+      });
+
+      expect(withEmptySkip.paneMap).toEqual(ref.paneMap);
+      expect(withEmptySkip.focusPane).toBe(ref.focusPane);
+    });
+
+    it("skipped focus leaf falls back to @tui as focus pane", async () => {
+      const services: Record<string, ServiceConfig> = {
+        api: { start: "npm start" },
+        worker: { start: "node w.js", flags: { start: false }, lazyPane: true },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "@tui" }, { pane: "api" }, { pane: "worker", focus: true }],
+      };
+
+      const { paneMap, focusPane } = await createLayout("%0", layout, services, undefined, {
+        skip: new Set(["worker"]),
+      });
+
+      // Worker was the declared focus target but it's skipped → fallback @tui.
+      expect(focusPane).toBe(paneMap["@tui"]);
+    });
+
+    it("throws when every layout leaf is skipped (impossible with @tui present)", async () => {
+      // Defensive: if the caller manages to skip @tui somehow we surface a clear error
+      // Rather than producing a paneMap-less window. P04-T02's guard ensures the
+      // Real caller never skips @tui, but this pins the contract.
+      const services: Record<string, ServiceConfig> = {
+        api: { start: "npm start", flags: { start: false }, lazyPane: true },
+      };
+      const layout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "api" }],
+      };
+
+      await expect(
+        createLayout("%0", layout, services, undefined, {
+          skip: new Set(["api"]),
+        }),
+      ).rejects.toThrow(/every layout leaf is skipped/);
+    });
+  });
 });
 
 describe("filterTree", () => {

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -9,9 +9,11 @@ vi.mock("../../src/lib/tmux.js", () => ({
 }));
 
 import {
+  checksum,
   computeRects,
   createLayout,
   filterTree,
+  layoutString,
   PaneTooSmallError,
   validateLayout,
   validateLayoutSizes,
@@ -666,6 +668,143 @@ describe("computeRects", () => {
     };
 
     expect(() => computeRects(tree, 80, 0)).toThrow(PaneTooSmallError);
+  });
+});
+
+describe("checksum", () => {
+  // Golden strings captured live from tmux next-3.7 via `#{window_layout}`:
+  // `tmux -L test new-session -d -x 100 -y 30; tmux -L test split-window ...;
+  //  Tmux -L test display -p '#{window_layout}'`.
+  const GOLDENS: { name: string; full: string }[] = [
+    { name: "single", full: "a87d,100x30,0,0,0" },
+    { name: "columns", full: "eb8f,100x30,0,0{50x30,0,0,1,49x30,51,0,2}" },
+    { name: "rows", full: "4892,100x30,0,0[100x15,0,0,3,100x14,0,16,4]" },
+    {
+      name: "nested",
+      full: "a80c,100x30,0,0[100x15,0,0,5,100x14,0,16{50x14,0,16,6,49x14,51,16,7}]",
+    },
+  ];
+
+  for (const { name, full } of GOLDENS) {
+    it(`matches tmux's checksum prefix for the ${name} layout`, () => {
+      const comma = full.indexOf(",");
+      const prefix = full.slice(0, comma);
+      const body = full.slice(comma + 1);
+      expect(checksum(body)).toBe(prefix);
+    });
+  }
+
+  it("returns a lowercase, zero-padded 4-hex-digit string", () => {
+    const result = checksum("100x30,0,0,0");
+    expect(result).toMatch(/^[0-9a-f]{4}$/);
+  });
+});
+
+describe("layoutString", () => {
+  it("single-pane tree → bare leaf cell, no braces (byte-for-byte vs tmux)", () => {
+    const tree: LayoutNode = { pane: "@tui" };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([["@tui", 0]]);
+
+    expect(layoutString(tree, rects, paneNumbers)).toBe("a87d,100x30,0,0,0");
+  });
+
+  it("flat columns round-trips a captured tmux string", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "left" }, { pane: "right" }],
+    };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([
+      ["left", 1],
+      ["right", 2],
+    ]);
+
+    expect(layoutString(tree, rects, paneNumbers)).toBe(
+      "eb8f,100x30,0,0{50x30,0,0,1,49x30,51,0,2}",
+    );
+  });
+
+  it("flat rows round-trips a captured tmux string", () => {
+    const tree: LayoutNode = {
+      direction: "rows",
+      children: [{ pane: "top" }, { pane: "bottom" }],
+    };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([
+      ["top", 3],
+      ["bottom", 4],
+    ]);
+
+    expect(layoutString(tree, rects, paneNumbers)).toBe(
+      "4892,100x30,0,0[100x15,0,0,3,100x14,0,16,4]",
+    );
+  });
+
+  it("3-level nested round-trips a captured tmux string byte-for-byte", () => {
+    const tree: LayoutNode = {
+      direction: "rows",
+      children: [
+        { pane: "A" },
+        {
+          direction: "columns",
+          children: [{ pane: "B" }, { pane: "C" }],
+        },
+      ],
+    };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([
+      ["A", 5],
+      ["B", 6],
+      ["C", 7],
+    ]);
+
+    expect(layoutString(tree, rects, paneNumbers)).toBe(
+      "a80c,100x30,0,0[100x15,0,0,5,100x14,0,16{50x14,0,16,6,49x14,51,16,7}]",
+    );
+  });
+
+  it("checksum prefix equals checksum(body) of the emitted string", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "left" }, { pane: "right" }],
+    };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([
+      ["left", 1],
+      ["right", 2],
+    ]);
+
+    const result = layoutString(tree, rects, paneNumbers);
+    const body = result.slice(result.indexOf(",") + 1);
+    expect(result.startsWith(`${checksum(body)},`)).toBe(true);
+  });
+
+  it("throws when a leaf has no pane number", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "left" }, { pane: "right" }],
+    };
+    const rects = computeRects(tree, 100, 30);
+    const paneNumbers = new Map([["left", 1]]);
+
+    expect(() => layoutString(tree, rects, paneNumbers)).toThrow(/no pane number for pane 'right'/);
+  });
+
+  it("throws when a leaf has no computed rect", () => {
+    const tree: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "left" }, { pane: "right" }],
+    };
+    const rects = computeRects({ pane: "left" }, 100, 30);
+    const paneNumbers = new Map([
+      ["left", 1],
+      ["right", 2],
+    ]);
+
+    expect(() => layoutString(tree, rects, paneNumbers)).toThrow(
+      /no rect computed for pane 'right'/,
+    );
   });
 });
 

--- a/test/lib/tmux-reflow.test.ts
+++ b/test/lib/tmux-reflow.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { LayoutNode } from "../../src/config/types.js";
 import { LayoutReflow } from "../../src/lib/tmux-reflow.js";
 import type { LayoutReflowDeps, PaneMap } from "../../src/lib/tmux-reflow.js";
+import type { SplitPaneOptions } from "../../src/lib/tmux.js";
 
 interface FakeTmux {
   getWindowSize: Mock<(target: string) => Promise<{ width: number; height: number }>>;
@@ -11,6 +12,10 @@ interface FakeTmux {
   swapPanes: Mock<(src: string, dst: string) => Promise<void>>;
   selectLayout: Mock<(target: string, layout: string) => Promise<void>>;
   resyncPaneSizes: Mock<(target: string) => Promise<void>>;
+  splitPane: Mock<
+    (target: string, direction: "h" | "v", options?: SplitPaneOptions) => Promise<string>
+  >;
+  selectPane: Mock<(target: string) => Promise<void>>;
 }
 
 function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 }): FakeTmux {
@@ -22,6 +27,8 @@ function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 })
     swapPanes: vi.fn<FakeTmux["swapPanes"]>().mockResolvedValue(undefined),
     selectLayout: vi.fn<FakeTmux["selectLayout"]>().mockResolvedValue(undefined),
     resyncPaneSizes: vi.fn<FakeTmux["resyncPaneSizes"]>().mockResolvedValue(undefined),
+    splitPane: vi.fn<FakeTmux["splitPane"]>().mockResolvedValue("%99"),
+    selectPane: vi.fn<FakeTmux["selectPane"]>().mockResolvedValue(undefined),
   };
 }
 
@@ -29,6 +36,7 @@ function makeReflow(
   layout: LayoutNode | undefined,
   paneMap: PaneMap,
   tmux: FakeTmux,
+  extra: Partial<LayoutReflowDeps> = {},
 ): { reflow: LayoutReflow; deps: LayoutReflowDeps } {
   const deps: LayoutReflowDeps = {
     getLayout: () => layout,
@@ -39,6 +47,9 @@ function makeReflow(
     swapPanes: tmux.swapPanes,
     selectLayout: tmux.selectLayout,
     resyncPaneSizes: tmux.resyncPaneSizes,
+    splitPane: tmux.splitPane,
+    selectPane: tmux.selectPane,
+    ...extra,
   };
   return { reflow: new LayoutReflow(deps), deps };
 }
@@ -256,5 +267,215 @@ describe("LayoutReflow — live getters survive Session._reload's paneMap reassi
     const [, [, secondLayout]] = tmux.selectLayout.mock.calls;
     expect(secondLayout.includes("[")).toBe(true); // Rows → `[...]`.
     expect(secondLayout.includes("{")).toBe(false);
+  });
+});
+
+describe("LayoutReflow.insertPane — zero-swap adjacency split", () => {
+  it("splits off the predecessor with -d for a middle insert", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1", web: "%3" }; // Api currently pane-less.
+    // Post-split spatial order = target DFS order → zero swaps in applyGeometry.
+    const tmux = makeFakeTmux(["%1", "%99", "%3"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const onPaneInserted = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInserted });
+
+    await reflow.insertPane("api");
+
+    // Split off the PREDECESSOR (@tui = %1) with detached + columns axis (-h).
+    expect(tmux.splitPane).toHaveBeenCalledTimes(1);
+    expect(tmux.splitPane).toHaveBeenCalledWith("%1", "h", {
+      detached: true,
+      before: false,
+    });
+    // PaneMap updated.
+    expect(paneMap.api).toBe("%99");
+    // Hook fired with (name, paneId).
+    expect(onPaneInserted).toHaveBeenCalledTimes(1);
+    expect(onPaneInserted).toHaveBeenCalledWith("api", "%99");
+    // ApplyGeometry ran exactly one selectLayout afterwards.
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    expect(tmux.swapPanes).not.toHaveBeenCalled();
+    // No focus stolen (leaf has no focus:true).
+    expect(tmux.selectPane).not.toHaveBeenCalled();
+  });
+
+  it("uses successor + before:true when inserting at the first position", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "api" }, { pane: "@tui" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%99", "%1"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.insertPane("api");
+
+    expect(tmux.splitPane).toHaveBeenCalledWith("%1", "h", {
+      detached: true,
+      before: true,
+    });
+    expect(paneMap.api).toBe("%99");
+  });
+
+  it("mirrors the parent split axis — rows → 'v', columns → 'h'", async () => {
+    const layout: LayoutNode = {
+      direction: "rows",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1", "%99"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.insertPane("api");
+
+    expect(tmux.splitPane).toHaveBeenCalledWith("%1", "v", {
+      detached: true,
+      before: false,
+    });
+  });
+
+  it("calls applyGeometry with the target visible set (current ∪ {name})", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1", web: "%3" };
+    const tmux = makeFakeTmux(["%1", "%99", "%3"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.insertPane("api");
+
+    // SelectLayout layout string is the body of applyGeometry's work; since
+    // The fake's spatialOrder = target DFS order, zero swaps happened, and the
+    // ONE selectLayout proves applyGeometry ran over the {@tui, api, web} set.
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    const [[, layoutStr]] = tmux.selectLayout.mock.calls;
+    // Encoded pane numbers 1, 99, 3 (from paneMap) must appear in DFS order.
+    expect(layoutStr).toMatch(/,1\b.*,99\b.*,3\b/u);
+  });
+
+  it("moves focus to the new pane only when the layout leaf has focus:true", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api", focus: true }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1", "%99"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.insertPane("api");
+
+    expect(tmux.selectPane).toHaveBeenCalledTimes(1);
+    expect(tmux.selectPane).toHaveBeenCalledWith("%99");
+  });
+
+  it("leaves the previously active pane active when focus:true is absent", async () => {
+    // Already covered above but pinned explicitly here so a future regression
+    // That defaults focus=true is impossible to ship.
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1", "%99"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.insertPane("api");
+
+    expect(tmux.selectPane).not.toHaveBeenCalled();
+  });
+
+  it("hook is optional — insertPane completes without onPaneInserted", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1", "%99"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    const { reflow } = makeReflow(layout, paneMap, tmux); // No onPaneInserted.
+
+    await expect(reflow.insertPane("api")).resolves.toBeUndefined();
+    expect(paneMap.api).toBe("%99");
+  });
+
+  it("leaves paneMap unchanged when the split itself fails", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1"]);
+    tmux.splitPane.mockRejectedValue(new Error("tmux: split-window failed"));
+    const onPaneInserted = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInserted });
+
+    await expect(reflow.insertPane("api")).rejects.toThrow(/split-window failed/);
+    expect(paneMap.api).toBeUndefined();
+    expect(onPaneInserted).not.toHaveBeenCalled();
+    expect(tmux.selectLayout).not.toHaveBeenCalled();
+  });
+
+  it("rolls back paneMap when applyGeometry fails after the split succeeded", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1", "%99"]);
+    tmux.splitPane.mockResolvedValue("%99");
+    tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+    const onPaneInserted = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInserted });
+
+    await expect(reflow.insertPane("api")).rejects.toThrow(/select-layout failed/);
+    // The session hook DID fire (paneMap was momentarily set), but the rollback
+    // Removed the entry to keep the paneMap-⊇-visible invariant honest.
+    expect(onPaneInserted).toHaveBeenCalledWith("api", "%99");
+    expect(paneMap.api).toBeUndefined();
+  });
+
+  it("throws when the pane already has a tmux pane", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1", "%2"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await expect(reflow.insertPane("api")).rejects.toThrow(/already has a tmux pane/);
+    expect(tmux.splitPane).not.toHaveBeenCalled();
+  });
+
+  it("throws when the pane is not declared in the layout", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1" };
+    const tmux = makeFakeTmux(["%1"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await expect(reflow.insertPane("unknown")).rejects.toThrow(
+      /is not a leaf in the declared layout/,
+    );
+    expect(tmux.splitPane).not.toHaveBeenCalled();
+  });
+
+  it("throws when there is no declared layout", async () => {
+    const tmux = makeFakeTmux([]);
+    const { reflow } = makeReflow(undefined, { "@tui": "%1" }, tmux);
+
+    await expect(reflow.insertPane("api")).rejects.toThrow(/no declared layout/);
   });
 });

--- a/test/lib/tmux-reflow.test.ts
+++ b/test/lib/tmux-reflow.test.ts
@@ -2,7 +2,8 @@ import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
 
 import type { LayoutNode } from "../../src/config/types.js";
-import { LayoutReflow } from "../../src/lib/tmux-reflow.js";
+import { PaneTooSmallError } from "../../src/lib/tmux-layout.js";
+import { LayoutReflow, TmuxFailedError } from "../../src/lib/tmux-reflow.js";
 import type { LayoutReflowDeps, PaneMap } from "../../src/lib/tmux-reflow.js";
 import type { SplitPaneOptions } from "../../src/lib/tmux.js";
 
@@ -17,6 +18,7 @@ interface FakeTmux {
   >;
   selectPane: Mock<(target: string) => Promise<void>>;
   killPane: Mock<(target: string) => Promise<void>>;
+  windowLayout: Mock<(target: string) => Promise<string>>;
 }
 
 function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 }): FakeTmux {
@@ -31,6 +33,7 @@ function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 })
     splitPane: vi.fn<FakeTmux["splitPane"]>().mockResolvedValue("%99"),
     selectPane: vi.fn<FakeTmux["selectPane"]>().mockResolvedValue(undefined),
     killPane: vi.fn<FakeTmux["killPane"]>().mockResolvedValue(undefined),
+    windowLayout: vi.fn<FakeTmux["windowLayout"]>().mockResolvedValue("prior-layout-string"),
   };
 }
 
@@ -52,6 +55,7 @@ function makeReflow(
     splitPane: tmux.splitPane,
     selectPane: tmux.selectPane,
     killPane: tmux.killPane,
+    windowLayout: tmux.windowLayout,
     ...extra,
   };
   return { reflow: new LayoutReflow(deps), deps };
@@ -425,7 +429,12 @@ describe("LayoutReflow.insertPane — zero-swap adjacency split", () => {
     await expect(reflow.insertPane("api")).rejects.toThrow(/split-window failed/);
     expect(paneMap.api).toBeUndefined();
     expect(onPaneInserted).not.toHaveBeenCalled();
-    expect(tmux.selectLayout).not.toHaveBeenCalled();
+    // The split never produced a pane id, so the rollback only restores prior
+    // Geometry — that's exactly ONE selectLayout call (the rollback restore),
+    // NOT the productive applyGeometry one (that path was never reached).
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    expect(tmux.selectLayout).toHaveBeenCalledWith("@0", "prior-layout-string");
+    expect(tmux.killPane).not.toHaveBeenCalled();
   });
 
   it("rolls back paneMap when applyGeometry fails after the split succeeded", async () => {
@@ -436,15 +445,26 @@ describe("LayoutReflow.insertPane — zero-swap adjacency split", () => {
     const paneMap: PaneMap = { "@tui": "%1" };
     const tmux = makeFakeTmux(["%1", "%99"]);
     tmux.splitPane.mockResolvedValue("%99");
-    tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+    // The PRODUCTIVE selectLayout (inside applyGeometry) rejects. The ROLLBACK
+    // SelectLayout (restoring prior layout) succeeds — so the second call
+    // Doesn't reject and the original error rethrows uncovered.
+    tmux.selectLayout.mockRejectedValueOnce(new Error("tmux: select-layout failed"));
     const onPaneInserted = vi.fn();
-    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInserted });
+    const onPaneInsertFailed = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInserted, onPaneInsertFailed });
 
     await expect(reflow.insertPane("api")).rejects.toThrow(/select-layout failed/);
     // The session hook DID fire (paneMap was momentarily set), but the rollback
     // Removed the entry to keep the paneMap-⊇-visible invariant honest.
     expect(onPaneInserted).toHaveBeenCalledWith("api", "%99");
     expect(paneMap.api).toBeUndefined();
+    // Round-7 buffer-leak fix: onPaneInsertFailed fires so the session can free
+    // The just-allocated paneBuffers[%99] + monitor key.
+    expect(onPaneInsertFailed).toHaveBeenCalledWith("api", "%99");
+    // The dangling new pane is killed so the prior layout string can apply.
+    expect(tmux.killPane).toHaveBeenCalledWith("%99");
+    // ROLLBACK selectLayout restored the snapshotted prior layout.
+    expect(tmux.selectLayout).toHaveBeenLastCalledWith("@0", "prior-layout-string");
   });
 
   it("throws when the pane already has a tmux pane", async () => {
@@ -604,5 +624,263 @@ describe("LayoutReflow.removePane — kill + re-expand survivors", () => {
     // PaneMap untouched — we bailed before the kill.
     expect(paneMap.api).toBe("%2");
     expect(tmux.killPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("LayoutReflow rollback (P03-T04)", () => {
+  const layout: LayoutNode = {
+    direction: "columns",
+    children: [{ pane: "@tui" }, { pane: "api" }],
+  };
+
+  describe("insertPane fault injection", () => {
+    it("captures windowLayout BEFORE the split (rollback can restore it)", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1", "%99"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      const { reflow } = makeReflow(layout, paneMap, tmux);
+
+      await reflow.insertPane("api");
+
+      // SnapshotPrior was captured before any mutation, even though the happy
+      // Path doesn't restore it.
+      const [splitCallIdx] = tmux.splitPane.mock.invocationCallOrder;
+      const [windowLayoutCallIdx] = tmux.windowLayout.mock.invocationCallOrder;
+      expect(windowLayoutCallIdx).toBeLessThan(splitCallIdx);
+    });
+
+    it("on split failure: restores prior layout, paneMap untouched, throws TmuxFailedError", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      const splitErr = new Error("tmux: split-window failed");
+      tmux.splitPane.mockRejectedValue(splitErr);
+      const onPaneInsertFailed = vi.fn();
+      const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInsertFailed });
+
+      let thrown: unknown;
+      try {
+        await reflow.insertPane("api");
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(TmuxFailedError);
+      if (thrown instanceof TmuxFailedError) {
+        expect(thrown.code).toBe("TMUX_FAILED");
+        expect(thrown.cause).toBe(splitErr);
+        expect(thrown.message).toMatch(/split-window failed/);
+      }
+      // Restore happened.
+      expect(tmux.selectLayout).toHaveBeenCalledWith("@0", "snapshot-prior");
+      // No pane to kill / no hook to fire — newPaneId was never set.
+      expect(tmux.killPane).not.toHaveBeenCalled();
+      expect(onPaneInsertFailed).not.toHaveBeenCalled();
+      expect(paneMap.api).toBeUndefined();
+    });
+
+    it("on applyGeometry failure: kills new pane, fires onPaneInsertFailed, restores prior", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1", "%99"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.splitPane.mockResolvedValue("%99");
+      // First selectLayout (productive applyGeometry) fails; rollback selectLayout succeeds.
+      tmux.selectLayout.mockRejectedValueOnce(new Error("tmux: select-layout rejected the layout"));
+      const onPaneInsertFailed = vi.fn();
+      const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInsertFailed });
+
+      await expect(reflow.insertPane("api")).rejects.toBeInstanceOf(TmuxFailedError);
+
+      expect(paneMap.api).toBeUndefined(); // PaneMap rolled back.
+      expect(onPaneInsertFailed).toHaveBeenCalledWith("api", "%99"); // Buffer-leak fix.
+      expect(tmux.killPane).toHaveBeenCalledWith("%99"); // Dangling pane killed.
+      // Two selectLayout calls: the failed productive one + the restore.
+      expect(tmux.selectLayout).toHaveBeenCalledTimes(2);
+      expect(tmux.selectLayout).toHaveBeenLastCalledWith("@0", "snapshot-prior");
+    });
+
+    it("on swap-pane failure during applyGeometry: full rollback (kill + restore)", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%99", "%1"]); // Wrong order — applyGeometry will swap.
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.splitPane.mockResolvedValue("%99");
+      tmux.swapPanes.mockRejectedValue(new Error("tmux: swap-pane failed"));
+      const onPaneInsertFailed = vi.fn();
+      const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInsertFailed });
+
+      await expect(reflow.insertPane("api")).rejects.toThrow(/swap-pane failed/);
+
+      expect(paneMap.api).toBeUndefined();
+      expect(onPaneInsertFailed).toHaveBeenCalledWith("api", "%99");
+      expect(tmux.killPane).toHaveBeenCalledWith("%99");
+      expect(tmux.selectLayout).toHaveBeenCalledWith("@0", "snapshot-prior");
+    });
+
+    it("PaneTooSmallError passes through unwrapped (not coerced to TmuxFailedError)", async () => {
+      // Provoke computeRects → PaneTooSmallError by using a window so small no
+      // Two-leaf split fits. ApplyGeometry will throw inside the catch block.
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1", "%99"], { width: 1, height: 1 });
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.splitPane.mockResolvedValue("%99");
+      const onPaneInsertFailed = vi.fn();
+      const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneInsertFailed });
+
+      let thrown: unknown;
+      try {
+        await reflow.insertPane("api");
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(PaneTooSmallError);
+      // Rollback still happened.
+      expect(tmux.killPane).toHaveBeenCalledWith("%99");
+      expect(onPaneInsertFailed).toHaveBeenCalledWith("api", "%99");
+      expect(paneMap.api).toBeUndefined();
+    });
+
+    it("rollback failures NEVER mask the original error", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1", "%99"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.splitPane.mockResolvedValue("%99");
+      // The productive selectLayout AND the rollback selectLayout both fail.
+      tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+      // The kill rollback ALSO fails.
+      tmux.killPane.mockRejectedValue(new Error("tmux: kill-pane gone"));
+
+      const rollbackErrors: { phase: string; error: unknown }[] = [];
+      const { reflow } = makeReflow(layout, paneMap, tmux, {
+        onRollbackError: (phase, error) => {
+          rollbackErrors.push({ phase, error });
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await reflow.insertPane("api");
+      } catch (error) {
+        thrown = error;
+      }
+
+      // Original error wins. The rethrown error carries the ORIGINAL message,
+      // Not "kill-pane gone" or anything from the rollback chain.
+      expect(thrown).toBeInstanceOf(TmuxFailedError);
+      if (thrown instanceof TmuxFailedError) {
+        expect(thrown.message).toMatch(/select-layout failed/);
+      }
+      // Both rollback failures were reported (phase names).
+      const phases = rollbackErrors.map((e) => e.phase);
+      expect(phases).toContain("rollback:killPane");
+      expect(phases).toContain("rollback:restoreLayout");
+    });
+
+    it("a throwing onRollbackError diagnostic does NOT mask the original error", async () => {
+      const paneMap: PaneMap = { "@tui": "%1" };
+      const tmux = makeFakeTmux(["%1", "%99"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.splitPane.mockResolvedValue("%99");
+      tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+      tmux.killPane.mockRejectedValue(new Error("tmux: kill-pane gone"));
+
+      const { reflow } = makeReflow(layout, paneMap, tmux, {
+        onRollbackError: () => {
+          throw new Error("diagnostic callback exploded");
+        },
+      });
+
+      await expect(reflow.insertPane("api")).rejects.toThrow(/select-layout failed/);
+    });
+  });
+
+  describe("removePane fault injection", () => {
+    it("on kill-pane failure: paneMap untouched, throws TmuxFailedError", async () => {
+      const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+      const tmux = makeFakeTmux(["%1", "%2"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.killPane.mockRejectedValue(new Error("tmux: kill-pane failed"));
+      const onPaneRemoved = vi.fn();
+      const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneRemoved });
+
+      let thrown: unknown;
+      try {
+        await reflow.removePane("api");
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(TmuxFailedError);
+      if (thrown instanceof TmuxFailedError) {
+        expect(thrown.phase).toBe("removePane:killPane");
+      }
+      // Window was never mutated, so the snapshotted prior is not re-applied
+      // (no need — nothing changed).
+      expect(tmux.selectLayout).not.toHaveBeenCalled();
+      expect(paneMap.api).toBe("%2");
+      expect(onPaneRemoved).not.toHaveBeenCalled();
+    });
+
+    it("on applyGeometry failure after kill: reconciles paneMap against live state", async () => {
+      // Setup: 3-pane layout. Removing `api` (%2) succeeds (kill goes through),
+      // But the post-kill applyGeometry's selectLayout rejects. The rollback's
+      // ReconcilePaneMap pass reads paneIndexOrder and drops any paneMap entry
+      // Pointing at a dead pane id (here: a stale %2 wouldn't be in paneMap any
+      // More, but a parallel kill could create one — we simulate by returning a
+      // Live order missing one of the survivors).
+      const threeLayout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+      };
+      const paneMap: PaneMap = { "@tui": "%1", api: "%2", web: "%3" };
+      const tmux = makeFakeTmux(["%1", "%3"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+      // Simulate a concurrent kill that took web (%3) too.
+      tmux.paneIndexOrder.mockResolvedValueOnce([
+        { index: 1, id: "%1" },
+        { index: 2, id: "%3" },
+      ]);
+      // Reconciliation pass: live = only %1.
+      tmux.paneIndexOrder.mockResolvedValueOnce([{ index: 1, id: "%1" }]);
+      const { reflow } = makeReflow(threeLayout, paneMap, tmux);
+
+      await expect(reflow.removePane("api")).rejects.toBeInstanceOf(TmuxFailedError);
+
+      // The kill ran (api gone), and reconciliation dropped the dead `web` entry.
+      expect(paneMap.api).toBeUndefined();
+      expect(paneMap.web).toBeUndefined();
+      expect(paneMap["@tui"]).toBe("%1");
+      expect(tmux.killPane).toHaveBeenCalledWith("%2");
+    });
+
+    it("rollback failures NEVER mask the original error (remove path)", async () => {
+      const threeLayout: LayoutNode = {
+        direction: "columns",
+        children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+      };
+      const paneMap: PaneMap = { "@tui": "%1", api: "%2", web: "%3" };
+      const tmux = makeFakeTmux(["%1", "%3"]);
+      tmux.windowLayout.mockResolvedValue("snapshot-prior");
+      // Productive applyGeometry selectLayout fails (the ORIGINAL error).
+      tmux.selectLayout.mockRejectedValue(new Error("tmux: select-layout failed"));
+      // ApplyGeometry's paneIndexOrder succeeds (so we reach selectLayout); the
+      // SECOND paneIndexOrder (rollback's reconciliation) fails.
+      tmux.paneIndexOrder.mockReset();
+      tmux.paneIndexOrder.mockResolvedValueOnce([
+        { index: 1, id: "%1" },
+        { index: 2, id: "%3" },
+      ]);
+      tmux.paneIndexOrder.mockRejectedValue(new Error("tmux: list-panes broke"));
+
+      const rollbackErrors: string[] = [];
+      const { reflow } = makeReflow(threeLayout, paneMap, tmux, {
+        onRollbackError: (phase) => {
+          rollbackErrors.push(phase);
+        },
+      });
+
+      await expect(reflow.removePane("api")).rejects.toThrow(/select-layout failed/);
+      expect(rollbackErrors).toContain("rollback:reconcilePaneMap");
+    });
   });
 });

--- a/test/lib/tmux-reflow.test.ts
+++ b/test/lib/tmux-reflow.test.ts
@@ -16,6 +16,7 @@ interface FakeTmux {
     (target: string, direction: "h" | "v", options?: SplitPaneOptions) => Promise<string>
   >;
   selectPane: Mock<(target: string) => Promise<void>>;
+  killPane: Mock<(target: string) => Promise<void>>;
 }
 
 function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 }): FakeTmux {
@@ -29,6 +30,7 @@ function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 })
     resyncPaneSizes: vi.fn<FakeTmux["resyncPaneSizes"]>().mockResolvedValue(undefined),
     splitPane: vi.fn<FakeTmux["splitPane"]>().mockResolvedValue("%99"),
     selectPane: vi.fn<FakeTmux["selectPane"]>().mockResolvedValue(undefined),
+    killPane: vi.fn<FakeTmux["killPane"]>().mockResolvedValue(undefined),
   };
 }
 
@@ -49,6 +51,7 @@ function makeReflow(
     resyncPaneSizes: tmux.resyncPaneSizes,
     splitPane: tmux.splitPane,
     selectPane: tmux.selectPane,
+    killPane: tmux.killPane,
     ...extra,
   };
   return { reflow: new LayoutReflow(deps), deps };
@@ -477,5 +480,129 @@ describe("LayoutReflow.insertPane — zero-swap adjacency split", () => {
     const { reflow } = makeReflow(undefined, { "@tui": "%1" }, tmux);
 
     await expect(reflow.insertPane("api")).rejects.toThrow(/no declared layout/);
+  });
+});
+
+describe("LayoutReflow.removePane — kill + re-expand survivors", () => {
+  const layout: LayoutNode = {
+    direction: "columns",
+    children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+  };
+
+  it("kills the pane, deletes the paneMap entry, and re-expands survivors", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2", web: "%3" };
+    // After kill, survivors in DFS order = [%1, %3] → zero swaps in applyGeometry.
+    const tmux = makeFakeTmux(["%1", "%3"]);
+    const onPaneRemoved = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneRemoved });
+
+    await reflow.removePane("api");
+
+    // Kill with the pre-delete pane id.
+    expect(tmux.killPane).toHaveBeenCalledTimes(1);
+    expect(tmux.killPane).toHaveBeenCalledWith("%2");
+    // PaneMap entry removed.
+    expect(paneMap.api).toBeUndefined();
+    expect(paneMap["@tui"]).toBe("%1");
+    expect(paneMap.web).toBe("%3");
+    // Hook fired with (name, OLD paneId) — captured pre-delete.
+    expect(onPaneRemoved).toHaveBeenCalledTimes(1);
+    expect(onPaneRemoved).toHaveBeenCalledWith("api", "%2");
+    // ApplyGeometry ran ONE selectLayout, ZERO swaps.
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    expect(tmux.swapPanes).not.toHaveBeenCalled();
+  });
+
+  it("passes the remaining visible set to applyGeometry (survivors only)", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2", web: "%3" };
+    const tmux = makeFakeTmux(["%1", "%3"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.removePane("api");
+
+    // The select-layout body should encode pane numbers 1 and 3 (the survivors),
+    // And NOT contain pane number 2 (the just-killed `api`).
+    const [[, layoutStr]] = tmux.selectLayout.mock.calls;
+    expect(layoutStr).toMatch(/,1\b/u);
+    expect(layoutStr).toMatch(/,3\b/u);
+    expect(layoutStr).not.toMatch(/,2\b/u);
+  });
+
+  it("is idempotent — no-op when the name has no pane in paneMap", async () => {
+    const paneMap: PaneMap = { "@tui": "%1" }; // No `api` entry.
+    const tmux = makeFakeTmux(["%1"]);
+    const onPaneRemoved = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneRemoved });
+
+    await expect(reflow.removePane("api")).resolves.toBeUndefined();
+
+    expect(tmux.killPane).not.toHaveBeenCalled();
+    expect(onPaneRemoved).not.toHaveBeenCalled();
+    expect(tmux.selectLayout).not.toHaveBeenCalled();
+    // PaneMap unchanged.
+    expect(paneMap).toEqual({ "@tui": "%1" });
+  });
+
+  it("refuses to remove the '@tui' pane", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1", "%2"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await expect(reflow.removePane("@tui")).rejects.toThrow(/refusing to remove the '@tui'/);
+    // Nothing else fired.
+    expect(tmux.killPane).not.toHaveBeenCalled();
+    expect(paneMap["@tui"]).toBe("%1");
+  });
+
+  it("leaves paneMap untouched on kill-pane failure", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1", "%2"]);
+    tmux.killPane.mockRejectedValue(new Error("tmux: kill-pane failed"));
+    const onPaneRemoved = vi.fn();
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneRemoved });
+
+    await expect(reflow.removePane("api")).rejects.toThrow(/kill-pane failed/);
+
+    // Pre-delete kill failed → paneMap entry still present.
+    expect(paneMap.api).toBe("%2");
+    expect(onPaneRemoved).not.toHaveBeenCalled();
+    expect(tmux.selectLayout).not.toHaveBeenCalled();
+  });
+
+  it("hook is optional — removePane completes without onPaneRemoved", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux); // No onPaneRemoved.
+
+    await expect(reflow.removePane("api")).resolves.toBeUndefined();
+    expect(paneMap.api).toBeUndefined();
+  });
+
+  it("captures pane id BEFORE deleting (hook receives the old id, not undefined)", async () => {
+    // Regression guard against a refactor that delete-first / fire-second.
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1"]);
+    let observedPaneId: string | undefined;
+    const onPaneRemoved = vi.fn((name: string, paneId: string) => {
+      observedPaneId = paneId;
+      // Inside the hook, paneMap.api must already be deleted (the hook fires
+      // AFTER the delete) — but `paneId` is the captured pre-delete value.
+      expect(paneMap[name]).toBeUndefined();
+    });
+    const { reflow } = makeReflow(layout, paneMap, tmux, { onPaneRemoved });
+
+    await reflow.removePane("api");
+    expect(observedPaneId).toBe("%2");
+  });
+
+  it("throws when no layout is declared (cannot reflow survivors)", async () => {
+    const paneMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const tmux = makeFakeTmux(["%1"]);
+    const { reflow } = makeReflow(undefined, paneMap, tmux);
+
+    await expect(reflow.removePane("api")).rejects.toThrow(/no declared layout/);
+    // PaneMap untouched — we bailed before the kill.
+    expect(paneMap.api).toBe("%2");
+    expect(tmux.killPane).not.toHaveBeenCalled();
   });
 });

--- a/test/lib/tmux-reflow.test.ts
+++ b/test/lib/tmux-reflow.test.ts
@@ -1,0 +1,260 @@
+import type { Mock } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LayoutNode } from "../../src/config/types.js";
+import { LayoutReflow } from "../../src/lib/tmux-reflow.js";
+import type { LayoutReflowDeps, PaneMap } from "../../src/lib/tmux-reflow.js";
+
+interface FakeTmux {
+  getWindowSize: Mock<(target: string) => Promise<{ width: number; height: number }>>;
+  paneIndexOrder: Mock<(target: string) => Promise<{ index: number; id: string }[]>>;
+  swapPanes: Mock<(src: string, dst: string) => Promise<void>>;
+  selectLayout: Mock<(target: string, layout: string) => Promise<void>>;
+  resyncPaneSizes: Mock<(target: string) => Promise<void>>;
+}
+
+function makeFakeTmux(spatialOrder: string[], size = { width: 100, height: 30 }): FakeTmux {
+  return {
+    getWindowSize: vi.fn<FakeTmux["getWindowSize"]>().mockResolvedValue(size),
+    paneIndexOrder: vi
+      .fn<FakeTmux["paneIndexOrder"]>()
+      .mockResolvedValue(spatialOrder.map((id, index) => ({ index: index + 1, id }))),
+    swapPanes: vi.fn<FakeTmux["swapPanes"]>().mockResolvedValue(undefined),
+    selectLayout: vi.fn<FakeTmux["selectLayout"]>().mockResolvedValue(undefined),
+    resyncPaneSizes: vi.fn<FakeTmux["resyncPaneSizes"]>().mockResolvedValue(undefined),
+  };
+}
+
+function makeReflow(
+  layout: LayoutNode | undefined,
+  paneMap: PaneMap,
+  tmux: FakeTmux,
+): { reflow: LayoutReflow; deps: LayoutReflowDeps } {
+  const deps: LayoutReflowDeps = {
+    getLayout: () => layout,
+    getPaneMap: () => paneMap,
+    getWindowTarget: () => "@0",
+    getWindowSize: tmux.getWindowSize,
+    paneIndexOrder: tmux.paneIndexOrder,
+    swapPanes: tmux.swapPanes,
+    selectLayout: tmux.selectLayout,
+    resyncPaneSizes: tmux.resyncPaneSizes,
+  };
+  return { reflow: new LayoutReflow(deps), deps };
+}
+
+describe("LayoutReflow.applyGeometry — order decision", () => {
+  const layout: LayoutNode = {
+    direction: "columns",
+    children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+  };
+  const paneMap: PaneMap = { "@tui": "%1", api: "%2", web: "%3" };
+
+  it("skips swap-pane entirely when spatial order already matches target DFS order", async () => {
+    const tmux = makeFakeTmux(["%1", "%2", "%3"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    expect(tmux.swapPanes).not.toHaveBeenCalled();
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits exactly one selectLayout per applyGeometry", async () => {
+    const tmux = makeFakeTmux(["%1", "%2", "%3"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    const [[target, layoutStr]] = tmux.selectLayout.mock.calls;
+    expect(target).toBe("@0");
+    // Real tmux layout string format: `<checksum>,<body>`.
+    expect(typeof layoutStr).toBe("string");
+    expect(layoutStr).toMatch(/^[0-9a-f]{4},/u);
+  });
+
+  it("emits the resolvePermutation swaps when current order doesn't match target", async () => {
+    // Current spatial order is reversed relative to target.
+    const tmux = makeFakeTmux(["%3", "%2", "%1"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    // Selection sort over [%3,%2,%1] → [%1,%2,%3] needs one swap (slot 0).
+    expect(tmux.swapPanes).toHaveBeenCalledTimes(1);
+    expect(tmux.swapPanes).toHaveBeenNthCalledWith(1, "%3", "%1");
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the swaps in selection-sort order for a 3-cycle", async () => {
+    // 3-cycle [A,B,C] → [C,A,B] needs 2 swaps.
+    const cycleLayout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "C" }, { pane: "A" }, { pane: "B" }],
+    };
+    const cycleMap: PaneMap = { A: "%1", B: "%2", C: "%3" };
+    const tmux = makeFakeTmux(["%1", "%2", "%3"]);
+    const { reflow } = makeReflow(cycleLayout, cycleMap, tmux);
+
+    await reflow.applyGeometry(new Set(["A", "B", "C"]));
+
+    expect(tmux.swapPanes).toHaveBeenCalledTimes(2);
+    expect(tmux.swapPanes).toHaveBeenNthCalledWith(1, "%1", "%3");
+    expect(tmux.swapPanes).toHaveBeenNthCalledWith(2, "%2", "%1");
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call resyncPaneSizes on the default path", async () => {
+    const tmux = makeFakeTmux(["%1", "%2", "%3"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]));
+
+    expect(tmux.resyncPaneSizes).not.toHaveBeenCalled();
+  });
+
+  it("invokes the resync fallback only when explicitly enabled", async () => {
+    const tmux = makeFakeTmux(["%1", "%2", "%3"]);
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "api", "web"]), { resyncFallback: true });
+
+    expect(tmux.resyncPaneSizes).toHaveBeenCalledTimes(1);
+    expect(tmux.resyncPaneSizes).toHaveBeenCalledWith("@0");
+  });
+});
+
+describe("LayoutReflow.applyGeometry — filtered visibility", () => {
+  it("uses the filtered DFS order (only visible panes contribute swaps)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }, { pane: "web" }],
+    };
+    const paneMap: PaneMap = { "@tui": "%1", web: "%3" }; // Api is hidden, no pane.
+    const tmux = makeFakeTmux(["%1", "%3"]); // Already in DFS order: @tui, web.
+    const { reflow } = makeReflow(layout, paneMap, tmux);
+
+    await reflow.applyGeometry(new Set(["@tui", "web"]));
+
+    expect(tmux.swapPanes).not.toHaveBeenCalled();
+    expect(tmux.selectLayout).toHaveBeenCalledTimes(1);
+    // The emitted layout string is for a 2-pane, not 3-pane, tree.
+    const [[, layoutStr]] = tmux.selectLayout.mock.calls;
+    expect(layoutStr).not.toContain(",2,"); // No middle "api" pane number.
+  });
+
+  it("throws when a visible pane is missing from paneMap (lifecycle invariant)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const tmux = makeFakeTmux(["%1"]);
+    const { reflow } = makeReflow(layout, { "@tui": "%1" }, tmux);
+
+    await expect(reflow.applyGeometry(new Set(["@tui", "api"]))).rejects.toThrow(
+      /pane 'api' is not in paneMap/,
+    );
+    expect(tmux.selectLayout).not.toHaveBeenCalled();
+  });
+
+  it("throws when no layout is declared (no geometry to reflow against)", async () => {
+    const tmux = makeFakeTmux(["%1"]);
+    const { reflow } = makeReflow(undefined, { "@tui": "%1" }, tmux);
+
+    await expect(reflow.applyGeometry(new Set(["@tui"]))).rejects.toThrow(/no declared layout/);
+  });
+
+  it("throws when the filtered tree is empty (no visible panes intersect the layout)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const tmux = makeFakeTmux([]);
+    const { reflow } = makeReflow(layout, { "@tui": "%1", api: "%2" }, tmux);
+
+    await expect(reflow.applyGeometry(new Set(["nobody"]))).rejects.toThrow(
+      /filtered tree is empty/,
+    );
+  });
+});
+
+describe("LayoutReflow — live getters survive Session._reload's paneMap reassignment", () => {
+  it("re-reads paneMap on each call (does not capture the constructor-time reference)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    // Two completely different paneMap objects (simulates _reload's reassignment).
+    const oldMap: PaneMap = { "@tui": "%1", api: "%2" };
+    const newMap: PaneMap = { "@tui": "%10", api: "%20" };
+    let live: PaneMap = oldMap;
+
+    const tmux = makeFakeTmux(["%1", "%2"]); // First call.
+    const reflow = new LayoutReflow({
+      getLayout: () => layout,
+      getPaneMap: () => live, // Live getter — survives reassignment.
+      getWindowTarget: () => "@0",
+      getWindowSize: tmux.getWindowSize,
+      paneIndexOrder: tmux.paneIndexOrder,
+      swapPanes: tmux.swapPanes,
+      selectLayout: tmux.selectLayout,
+      resyncPaneSizes: tmux.resyncPaneSizes,
+    });
+
+    await reflow.applyGeometry(new Set(["@tui", "api"]));
+    const [[, firstLayout]] = tmux.selectLayout.mock.calls;
+    expect(firstLayout.includes(",0,0,1,")).toBe(true);
+    expect(firstLayout.includes(",2")).toBe(true); // "%2" → encoded pane number 2.
+
+    // Simulate Session._reload: swap the whole paneMap object + tmux pane ids.
+    live = newMap;
+    tmux.paneIndexOrder.mockResolvedValue([
+      { index: 1, id: "%10" },
+      { index: 2, id: "%20" },
+    ]);
+
+    await reflow.applyGeometry(new Set(["@tui", "api"]));
+    // The SECOND select-layout MUST reference the new pane numbers (10, 20),
+    // Proving the reflow re-read paneMap rather than hold onto the old one.
+    const [, [, secondLayout]] = tmux.selectLayout.mock.calls;
+    expect(secondLayout).toMatch(/,10\b/);
+    expect(secondLayout).toMatch(/,20\b/);
+    expect(secondLayout).not.toMatch(/,1\b/);
+    expect(tmux.swapPanes).not.toHaveBeenCalled();
+  });
+
+  it("re-reads layout on each call (a reload that swaps the tree is honored)", async () => {
+    const oldLayout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const newLayout: LayoutNode = {
+      direction: "rows",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    let live = oldLayout;
+    const tmux = makeFakeTmux(["%1", "%2"]);
+    const reflow = new LayoutReflow({
+      getLayout: () => live,
+      getPaneMap: () => ({ "@tui": "%1", api: "%2" }),
+      getWindowTarget: () => "@0",
+      getWindowSize: tmux.getWindowSize,
+      paneIndexOrder: tmux.paneIndexOrder,
+      swapPanes: tmux.swapPanes,
+      selectLayout: tmux.selectLayout,
+      resyncPaneSizes: tmux.resyncPaneSizes,
+    });
+
+    await reflow.applyGeometry(new Set(["@tui", "api"]));
+    const [[, firstLayout]] = tmux.selectLayout.mock.calls;
+    expect(firstLayout.includes("{")).toBe(true); // Columns → `{...}`.
+    expect(firstLayout.includes("[")).toBe(false);
+
+    live = newLayout;
+    await reflow.applyGeometry(new Set(["@tui", "api"]));
+    const [, [, secondLayout]] = tmux.selectLayout.mock.calls;
+    expect(secondLayout.includes("[")).toBe(true); // Rows → `[...]`.
+    expect(secondLayout.includes("{")).toBe(false);
+  });
+});

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -39,6 +39,10 @@ import {
   getWindowSize,
   resizeWindow,
   resyncPaneSizes,
+  swapPanes,
+  selectLayout,
+  windowLayout,
+  paneIndexOrder,
 } from "../../src/lib/tmux.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -143,7 +147,7 @@ describe("killSession", () => {
 });
 
 describe("splitPane", () => {
-  it("splits horizontally without percent", async () => {
+  it("splits horizontally without options", async () => {
     mockSpawn.mockReturnValue(createMockProc("%2"));
     const paneId = await splitPane("%0", "h");
     expect(paneId).toBe("%2");
@@ -156,13 +160,104 @@ describe("splitPane", () => {
 
   it("splits vertically with percent", async () => {
     mockSpawn.mockReturnValue(createMockProc("%5"));
-    const paneId = await splitPane("%1", "v", 30);
+    const paneId = await splitPane("%1", "v", { percent: 30 });
     expect(paneId).toBe("%5");
     expect(mockSpawn).toHaveBeenCalledWith(
       "tmux",
       ["split-window", "-v", "-t", "%1", "-l", "30%", "-P", "-F", "#{pane_id}"],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
+  });
+
+  it("passes -d so the new pane does not steal focus", async () => {
+    mockSpawn.mockReturnValue(createMockProc("%6"));
+    await splitPane("%0", "h", { detached: true });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["split-window", "-h", "-d", "-t", "%0", "-P", "-F", "#{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("passes -b so the new pane is inserted before the target", async () => {
+    mockSpawn.mockReturnValue(createMockProc("%7"));
+    await splitPane("%0", "h", { before: true });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["split-window", "-h", "-b", "-t", "%0", "-P", "-F", "#{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("combines before + detached + percent in the documented order", async () => {
+    mockSpawn.mockReturnValue(createMockProc("%8"));
+    await splitPane("%0", "v", { before: true, detached: true, percent: 25 });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["split-window", "-v", "-b", "-d", "-t", "%0", "-l", "25%", "-P", "-F", "#{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+});
+
+describe("swapPanes", () => {
+  it("issues swap-pane with -s and -t", async () => {
+    mockSpawn.mockReturnValue(createMockProc(""));
+    await swapPanes("%2", "%4");
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["swap-pane", "-s", "%2", "-t", "%4"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  });
+});
+
+describe("selectLayout", () => {
+  it("passes the layout string as a single argv element", async () => {
+    mockSpawn.mockReturnValue(createMockProc(""));
+    const layout = "eb8f,100x30,0,0{50x30,0,0,1,49x30,51,0,2}";
+    await selectLayout("@0", layout);
+    // CRITICAL: layout is one element — the `{`/`[` never need shell escaping.
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["select-layout", "-t", "@0", layout], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    // Pin "layout is ONE argv element" — guards against accidental .join(" ").
+    const [[, argv]] = mockSpawn.mock.calls;
+    expect(Array.isArray(argv) && argv.at(-1)).toBe(layout);
+  });
+});
+
+describe("windowLayout", () => {
+  it("reads #{window_layout} via display-message", async () => {
+    const layout = "a87d,100x30,0,0,0";
+    mockSpawn.mockReturnValue(createMockProc(layout));
+    expect(await windowLayout("@0")).toBe(layout);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["display-message", "-p", "-t", "@0", "#{window_layout}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+});
+
+describe("paneIndexOrder", () => {
+  it("parses pane index + id, sorted ascending by index", async () => {
+    // Feed an out-of-order stream to assert the sort.
+    mockSpawn.mockReturnValue(createMockProc("3 %7\n1 %5\n2 %6"));
+    const order = await paneIndexOrder("@0");
+    expect(order).toEqual([
+      { index: 1, id: "%5" },
+      { index: 2, id: "%6" },
+      { index: 3, id: "%7" },
+    ]);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["list-panes", "-t", "@0", "-F", "#{pane_index} #{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("returns an empty array when the window has no panes", async () => {
+    mockSpawn.mockReturnValue(createMockProc(""));
+    expect(await paneIndexOrder("@0")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds **optional / lazy panes**: services can opt out of receiving a tmux pane at
boot (`lazyPane`), and panes are dynamically inserted and removed at runtime via
a new layout-reflow engine as services start and stop — without swapping or
restarting surviving panes.

## What's included

**tmux layout primitives** (`src/lib/tmux-layout.ts`, `src/lib/tmux-reflow.ts`)

- `filterTree` to drop invisible panes and collapse splits
- `computeRects` for absolute pane geometry with divider accounting
- layout-tree → `select-layout` serialization with checksum
- `resolvePermutation` (swap-pane reorder fallback) + `splitAnchor` for
  zero-swap insertion
- `LayoutReflow` engine: `applyGeometry`, `insertPane`, `removePane`
  (kill + re-expand survivors), with best-effort atomic rollback

**Config** (`src/config/`)

- new `lazyPane` field with detached + group-member guardrails
- per-service default resolution in the loader

**Wiring** (`src/daemon/`, `src/lib/service/manager.ts`)

- dynamic pane log buffers + `LayoutReflow` into `Session`
- boot-skip pane allocation for pane-less lazy services
- reflow on service start/stop, guarded against hook-driven shutdown deadlocks
- proportional sizing + pty winsize resync on reflow
