### PR TITLE
feat(tui): broadcast live pane map so z/E target lazy panes

### DIFF
--- a/src/client/daemon-client.ts
+++ b/src/client/daemon-client.ts
@@ -16,6 +16,7 @@ export interface DaemonClientEvents {
   "session.destroyed": () => void;
   "session.configReloaded": (snapshot: SessionSnapshot) => void;
   "session.configStale": () => void;
+  "session.paneMap": (paneMap: Record<string, string>) => void;
   disconnect: () => void;
 }
 
@@ -235,6 +236,10 @@ export class DaemonClient extends EventEmitter {
       }
       case "session.configStale": {
         this.emit("session.configStale");
+        break;
+      }
+      case "session.paneMap": {
+        this.emit("session.paneMap", data.paneMap);
         break;
       }
       default: {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,7 @@ import type { DaemonClient } from "#src/client/daemon-client.js";
 import { resolveUiConfig } from "#src/config/index.js";
 import type { UiConfig } from "#src/config/types.js";
 import type { ServiceMeta, TaskInfo } from "#src/daemon/session.js";
+import { usePaneMap } from "#src/hooks/usePaneMap.js";
 import { AppProvider } from "#src/hooks/useZaps.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
 
@@ -43,11 +44,15 @@ export function App({
   const resolvedUi = useMemo(() => resolveUiConfig(ui), [ui]);
   const iconTheme = useMemo(() => createIconTheme(resolveIconTier(resolvedUi.icons)), [resolvedUi]);
 
+  // Lazy panes are created/destroyed after attach, so keep the map live (the
+  // `paneMap` prop is only the startup snapshot). Drives `z`/`E` pane targeting.
+  const livePaneMap = usePaneMap(client, paneMap);
+
   return (
     <IconThemeProvider value={iconTheme}>
       <AppProvider
         client={client}
-        paneMap={paneMap}
+        paneMap={livePaneMap}
         projectName={projectName}
         tasks={tasks}
         servicesMeta={servicesMeta}

--- a/src/components/HelpBar.tsx
+++ b/src/components/HelpBar.tsx
@@ -15,14 +15,14 @@ export function HelpBar({ compact, status }: HelpBarProps) {
     // Compact: merge action hints + nav into one line
     return (
       <Box>
-        <Text dimColor>[r]estart [s]top [t]asks [q]uit/detach [d] down</Text>
+        <Text dimColor>[r]estart [s]top [t]asks [q]uit/detach [d]own</Text>
       </Box>
     );
   }
   if (compact && isUnavailable) {
     return (
       <Box>
-        <Text dimColor>[t]asks [q]uit/detach [d] down</Text>
+        <Text dimColor>[t]asks [q]uit/detach [d]own</Text>
       </Box>
     );
   }

--- a/src/components/hintText.ts
+++ b/src/components/hintText.ts
@@ -1,7 +1,7 @@
 import type { ServiceStatus } from "#src/lib/service/types.js";
 
 /** Global (non-service-specific) hints, also used to budget the merged footer line. */
-export const GLOBAL_HINTS = "[t]asks [a]ll restart [q]uit/detach [d] down";
+export const GLOBAL_HINTS = "[t]asks [a]ll restart [q]uit/detach [d]own";
 
 /**
  * The service-specific (left-hand) hint string for the footer: the keymap for

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -195,9 +195,13 @@ export class Session {
       getWindowTarget: () => this.tmuxSession,
       onPaneInserted: (name, paneId) => {
         this.allocatePaneLog(name, paneId);
+        // Lazy panes are created/destroyed after the TUI captured its startup
+        // Snapshot, so push the live map or `z`/`E` target a missing/stale pane.
+        this.broadcastPaneMap();
       },
       onPaneRemoved: (name, paneId) => {
         this.freePaneLog(name, paneId);
+        this.broadcastPaneMap();
       },
       onPaneInsertFailed: (name, paneId) => {
         // Symmetric with `onPaneRemoved` — same freePaneLog cleanup. Closes the
@@ -206,6 +210,7 @@ export class Session {
         // Monitor key would otherwise orphan when a retry with a NEW pane id
         // Lands (idempotency only covers same-id retry).
         this.freePaneLog(name, paneId);
+        this.broadcastPaneMap();
       },
     });
 
@@ -650,6 +655,20 @@ export class Session {
     this.paneBuffers.delete(paneId);
     this.paneMembers.delete(paneId);
     // NOTE: `this.logBuffers[name]` is RETAINED on purpose — see method docstring.
+  }
+
+  /**
+   * Push the current pane map to subscribers. Fired whenever a lazy pane is
+   * inserted/removed so the TUI's `paneMap` (frozen at attach) stays live and
+   * `z`/`E` resolve the right pane. A shallow copy is sent so the broadcast
+   * can't be mutated by a later reflow before it serializes.
+   */
+  private broadcastPaneMap(): void {
+    this.broadcast({
+      session: this.id,
+      event: "session.paneMap",
+      data: { paneMap: { ...this.paneMap } },
+    });
   }
 
   /**

--- a/src/hooks/usePaneMap.ts
+++ b/src/hooks/usePaneMap.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import type { DaemonClient } from "#src/client/daemon-client.js";
+import type { SessionSnapshot } from "#src/daemon/session.js";
+
+type PaneMap = Record<string, string>;
+
+/**
+ * Keep the pane map live. The TUI receives a `paneMap` snapshot at attach, but
+ * lazy panes (non-autostart services) are created/destroyed afterwards via
+ * reflow — without this, `z` (zoom) and `E` (edit-capture) resolve a missing or
+ * stale pane for any optional service started after launch. Mirrors
+ * `useServices`: seed from the snapshot, then track `session.paneMap` events and
+ * refresh wholesale on config reload.
+ */
+export function usePaneMap(client: DaemonClient, initial: PaneMap): PaneMap {
+  const [paneMap, setPaneMap] = useState<PaneMap>(initial);
+
+  useEffect(() => {
+    function onPaneMap(next: PaneMap) {
+      setPaneMap(next);
+    }
+    function onReload(snapshot: SessionSnapshot) {
+      setPaneMap(snapshot.paneMap);
+    }
+    client.on("session.paneMap", onPaneMap);
+    client.on("session.configReloaded", onReload);
+    return () => {
+      client.off("session.paneMap", onPaneMap);
+      client.off("session.configReloaded", onReload);
+    };
+  }, [client]);
+
+  return paneMap;
+}

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -122,7 +122,7 @@ describe("App", () => {
     const { lastFrame } = renderApp({ statuses });
 
     expect(lastFrame()).toContain("[t]asks");
-    expect(lastFrame()).toContain("[d] down");
+    expect(lastFrame()).toContain("[d]own");
     expect(lastFrame()).toContain("[q]uit/detach");
   });
 

--- a/test/client/daemon-client.test.ts
+++ b/test/client/daemon-client.test.ts
@@ -444,6 +444,20 @@ describe("DaemonClient", () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    it("routes session.paneMap", () => {
+      const spy = vi.fn();
+      client.on("session.paneMap", spy);
+      client.connect();
+
+      eventHandler({
+        session: "sess1",
+        event: "session.paneMap",
+        data: { paneMap: { "@tui": "%1", rainfrog: "%9" } },
+      });
+
+      expect(spy).toHaveBeenCalledWith({ "@tui": "%1", rainfrog: "%9" });
+    });
+
     it("ignores unknown events", () => {
       client.connect();
       // Should not throw

--- a/test/hooks/usePaneMap.test.tsx
+++ b/test/hooks/usePaneMap.test.tsx
@@ -1,0 +1,90 @@
+import { EventEmitter } from "node:events";
+
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DaemonClient } from "../../src/client/daemon-client.js";
+import { usePaneMap } from "../../src/hooks/usePaneMap.js";
+
+function createMockClient(): DaemonClient {
+  const emitter = new EventEmitter();
+  const client = Object.assign(emitter, {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    connected: true,
+    session: "test",
+  });
+  return client as unknown as DaemonClient;
+}
+
+function renderPaneMap(client: DaemonClient, initial: Record<string, string>) {
+  function TestWrapper() {
+    const paneMap = usePaneMap(client, initial);
+    return (
+      <Text>
+        {Object.entries(paneMap)
+          .map(([name, id]) => `${name}=${id}`)
+          .join(",")}
+      </Text>
+    );
+  }
+  return render(<TestWrapper />);
+}
+
+describe("usePaneMap", () => {
+  it("returns the initial snapshot on first render", () => {
+    const client = createMockClient();
+    const { lastFrame } = renderPaneMap(client, { "@tui": "%1", nuxt: "%2" });
+    expect(lastFrame()).toContain("@tui=%1");
+    expect(lastFrame()).toContain("nuxt=%2");
+  });
+
+  it("updates wholesale on a session.paneMap event (lazy pane inserted)", () => {
+    const client = createMockClient();
+    const { lastFrame } = renderPaneMap(client, { "@tui": "%1" });
+    expect(lastFrame()).not.toContain("rainfrog");
+
+    act(() => {
+      client.emit("session.paneMap", { "@tui": "%1", rainfrog: "%9" });
+    });
+
+    expect(lastFrame()).toContain("rainfrog=%9");
+  });
+
+  it("drops a pane when session.paneMap omits it (lazy pane removed)", () => {
+    const client = createMockClient();
+    const { lastFrame } = renderPaneMap(client, { "@tui": "%1", rainfrog: "%9" });
+    expect(lastFrame()).toContain("rainfrog=%9");
+
+    act(() => {
+      client.emit("session.paneMap", { "@tui": "%1" });
+    });
+
+    expect(lastFrame()).not.toContain("rainfrog");
+  });
+
+  it("refreshes from the snapshot on session.configReloaded", () => {
+    const client = createMockClient();
+    const { lastFrame } = renderPaneMap(client, { "@tui": "%1", old: "%2" });
+
+    act(() => {
+      client.emit("session.configReloaded", { paneMap: { "@tui": "%1", web: "%5" } });
+    });
+
+    expect(lastFrame()).toContain("web=%5");
+    expect(lastFrame()).not.toContain("old");
+  });
+
+  it("cleans up listeners on unmount", () => {
+    const client = createMockClient();
+    const { unmount } = renderPaneMap(client, {});
+    expect(client.listenerCount("session.paneMap")).toBe(1);
+    expect(client.listenerCount("session.configReloaded")).toBe(1);
+
+    unmount();
+    expect(client.listenerCount("session.paneMap")).toBe(0);
+    expect(client.listenerCount("session.configReloaded")).toBe(0);
+  });
+});

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -467,6 +467,38 @@ describe.skipIf(!hasTmux())("Session.reflow log lifecycle — real tmux", () => 
     expect(apiEvent).toBeDefined();
   });
 
+  it("broadcasts session.paneMap on lazy insert and remove (keeps TUI paneMap live)", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap);
+    const broadcastSpy = vi.spyOn(zapsSession, "broadcast");
+
+    await zapsSession.reflow.insertPane("api");
+
+    const insertMaps = broadcastSpy.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.event === "session.paneMap")
+      .map((event) => (event.data as { paneMap: PaneMap }).paneMap);
+    expect(insertMaps.length).toBeGreaterThan(0);
+    const insertMap = insertMaps[insertMaps.length - 1];
+    expect(insertMap.api).toBeDefined();
+    expect(insertMap.api).toBe(zapsSession.paneMap.api);
+
+    broadcastSpy.mockClear();
+    await zapsSession.reflow.removePane("api");
+
+    const removeMaps = broadcastSpy.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.event === "session.paneMap")
+      .map((event) => (event.data as { paneMap: PaneMap }).paneMap);
+    expect(removeMaps.length).toBeGreaterThan(0);
+    expect(removeMaps[removeMaps.length - 1].api).toBeUndefined();
+  });
+
   it("after remove the monitor key is gone; logBuffers[name] is RETAINED with history", async () => {
     const layout: LayoutNode = {
       direction: "columns",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    exclude: ["test/integration/**", "node_modules/**"],
+    exclude: ["test/integration/**", "**/node_modules/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary", "json"],


### PR DESCRIPTION
## What

The TUI captures the `paneMap` once at attach. Lazy (non-autostart) panes are created/destroyed afterwards via reflow, so `z` (zoom) and `E` (edit-capture) resolved a missing/stale pane for any optional service started after launch.

## Changes

- **`session.ts`**: `broadcastPaneMap()` fired on pane insert / remove / insert-failed (shallow copy to avoid mutation before serialize).
- **`daemon-client.ts`**: route the new `session.paneMap` event.
- **`usePaneMap` hook**: seed from attach snapshot, track `session.paneMap` events, refresh on config reload. Wired into `App.tsx`.
- Footer hint `[d] down` → `[d]own`.
- vitest: widen exclude to `**/node_modules/**`.

## Tests

- Unit: `daemon-client` routes `session.paneMap`.
- Integration (real tmux): broadcast on lazy insert and remove.