### PR TITLE
feat: namespaced Library API + config-eval hardening

### DIFF
--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -36,8 +36,8 @@ Activate this skill when the user:
 ```ts
 import type { Library } from "zaps";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     name: "my-project",
     services: {
       app: {
@@ -49,10 +49,13 @@ export function config({ defineProject }: Library) {
 }
 ```
 
+The `Library` object groups everything into namespaces — destructure what you need:
+`define`, `find`, `cli`, `task`, `service`, `browser`, `node`.
+
 ## Key Rules
 
 - Config file must export a `config` function (named export or default export)
-- The function receives a `Library` object and must call `defineProject()`
+- The function receives a `Library` object and must call `define()`
 - At least one service is required in the `services` record
 - Each service needs exactly one of: `start`, `run`, or `docker`
 - Import the `Library` type from the `"zaps"` package
@@ -172,13 +175,13 @@ services: {
 ### Hook that triggers a task
 
 ```ts
-export function config({ defineProject, runTask }: Library) {
-  return defineProject({
+export function config({ define, task }: Library) {
+  return define({
     services: {
       /* ... */
     },
     hooks: {
-      onStart: () => runTask("setup"),
+      onStart: () => task.run("setup"),
     },
     tasks: {
       setup: {

--- a/.claude/skills/zaps-config/references/01-getting-started.md
+++ b/.claude/skills/zaps-config/references/01-getting-started.md
@@ -23,13 +23,13 @@ ZAPS walks up from cwd to filesystem root, checking each directory for config fi
 
 ## File Structure
 
-Config files must export a `config` function (named or default export). The function receives a `Library` object and must return a `ProjectConfig` via `defineProject()`.
+Config files must export a `config` function (named or default export). The function receives a `Library` object and must return a `ProjectConfig` via `define()`.
 
 ```ts
 import type { Library } from "zaps";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     name: "my-project",
     services: {
       app: {
@@ -41,11 +41,21 @@ export function config({ defineProject }: Library) {
 }
 ```
 
+The config function may also be `async` — return a `Promise<ProjectConfig>` when you
+need to `await` before building the config:
+
+```ts
+export async function config({ define, node }: Library) {
+  const pkg = JSON.parse(await node.fs.promises.readFile("package.json", "utf8"));
+  return define({ name: pkg.name, services: { app: { start: "npm run dev" } } });
+}
+```
+
 **Gotchas:**
 
 - The loader checks `mod.config` first, then `mod.default` — a named `config` export is preferred
 - The export must be a function, not a plain object
-- `defineProject()` validates the config via Zod and returns it unchanged
+- `define()` validates the config via Zod and **throws a `ConfigError`** on invalid config (it never calls `process.exit` — the CLI boundary renders the error, the daemon keeps the previous config live)
 
 ## ProjectConfig Top-Level Fields
 
@@ -77,8 +87,8 @@ export interface CwdContext {
 
 ```ts
 // Monorepo example: config at repo root, services run from packages/app
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     cwd: "./packages/app",
     services: {
       /* ... */
@@ -87,9 +97,19 @@ export function config({ defineProject }: Library) {
 }
 
 // Dynamic resolution
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     cwd: ({ configDir }) => `${configDir}/packages/app`,
+    services: {
+      /* ... */
+    },
+  });
+}
+
+// Walk upward for a marker file (throws ConfigError if not found)
+export function config({ define, find }: Library) {
+  return define({
+    cwd: find.up("package.json"),
     services: {
       /* ... */
     },
@@ -99,26 +119,48 @@ export function config({ defineProject }: Library) {
 
 ## Library API
 
-The `Library` object passed to `config()` provides `defineProject` for config creation and runtime action methods usable inside hooks:
+The `Library` object groups everything into namespaces. Destructure what you need:
 
-| Method             | Signature                                  | Description                                                           |
-| ------------------ | ------------------------------------------ | --------------------------------------------------------------------- |
-| `defineProject`    | `(config: ProjectConfig) => ProjectConfig` | Validates and returns the config. Call exactly once.                  |
-| `runTask`          | `(key: string) => Promise<void>`           | Run a defined task by key                                             |
-| `startService`     | `(name: string) => Promise<void>`          | Start a service                                                       |
-| `restartService`   | `(name: string) => Promise<void>`          | Restart a service                                                     |
-| `stopService`      | `(name: string) => Promise<void>`          | Stop a service                                                        |
-| `isServiceRunning` | `(name: string) => boolean`                | Check if a service is running                                         |
-| `openInBrowser`    | `(url: string) => Promise<void>`           | Open a URL in the default browser                                     |
-| `node`             | `NodeModules`                              | Node built-ins: `path`, `fs`, `process`, `url`, `os`, `child_process` |
+| Namespace | Member                           | Description                                                            |
+| --------- | -------------------------------- | ---------------------------------------------------------------------- |
+| `define`  | `(config) => config`             | Validate and return the config. Throws `ConfigError` on bad config.    |
+| `find`    | `up(filename, opts?)`            | Build a `cwd` resolver that walks upward for `filename`.               |
+| `cli`     | `fatal(message, opts?)`          | Abort config eval by throwing a `ConfigError`. Never returns.          |
+| `cli`     | `warn / info / success(message)` | Emit a notice (stderr in the CLI; a TUI toast during a daemon reload). |
+| `task`    | `run(key)`                       | Run a defined task by key. Hooks only.                                 |
+| `service` | `start / stop / restart(name)`   | Control a service. Hooks only.                                         |
+| `service` | `isRunning(name)`                | Whether a service is currently ready. Hooks only.                      |
+| `browser` | `open(url)`                      | Open a URL in the default browser.                                     |
+| `node`    | `path / fs / process / …`        | Node built-ins: `path`, `fs`, `process`, `url`, `os`, `child_process`  |
 
-Runtime methods (`runTask`, `startService`, etc.) are bound after config loading. Use them in service/project hooks, not during config definition.
+`task.*` and `service.*` are bound only while a session is running. Use them inside
+service/project hooks (e.g. `onReady`), not during config definition — calling them too
+early throws a clear error.
+
+`cli.fatal(message, opts?)` is the explicit escape hatch: it throws a `ConfigError` and
+returns `never`, so it composes in any value position:
+
+```ts
+export function config({ define, cli }: Library) {
+  return define({
+    services: {
+      api: {
+        start: "npm run dev",
+        env: { API_KEY: process.env.API_KEY ?? cli.fatal("API_KEY is required") },
+      },
+    },
+  });
+}
+```
+
+`cli.warn` / `cli.info` / `cli.success` surface a short message without aborting (a styled
+stderr line in a one-shot CLI run; a transient toast during a daemon reload).
 
 `node` is available immediately (not just in hooks) — use it in config expressions like `cwd`:
 
 ```ts
-export function config({ defineProject, node }: Library) {
-  return defineProject({
+export function config({ define, node }: Library) {
+  return define({
     cwd: ({ configDir }) => node.path.join(configDir, "backend"),
     services: {
       api: {
@@ -131,8 +173,8 @@ export function config({ defineProject, node }: Library) {
 ```
 
 ```ts
-export function config({ defineProject, restartService }: Library) {
-  return defineProject({
+export function config({ define, service }: Library) {
+  return define({
     services: {
       db: { start: "docker compose up db", ready: { port: 5432 } },
       app: {
@@ -144,7 +186,7 @@ export function config({ defineProject, restartService }: Library) {
     hooks: {
       onStart: async () => {
         // Runtime actions available in hooks
-        await restartService("db");
+        await service.restart("db");
       },
     },
   });
@@ -174,8 +216,8 @@ Generated file:
 ```ts
 import type { Library } from "zaps";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     services: {
       app: {
         start: "echo 'Replace with your start command'",

--- a/.claude/skills/zaps-config/references/04-docker.md
+++ b/.claude/skills/zaps-config/references/04-docker.md
@@ -200,7 +200,7 @@ infra: {
   docker: {
     service: ["caddy", "postgres", "bugsink"],
     expand: {
-      postgres: { onReady: () => runTask("prisma:deploy") },
+      postgres: { onReady: () => task.run("prisma:deploy") },
       bugsink: { ready: { http: "http://localhost:8000/health" } },
     },
   },

--- a/.claude/skills/zaps-config/references/05-environment.md
+++ b/.claude/skills/zaps-config/references/05-environment.md
@@ -5,13 +5,18 @@
 `env` accepts a static record or a dynamic function:
 
 ```ts
-type EnvConfig = Record<string, string> | ((ctx: ServiceContext) => Record<string, string>);
+type EnvValue = string | null | undefined;
+type EnvConfig = Record<string, EnvValue> | ((ctx: ServiceContext) => Record<string, EnvValue>);
 ```
 
-| Form                              | Description                                                                  |
-| --------------------------------- | ---------------------------------------------------------------------------- |
-| `Record<string, string>`          | Static key-value pairs, resolved immediately                                 |
-| `(ctx) => Record<string, string>` | Dynamic function, called at service start time with current `ServiceContext` |
+| Form                                | Description                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| `Record<string, EnvValue>`          | Static key-value pairs, resolved immediately                                 |
+| `(ctx) => Record<string, EnvValue>` | Dynamic function, called at service start time with current `ServiceContext` |
+
+A `null` or `undefined` value is **dropped** — the variable is omitted rather than set to
+`""`. This makes `ctx.url()` (which returns `string | null`) safe to use directly in env,
+with no `?? ""` fallback needed.
 
 ## ServiceContext Shape
 
@@ -26,6 +31,7 @@ interface ServiceContext {
     }
   >;
   projectDir: string; // Resolved project root
+  url(service: string, opts?: UrlOptions): string | null; // Build a URL from a service port
 }
 ```
 
@@ -33,6 +39,40 @@ interface ServiceContext {
 - `port` is `undefined` if the service hasn't reported a port yet
 - `cwd` is the service's configured `cwd` (resolved), or `projectDir` when the service sets none
 - `projectDir` is the resolved working directory for the project
+- `url()` builds `{protocol}://{auth@}{host}:{port}{path}` from a service's detected port
+
+## Building URLs with `ctx.url()`
+
+`ctx.url(service, opts?)` is the ergonomic way to derive a service URL instead of
+hand-interpolating ports. It returns `null` when the port isn't detected yet (and that
+`null` is dropped from env), and **throws `ConfigError`** for an unknown service.
+
+```ts
+interface UrlOptions {
+  protocol?: string; // default "http"
+  auth?: string; // e.g. "user:pass"
+  host?: string; // default "localhost"
+  port?: number; // override the detected port
+  path?: string; // e.g. "/mydb" (a leading "/" is added if missing)
+}
+```
+
+```ts
+services: {
+  db: { start: "docker compose up db", ready: { port: 5432 } },
+  api: {
+    start: "node server.js",
+    dependsOn: ["db"],
+    env: (ctx) => ({
+      // postgres://user:pass@localhost:5432/mydb
+      DATABASE_URL: ctx.url("db", { protocol: "postgres", auth: "user:pass", path: "/mydb" }),
+    }),
+  },
+}
+```
+
+In task `run` callbacks, the same helper is reachable as `ctx.services.url()` (and the
+mirrored `ctx.url()`).
 
 ## How Env Vars Are Applied
 

--- a/.claude/skills/zaps-config/references/06-dependencies.md
+++ b/.claude/skills/zaps-config/references/06-dependencies.md
@@ -44,7 +44,7 @@ services: {
 // Level 1: [api]        — waits for both to be ready
 ```
 
-Each level awaits `Promise.all()` of its services before proceeding to the next level. A dependency must reach `"ready"` state before its dependent can start — otherwise `startService()` throws.
+Each level awaits `Promise.all()` of its services before proceeding to the next level. A dependency must reach `"ready"` state before its dependent can start — otherwise `service.start()` throws.
 
 ## Shutdown Order
 

--- a/.claude/skills/zaps-config/references/07-tasks.md
+++ b/.claude/skills/zaps-config/references/07-tasks.md
@@ -42,12 +42,13 @@ commands: ["node -e \"console.log('migrating...')\"", "node -e \"console.log('do
 
 Tasks with `run` receive a context object:
 
-| Property     | Type                                  | Description                   |
-| ------------ | ------------------------------------- | ----------------------------- |
-| `exec`       | `(cmd, opts?) => Promise<ExecResult>` | Execute a shell command       |
-| `stdout`     | `{ write(text: string): void }`       | Write directly to task output |
-| `services`   | `ServiceContext`                      | Access running services       |
-| `projectDir` | `string`                              | Resolved project directory    |
+| Property     | Type                                  | Description                                                 |
+| ------------ | ------------------------------------- | ----------------------------------------------------------- |
+| `exec`       | `(cmd, opts?) => Promise<ExecResult>` | Execute a shell command                                     |
+| `stdout`     | `{ write(text: string): void }`       | Write directly to task output                               |
+| `services`   | `ServiceContext`                      | Access running services                                     |
+| `projectDir` | `string`                              | Resolved project directory                                  |
+| `url`        | `(service, opts?) => string \| null`  | Build a URL from a service port (also `ctx.services.url()`) |
 
 `exec` options: `{ cwd?: string; env?: Record<string, string> }`
 
@@ -161,16 +162,16 @@ tasks: {
 
 ## Triggering from Hooks
 
-Use `lib.runTask()` to trigger tasks from service or project hooks:
+Use `task.run()` to trigger tasks from service or project hooks:
 
 ```ts
-export function config({ defineProject, runTask }: Library) {
-  return defineProject({
+export function config({ define, task }: Library) {
+  return define({
     services: {
       db: {
         start: "docker compose up db",
         ready: { port: 5432 },
-        onReady: () => runTask("seed"),
+        onReady: () => task.run("seed"),
       },
     },
     tasks: {

--- a/.claude/skills/zaps-config/references/09-hooks.md
+++ b/.claude/skills/zaps-config/references/09-hooks.md
@@ -65,22 +65,22 @@ services: {
 
 The `Library` object destructured in `config()` provides runtime actions usable inside hooks:
 
-| Method             | Signature                         | Description                   |
-| ------------------ | --------------------------------- | ----------------------------- |
-| `runTask`          | `(key: string) => Promise<void>`  | Run a defined task by key     |
-| `startService`     | `(name: string) => Promise<void>` | Start a service               |
-| `restartService`   | `(name: string) => Promise<void>` | Restart a service             |
-| `stopService`      | `(name: string) => Promise<void>` | Stop a service                |
-| `isServiceRunning` | `(name: string) => boolean`       | Check if a service is running |
-| `openInBrowser`    | `(url: string) => Promise<void>`  | Open URL in default browser   |
+| Namespace | Member            | Description                       |
+| --------- | ----------------- | --------------------------------- |
+| `task`    | `run(key)`        | Run a defined task by key         |
+| `service` | `start(name)`     | Start a service                   |
+| `service` | `restart(name)`   | Restart a service                 |
+| `service` | `stop(name)`      | Stop a service                    |
+| `service` | `isRunning(name)` | Check if a service is running     |
+| `browser` | `open(url)`       | Open a URL in the default browser |
 
 ```ts
-export function config({ defineProject, runTask, startService, openInBrowser }: Library) {
-  return defineProject({
+export function config({ define, task, browser }: Library) {
+  return define({
     services: {
       db: {
         docker: { service: "postgres" },
-        onReady: () => runTask("migrate"),
+        onReady: () => task.run("migrate"),
       },
       api: {
         start: "npm run dev:api",
@@ -92,7 +92,7 @@ export function config({ defineProject, runTask, startService, openInBrowser }: 
       migrate: { name: "Run migrations", commands: "prisma migrate deploy" },
     },
     hooks: {
-      onStart: () => openInBrowser("http://localhost:3000"),
+      onStart: () => browser.open("http://localhost:3000"),
     },
   });
 }
@@ -127,19 +127,13 @@ services: {
 ## Cross-Service Orchestration Example
 
 ```ts
-export function config({
-  defineProject,
-  runTask,
-  restartService,
-  isServiceRunning,
-  openInBrowser,
-}: Library) {
-  return defineProject({
+export function config({ define, task, service, browser }: Library) {
+  return define({
     services: {
       db: {
         docker: { service: "postgres" },
         ready: { port: 5432 },
-        onReady: () => runTask("migrate"),
+        onReady: () => task.run("migrate"),
       },
       api: {
         start: "npm run dev:api",
@@ -147,7 +141,7 @@ export function config({
         dependsOn: ["db"],
         onOutput: (line) => {
           if (line.includes("schema changed")) {
-            void restartService("web");
+            void service.restart("web");
           }
         },
       },
@@ -161,7 +155,7 @@ export function config({
       migrate: { name: "Run migrations", commands: "prisma migrate deploy" },
     },
     hooks: {
-      onStart: () => openInBrowser("http://localhost:3000"),
+      onStart: () => browser.open("http://localhost:3000"),
     },
   });
 }
@@ -169,7 +163,7 @@ export function config({
 
 ## Gotchas
 
-- **Library actions only work in hooks** — calling `runTask`, `startService`, etc. at config definition time throws `"not available outside of service hooks"`
+- **`task.*` and `service.*` only work in hooks** — calling them at config definition time throws `"not available outside of service hooks"`
 - **Hook errors don't fail lifecycle** — errors are logged but the service continues starting/stopping normally
 - **onOutput is not real-time** — it polls every 1s via tmux pane capture, not a direct stream
-- **`openInBrowser` works anytime** — unlike other library actions, it doesn't require runtime context
+- **`browser.open` works anytime** — unlike `task.*`/`service.*`, it doesn't require runtime context

--- a/.zaps.mts
+++ b/.zaps.mts
@@ -1,7 +1,7 @@
 import type { Library } from ".";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     name: "zaps",
     services: {
       app: {

--- a/README.md
+++ b/README.md
@@ -351,10 +351,13 @@ throws a clear error.
 
 ```typescript
 export function config({ define, cli, service }) {
-  const apiKey = process.env.API_KEY ?? cli.fatal("API_KEY is required");
   return define({
     services: {
-      api: { start: "npm run dev", ready: { port: 3000 } },
+      api: {
+        start: "npm run dev",
+        ready: { port: 3000 },
+        env: { API_KEY: process.env.API_KEY ?? cli.fatal("API_KEY is required") },
+      },
       worker: {
         run: "npm run worker",
         onReady: () => service.restart("api"),
@@ -369,8 +372,10 @@ export function config({ define, cli, service }) {
 Config-eval failures **throw** a `ConfigError` rather than calling `process.exit`.
 This keeps the daemon safe:
 
-- **From the CLI** (e.g. `zaps config`, `zaps up`), a `ConfigError` is rendered as a
-  styled `✖ <message>` line and the process exits non-zero.
+- **In-process loads** (`zaps config`) render a styled `✖ <message>` line and exit
+  non-zero.
+- **Daemon-path commands** (`zaps up`, `start`, …) report the same message **unstyled**
+  and exit non-zero.
 - **During a daemon reload**, a thrown `ConfigError` is caught: the running session is
   left fully intact (validate-then-swap), the old config stays live, and the error is
   reported — it never tears down your services.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ ZAPS walks up from the current directory looking for these filenames (first matc
 ```typescript
 import type { Library } from "zaps";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     services: {
       api: {
         start: "npm run dev",
@@ -114,13 +114,19 @@ export function config({ defineProject }: Library) {
 }
 ```
 
+The config function receives the `Library` object, which groups everything into
+namespaces: `define`, `find`, `cli`, `task`, `service`, `browser`, and `node`.
+Destructure just the pieces you use. See [Library API](#library-api) for the full
+reference. The function may be **async** — declare it
+`export async function config(lib) { … }` (the result is awaited).
+
 ### Full Config Reference
 
 ```typescript
 import type { Library } from "zaps";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     name: "my-app",
     cwd: "./packages/app",
 
@@ -245,13 +251,39 @@ cwd: "./customer-1";
 cwd: ({ invokeDir }) => invokeDir; // already the default
 ```
 
+**`find.up(filename, opts?)`** — walk upward from the invoke directory to the first
+directory containing `filename`, and use that as `cwd`. Handy for monorepos where you
+run `zaps` from a nested package but want the project root:
+
+```typescript
+export function config({ define, find }) {
+  return define({
+    cwd: find.up("package.json"),
+    services: {
+      /* … */
+    },
+  });
+}
+```
+
+Options:
+
+- `stopAt` — stop the walk at a boundary: an absolute path, or the literal `"config"`
+  to stop at the config file's directory. `cwd: find.up("package.json", { stopAt: "config" })`.
+- `orFatal` — the message used if `filename` is never found:
+  `cwd: find.up("Cargo.toml", { orFatal: "Run zaps inside a Rust crate" })`.
+
+`find.up` always returns a resolver (never `null`). If the file isn't found, it throws a
+`ConfigError` when the config loads — there's no `?? cli.fatal()` to write. See
+[Error Model](#error-model).
+
 ### Node Built-ins
 
 The `Library` object includes a `node` namespace with common Node.js modules (`path`, `fs`, `process`, `url`, `os`, `child_process`) so configs don't need raw `import` statements:
 
 ```typescript
-export function config({ defineProject, node }: Library) {
-  return defineProject({
+export function config({ define, node }: Library) {
+  return define({
     cwd: ({ configDir }) => node.path.join(configDir, "backend"),
     services: {
       api: {
@@ -295,6 +327,106 @@ down the running session — the old config stays live and the load error is rep
 When ZAPS detects the config file changed on disk, the TUI header shows a
 `config changed — press c to reload` hint; press **`c`** on the dashboard (while no
 service is mid-operation) to apply it.
+
+## Library API
+
+The `Library` object passed to your `config` function groups everything into
+namespaces. Destructure what you need: `config(({ define, find, cli, service }) => …)`.
+
+| Namespace | Member                           | Description                                                                 |
+| --------- | -------------------------------- | --------------------------------------------------------------------------- |
+| `define`  | `(config) => config`             | Validate and return the project config. Throws `ConfigError` on bad config. |
+| `find`    | `up(filename, opts?)`            | Build a `cwd` resolver that walks upward (see [`cwd`](#cwd)).               |
+| `cli`     | `fatal(message, opts?)`          | Abort config eval by throwing a `ConfigError`. Never returns.               |
+| `cli`     | `warn / info / success(message)` | Emit a notice (stderr in the CLI; a TUI toast during a daemon reload).      |
+| `task`    | `run(key)`                       | Run a named task. Only available inside service hooks.                      |
+| `service` | `start / stop / restart(name)`   | Control a service. Only available inside service hooks.                     |
+| `service` | `isRunning(name)`                | Whether a service is currently ready. Hooks only.                           |
+| `browser` | `open(url)`                      | Open a URL in the default browser.                                          |
+| `node`    | `path / fs / process / …`        | Common Node.js modules, no `import` needed.                                 |
+
+`task.*` and `service.*` are only wired up while a session is running, so call them
+from hooks (e.g. `onReady`), not at the top level of `config`. Calling them too early
+throws a clear error.
+
+```typescript
+export function config({ define, cli, service }) {
+  const apiKey = process.env.API_KEY ?? cli.fatal("API_KEY is required");
+  return define({
+    services: {
+      api: { start: "npm run dev", ready: { port: 3000 } },
+      worker: {
+        run: "npm run worker",
+        onReady: () => service.restart("api"),
+      },
+    },
+  });
+}
+```
+
+### Error Model
+
+Config-eval failures **throw** a `ConfigError` rather than calling `process.exit`.
+This keeps the daemon safe:
+
+- **From the CLI** (e.g. `zaps config`, `zaps up`), a `ConfigError` is rendered as a
+  styled `✖ <message>` line and the process exits non-zero.
+- **During a daemon reload**, a thrown `ConfigError` is caught: the running session is
+  left fully intact (validate-then-swap), the old config stays live, and the error is
+  reported — it never tears down your services.
+
+`cli.fatal(message, opts?)` is the explicit escape hatch — it throws a `ConfigError`
+with your message (and optional `field`). Because it returns `never`, it composes in any
+value position: `name: pkg.name ?? cli.fatal("name required")`.
+
+### Config Notices
+
+`cli.warn`, `cli.info`, and `cli.success` surface a short message without aborting:
+
+- In a one-shot CLI run they print a styled line to stderr.
+- During a daemon reload (with the TUI attached) they appear as transient toasts.
+
+```typescript
+export function config({ define, cli }) {
+  if (!process.env.STRIPE_KEY) cli.warn("STRIPE_KEY unset — payments disabled");
+  return define({ services: { app: { start: "npm run dev" } } });
+}
+```
+
+### Async Config
+
+The config function may be `async`:
+
+```typescript
+export async function config({ define, node }) {
+  const pkg = JSON.parse(await node.fs.promises.readFile("package.json", "utf8"));
+  return define({ name: pkg.name, services: { app: { start: "npm run dev" } } });
+}
+```
+
+Async evaluation is bounded by a 30-second timeout: if an async config hangs (awaiting
+something that never resolves), the load fails with a `ConfigError` instead of blocking
+a reload forever. The timeout only covers async waits — a synchronous infinite loop
+isn't interruptible.
+
+### Migrating from the flat API
+
+Earlier versions exposed flat methods on the `Library`. They are now grouped into
+namespaces (a breaking change, with no compatibility shim):
+
+| Old                      | New                       |
+| ------------------------ | ------------------------- |
+| `defineProject(config)`  | `define(config)`          |
+| `runTask(key)`           | `task.run(key)`           |
+| `startService(name)`     | `service.start(name)`     |
+| `stopService(name)`      | `service.stop(name)`      |
+| `restartService(name)`   | `service.restart(name)`   |
+| `isServiceRunning(name)` | `service.isRunning(name)` |
+| `openInBrowser(url)`     | `browser.open(url)`       |
+
+`node` is unchanged. To migrate, update the destructure in your `config` function and
+rename the calls — e.g. `({ defineProject }) => defineProject({…})` becomes
+`({ define }) => define({…})`.
 
 ## Services
 
@@ -575,7 +707,7 @@ services: {
       service: ["caddy", "postgres", "mailpit", "bugsink"],
       expand: {
         postgres: {
-          onReady: () => runTask("prisma:deploy"),
+          onReady: () => task.run("prisma:deploy"),
         },
         bugsink: {
           ready: { http: "http://localhost:8000/health/ready" },
@@ -649,8 +781,37 @@ env: (ctx) => ({
     }
   >;
   projectDir: string;
+  url(service: string, opts?: UrlOptions): string | null;
 }
 ```
+
+### `ctx.url()`
+
+`ctx.url(service, opts?)` builds a URL from a service's detected port, so you don't
+have to hand-assemble strings:
+
+```typescript
+env: (ctx) => ({
+  API_URL: ctx.url("api"), // "http://localhost:3000"
+  DATABASE_URL: ctx.url("db", { protocol: "postgres", auth: "user:pass", path: "/mydb" }),
+  // → "postgres://user:pass@localhost:5432/mydb"
+});
+```
+
+`UrlOptions`: `protocol` (default `"http"`), `auth` (e.g. `"user:pass"`), `host`
+(default `"localhost"`), `port` (override the detected port), `path` (a leading `/` is
+added if missing). IPv6 hosts are bracketed automatically (`http://[::1]:3000`).
+
+Behavior:
+
+- **Unknown service** → throws a `ConfigError`.
+- **No port detected yet** (and no `port` override) → returns `null`.
+- A `null` result is **dropped** from an env object — the variable is simply omitted
+  rather than set to an empty string, so `API_URL: ctx.url("api")` is safe even before
+  the port is up.
+
+`ctx.url()` is available wherever a `ServiceContext` is — dynamic `env`, command
+functions, the `url:` field, and task `run` callbacks (also as `ctx.services.url()`).
 
 ## Tasks
 
@@ -725,6 +886,7 @@ tasks: {
   stdout: { write(text: string): void };
   services: ServiceContext;  // same as dynamic env context
   projectDir: string;
+  url(service: string, opts?: UrlOptions): string | null;  // mirrors services.url()
 }
 ```
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { program } from "commander";
 
+import { renderCliError } from "./cli/errors.js";
 import type { SessionInfo, SessionIpc } from "./cli/helpers.js";
 import {
   CliError,
@@ -294,8 +295,7 @@ async function upFlow(detach?: boolean): Promise<void> {
       await runDetachedStartAll(sock, session.id, session.name);
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -347,8 +347,7 @@ program
           }
         } catch (error) {
           if (error instanceof CliError) {
-            process.stderr.write(`${error.message}\n`);
-            process.exit(1);
+            renderCliError(error);
           }
           throw error;
         }
@@ -434,8 +433,7 @@ for (const action of ["start", "stop", "restart"] as const) {
         }, globalSession());
       } catch (error) {
         if (error instanceof CliError) {
-          process.stderr.write(`${error.message}\n`);
-          process.exit(1);
+          renderCliError(error);
         }
         throw error;
       }
@@ -480,8 +478,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -560,8 +557,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -674,8 +670,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -711,8 +706,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -743,8 +737,7 @@ program
         return resolveListedSessionId(sessions, globalSession());
       } catch (error) {
         if (error instanceof CliError) {
-          process.stderr.write(`${error.message}\n`);
-          process.exit(1);
+          renderCliError(error);
         }
         throw error;
       }
@@ -804,7 +797,7 @@ program
       return;
     }
 
-    const config = await loadConfig(configPath);
+    const config = await loadConfig(configPath).catch((error: unknown) => renderCliError(error));
 
     const format = resolveFormat(opts);
     if (format !== "text") {
@@ -907,8 +900,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -929,8 +921,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -984,8 +975,7 @@ program
       await runTui({ sessionId: targetSession.id, socketPath: sock });
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }
@@ -1022,8 +1012,7 @@ program
       }, globalSession());
     } catch (error) {
       if (error instanceof CliError) {
-        process.stderr.write(`${error.message}\n`);
-        process.exit(1);
+        renderCliError(error);
       }
       throw error;
     }

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,0 +1,31 @@
+import chalk from "chalk";
+
+import { ConfigError } from "#src/config/index.js";
+
+const defaultDeps: RenderErrorDeps = {
+  write: (text) => {
+    process.stderr.write(text);
+  },
+  exit: (code) => process.exit(code),
+};
+
+export interface RenderErrorDeps {
+  write: (text: string) => void;
+  exit: (code: number) => never;
+}
+
+/**
+ * Render an error at the CLI boundary and exit(1). A `ConfigError` is styled
+ * with a red `✖` prefix via chalk (auto-disabled on non-TTY / `NO_COLOR`);
+ * anything else prints its plain message. ANSI styling lives here, never in
+ * `ConfigError.message`.
+ */
+export function renderCliError(error: unknown, deps: RenderErrorDeps = defaultDeps): never {
+  if (error instanceof ConfigError) {
+    deps.write(`\n  ${chalk.bold.red("✖")} ${chalk.red(error.message)}\n`);
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.write(`${message}\n`);
+  }
+  return deps.exit(1);
+}

--- a/src/client/daemon-client.ts
+++ b/src/client/daemon-client.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 
-import type { DockerConfig } from "#src/config/types.js";
+import type { DockerConfig, NoticeLevel } from "#src/config/types.js";
 import type { SessionSnapshot } from "#src/daemon/session.js";
 import type { TaskOutputSnapshot } from "#src/daemon/task-output-store.js";
 import type { IpcSubscription } from "#src/lib/ipc/client.js";
@@ -17,6 +17,7 @@ export interface DaemonClientEvents {
   "session.configReloaded": (snapshot: SessionSnapshot) => void;
   "session.configStale": () => void;
   "session.paneMap": (paneMap: Record<string, string>) => void;
+  "config.notice": (level: NoticeLevel, message: string) => void;
   disconnect: () => void;
 }
 
@@ -39,7 +40,7 @@ export class DaemonClient extends EventEmitter {
     this.sub = ipcSubscribe(
       this.socketPath,
       this.sessionId,
-      ["service.*", "log.*", "task.*", "session.*"],
+      ["service.*", "log.*", "task.*", "session.*", "config.*"],
       (event: DaemonEvent) => {
         this.handleEvent(event);
       },
@@ -240,6 +241,10 @@ export class DaemonClient extends EventEmitter {
       }
       case "session.paneMap": {
         this.emit("session.paneMap", data.paneMap);
+        break;
+      }
+      case "config.notice": {
+        this.emit("config.notice", data.level, data.message);
         break;
       }
       default: {

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,7 +1,7 @@
 import { useApp as useInkApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { DockerConfig, UiTaskMode } from "#src/config/types.js";
+import type { DockerConfig, NoticeLevel, UiTaskMode } from "#src/config/types.js";
 import { useConnection } from "#src/hooks/useConnection.js";
 import { useInputRouter } from "#src/hooks/useInputRouter.js";
 import { useLogs } from "#src/hooks/useLogs.js";
@@ -154,6 +154,23 @@ export function Router({
       client.off("task.complete", handleTaskComplete);
     };
   }, [client, notify, ui.notifications]);
+
+  // Surface config-eval notices (cli.warn/info/success during a daemon reload)
+  // As transient toasts. `warn` has no ToastLevel, so it maps to `info`.
+  useEffect(() => {
+    function handleConfigNotice(level: NoticeLevel, message: string) {
+      notify({
+        level: level === "warn" ? "info" : level,
+        message,
+        runId: null,
+        sticky: false,
+      });
+    }
+    client.on("config.notice", handleConfigNotice);
+    return () => {
+      client.off("config.notice", handleConfigNotice);
+    };
+  }, [client, notify]);
 
   // Ready gate: delay rendering for minimum splash time only
   const [ready, setReady] = useState(!autoStart);
@@ -436,7 +453,7 @@ export function Router({
           }),
         openLogs: goToLogs,
         openUrl: (url) => {
-          void openInBrowser(url);
+          void openInBrowser(url).catch(() => undefined);
         },
         rebuildDocker: openDockerRebuild,
         zoom: zoomService,

--- a/src/components/dashboard/useDashboardInput.ts
+++ b/src/components/dashboard/useDashboardInput.ts
@@ -63,7 +63,7 @@ function handleDashboardInput(input: string, key: Key, ctx: DashboardInputContex
   }
   const selectedUrl = selected?.url;
   if (input === "o" && selectedUrl) {
-    void openInBrowser(selectedUrl);
+    void openInBrowser(selectedUrl).catch(() => undefined);
   }
   if (input === "R" && selected?.isDocker && !isUnavailable) {
     ctx.goToDockerRebuild(selectedName);

--- a/src/config/builder.ts
+++ b/src/config/builder.ts
@@ -76,7 +76,12 @@ export function createZapsLib(opts?: { onNotice?: NoticeSink }): ZapsLib {
       },
       browser: {
         async open(url: string): Promise<void> {
-          await openInBrowser(url);
+          try {
+            await openInBrowser(url);
+          } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            sink({ level: "warn", message: `Could not open browser for ${url}: ${reason}` });
+          }
         },
       },
       node: nodeModules,

--- a/src/config/builder.ts
+++ b/src/config/builder.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { openInBrowser } from "#src/lib/open.js";
 
+import { ConfigError } from "./errors.js";
 import { nodeModules } from "./node.js";
 import { projectConfigSchema } from "./schema.js";
 import type { Library, LibraryActions, ProjectConfig } from "./types.js";
@@ -21,15 +22,15 @@ export function createZapsLib(): ZapsLib {
           return projectConfigSchema.parse(config);
         } catch (error) {
           if (error instanceof z.ZodError) {
-            throw new Error(
-              error.issues
-                .map((i) => {
-                  const path = i.path.length ? `${i.path.join(".")}: ` : "";
-                  return `${path}${i.message}`;
-                })
-                .join("\n"),
-              { cause: error },
-            );
+            const message = error.issues
+              .map((i) => {
+                const path = i.path.length ? `${i.path.join(".")}: ` : "";
+                return `${path}${i.message}`;
+              })
+              .join("\n");
+            const firstPath = error.issues[0]?.path;
+            const field = firstPath?.length ? firstPath.join(".") : undefined;
+            throw new ConfigError(message, { kind: "validation", field });
           }
           throw error;
         }

--- a/src/config/builder.ts
+++ b/src/config/builder.ts
@@ -3,21 +3,24 @@ import { z } from "zod";
 import { openInBrowser } from "#src/lib/open.js";
 
 import { ConfigError } from "./errors.js";
+import { createCliHelpers, createStderrSink } from "./helpers/cli.js";
+import { createFindHelpers } from "./helpers/find.js";
 import { nodeModules } from "./node.js";
 import { projectConfigSchema } from "./schema.js";
-import type { Library, LibraryActions, ProjectConfig } from "./types.js";
+import type { Library, LibraryActions, NoticeSink, ProjectConfig } from "./types.js";
 
 export interface ZapsLib {
   lib: Library;
   bindActions: (actions: LibraryActions) => void;
 }
 
-export function createZapsLib(): ZapsLib {
+export function createZapsLib(opts?: { onNotice?: NoticeSink }): ZapsLib {
   let actions: LibraryActions | null = null;
+  const sink = opts?.onNotice ?? createStderrSink();
 
   return {
     lib: {
-      defineProject(config: ProjectConfig): ProjectConfig {
+      define(config: ProjectConfig): ProjectConfig {
         try {
           return projectConfigSchema.parse(config);
         } catch (error) {
@@ -35,38 +38,46 @@ export function createZapsLib(): ZapsLib {
           throw error;
         }
       },
-      async runTask(key: string): Promise<void> {
-        if (!actions) {
-          throw new Error("runTask is not available outside of service hooks");
-        }
-        await actions.runTask(key);
+      find: createFindHelpers(),
+      cli: createCliHelpers(sink),
+      task: {
+        async run(key: string): Promise<void> {
+          if (!actions) {
+            throw new Error("task.run is not available outside of service hooks");
+          }
+          await actions.runTask(key);
+        },
       },
-      async startService(name: string): Promise<void> {
-        if (!actions) {
-          throw new Error("startService is not available outside of service hooks");
-        }
-        await actions.startService(name);
+      service: {
+        async start(name: string): Promise<void> {
+          if (!actions) {
+            throw new Error("service.start is not available outside of service hooks");
+          }
+          await actions.startService(name);
+        },
+        async stop(name: string): Promise<void> {
+          if (!actions) {
+            throw new Error("service.stop is not available outside of service hooks");
+          }
+          await actions.stopService(name);
+        },
+        async restart(name: string): Promise<void> {
+          if (!actions) {
+            throw new Error("service.restart is not available outside of service hooks");
+          }
+          await actions.restartService(name);
+        },
+        isRunning(name: string): boolean {
+          if (!actions) {
+            throw new Error("service.isRunning is not available outside of service hooks");
+          }
+          return actions.isServiceRunning(name);
+        },
       },
-      async restartService(name: string): Promise<void> {
-        if (!actions) {
-          throw new Error("restartService is not available outside of service hooks");
-        }
-        await actions.restartService(name);
-      },
-      async stopService(name: string): Promise<void> {
-        if (!actions) {
-          throw new Error("stopService is not available outside of service hooks");
-        }
-        await actions.stopService(name);
-      },
-      isServiceRunning(name: string): boolean {
-        if (!actions) {
-          throw new Error("isServiceRunning is not available outside of service hooks");
-        }
-        return actions.isServiceRunning(name);
-      },
-      async openInBrowser(url: string): Promise<void> {
-        await openInBrowser(url);
+      browser: {
+        async open(url: string): Promise<void> {
+          await openInBrowser(url);
+        },
       },
       node: nodeModules,
     },

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -1,0 +1,33 @@
+export type ConfigErrorKind = "fatal" | "validation" | "notFound";
+
+export interface ConfigErrorOptions {
+  kind?: ConfigErrorKind;
+  file?: string;
+  service?: string;
+  task?: string;
+  field?: string;
+}
+
+/**
+ * Typed error thrown by every config-eval failure path.
+ *
+ * `message` is kept plain (no ANSI) so it is safe across IPC and logs; styling
+ * is applied once at the CLI boundary, never stored here.
+ */
+export class ConfigError extends Error {
+  public readonly kind: ConfigErrorKind;
+  public readonly file?: string;
+  public readonly service?: string;
+  public readonly task?: string;
+  public readonly field?: string;
+
+  public constructor(message: string, opts: ConfigErrorOptions = {}) {
+    super(message);
+    this.name = "ConfigError";
+    this.kind = opts.kind ?? "validation";
+    this.file = opts.file;
+    this.service = opts.service;
+    this.task = opts.task;
+    this.field = opts.field;
+  }
+}

--- a/src/config/helpers/cli.ts
+++ b/src/config/helpers/cli.ts
@@ -1,0 +1,45 @@
+import chalk from "chalk";
+
+import { ConfigError } from "#src/config/errors.js";
+import type { CliHelpers, ConfigNotice, NoticeLevel, NoticeSink } from "#src/config/types.js";
+
+const NOTICE_STYLES: Record<NoticeLevel, { glyph: string; color: (text: string) => string }> = {
+  warn: { glyph: "⚠", color: chalk.yellow },
+  info: { glyph: "ℹ", color: chalk.blue },
+  success: { glyph: "✔", color: chalk.green },
+};
+
+/**
+ * Default `NoticeSink`: writes chalk-styled lines to stderr (one bold glyph +
+ * colored message per level). chalk auto-disables color on non-TTY / `NO_COLOR`.
+ * Mirrors `renderCliError`'s `✖` style from P01-T06.
+ */
+export function createStderrSink(): NoticeSink {
+  return (notice: ConfigNotice): void => {
+    const { glyph, color } = NOTICE_STYLES[notice.level];
+    process.stderr.write(`\n  ${chalk.bold(color(glyph))} ${color(notice.message)}\n`);
+  };
+}
+
+/**
+ * The `cli` namespace. `fatal` throws a `ConfigError` (`kind: "fatal"`) — it
+ * never writes or exits, so it composes as `never` in `cwd: find.up(...) ?? cli.fatal(...)`.
+ * `warn/info/success` emit a `ConfigNotice` through the injected sink, which
+ * decides the destination (CLI default → stderr; daemon → broadcast).
+ */
+export function createCliHelpers(sink: NoticeSink): CliHelpers {
+  return {
+    fatal(message: string, opts?: { field?: string }): never {
+      throw new ConfigError(message, { kind: "fatal", field: opts?.field });
+    },
+    warn(message: string): void {
+      sink({ level: "warn", message });
+    },
+    info(message: string): void {
+      sink({ level: "info", message });
+    },
+    success(message: string): void {
+      sink({ level: "success", message });
+    },
+  };
+}

--- a/src/config/helpers/cli.ts
+++ b/src/config/helpers/cli.ts
@@ -23,7 +23,8 @@ export function createStderrSink(): NoticeSink {
 
 /**
  * The `cli` namespace. `fatal` throws a `ConfigError` (`kind: "fatal"`) — it
- * never writes or exits, so it composes as `never` in `cwd: find.up(...) ?? cli.fatal(...)`.
+ * never writes or exits. Its `never` return type lets it stand in any value
+ * position, e.g. `name: pkg.name ?? cli.fatal("name required")`.
  * `warn/info/success` emit a `ConfigNotice` through the injected sink, which
  * decides the destination (CLI default → stderr; daemon → broadcast).
  */

--- a/src/config/helpers/context.ts
+++ b/src/config/helpers/context.ts
@@ -1,0 +1,40 @@
+import { ConfigError } from "#src/config/errors.js";
+import type { ServiceContext, UrlOptions } from "#src/config/types.js";
+
+/**
+ * Pure URL builder backing `ctx.url()`. Throws on an unknown service, returns
+ * `null` when no port is available (neither an override nor a detected port),
+ * else assembles a total URL: `{protocol}://{auth@}{host}:{port}{path}` with
+ * `http`/`localhost` defaults, IPv6 hosts bracketed, and a leading slash added
+ * to a non-empty path that lacks one (Q-R4c).
+ */
+export function buildUrl(
+  services: ServiceContext["services"],
+  name: string,
+  opts: UrlOptions = {},
+): string | null {
+  const service = services[name];
+  if (!service) {
+    throw new ConfigError(`ctx.url(): unknown service '${name}'`, {
+      kind: "validation",
+      service: name,
+    });
+  }
+
+  const port = opts.port ?? service.port;
+  if (port === undefined) {
+    return null;
+  }
+
+  const protocol = opts.protocol ?? "http";
+  const host = opts.host ?? "localhost";
+  const bracketedHost = host.includes(":") ? `[${host}]` : host;
+  const auth = opts.auth !== undefined && opts.auth !== "" ? `${opts.auth}@` : "";
+
+  let path = "";
+  if (opts.path !== undefined && opts.path !== "") {
+    path = opts.path.startsWith("/") ? opts.path : `/${opts.path}`;
+  }
+
+  return `${protocol}://${auth}${bracketedHost}:${port}${path}`;
+}

--- a/src/config/helpers/find.ts
+++ b/src/config/helpers/find.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ConfigError } from "#src/config/errors.js";
+import type { CwdContext, CwdResolver, FindHelpers, FindUpOptions } from "#src/config/types.js";
+
+/** Defensive cap so a pathological filesystem can't loop the walk unboundedly. */
+const MAX_WALK_DEPTH = 256;
+
+/** Resolve the walk boundary: a static path, the configDir, or none (root). */
+function resolveBoundary(stopAt: FindUpOptions["stopAt"], configDir: string): string | null {
+  if (stopAt === undefined) {
+    return null;
+  }
+  return stopAt === "config" ? path.resolve(configDir) : path.resolve(stopAt);
+}
+
+/**
+ * `find.up(filename, opts?)` returns a `CwdResolver` that walks upward from
+ * `ctx.invokeDir` looking for a directory containing `filename`. The walk is
+ * bounded by `opts.stopAt` (a static path or `"config"` → `ctx.configDir`),
+ * else the filesystem root. On not-found it throws `ConfigError` (`notFound`)
+ * — it never returns null, so it assigns directly to the `cwd` field.
+ */
+export function createFindHelpers(): FindHelpers {
+  const up =
+    (filename: string, opts: FindUpOptions = {}): CwdResolver =>
+    (ctx: CwdContext): string => {
+      const boundary = resolveBoundary(opts.stopAt, ctx.configDir);
+      let dir = path.resolve(ctx.invokeDir);
+
+      for (let depth = 0; depth < MAX_WALK_DEPTH; depth += 1) {
+        if (fs.existsSync(path.join(dir, filename))) {
+          return dir;
+        }
+        if (boundary !== null && dir === boundary) {
+          break;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+          break;
+        }
+        dir = parent;
+      }
+
+      throw new ConfigError(
+        opts.orFatal ?? `${filename} not found walking up from ${ctx.invokeDir}`,
+        {
+          kind: "notFound",
+          field: "cwd",
+        },
+      );
+    };
+
+  return { up };
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,6 @@
 export { discoverConfig } from "./discovery.js";
+export { ConfigError } from "./errors.js";
+export type { ConfigErrorKind } from "./errors.js";
 export { loadConfig } from "./loader.js";
 export { createZapsLib } from "./builder.js";
 export { generateTemplate, scaffoldConfig } from "./scaffold.js";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -340,6 +340,12 @@ function resolveProjectDir(
   }
   if (typeof cwd === "function") {
     const result = cwd({ configDir, invokeDir });
+    if (typeof result !== "string" || result.trim() === "") {
+      throw new ConfigError(`cwd function returned a non-string value (${typeof result})`, {
+        kind: "validation",
+        field: "cwd",
+      });
+    }
     return path.isAbsolute(result) ? result : path.resolve(configDir, result);
   }
   return invokeDir;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,6 +9,7 @@ import { RESERVED_TASK_SHORTCUT_KEYS } from "#src/lib/taskShortcuts.js";
 import { validateLayoutSizes } from "#src/lib/tmux-layout.js";
 
 import { createZapsLib } from "./builder.js";
+import { ConfigError } from "./errors.js";
 import { expandOverrideSchema } from "./schema.js";
 import type {
   CombinedServiceMeta,
@@ -578,7 +579,31 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
   const configDir = path.dirname(configPath);
   const resolvedInvokeDir = invokeDir ?? process.cwd();
   const { lib, bindActions } = createZapsLib();
-  const project: ProjectConfig = configFn(lib);
+
+  // The config function may be sync or async. Await it and bound the eval with a
+  // Timeout so a hanging async config cannot block daemon reload forever. The
+  // Timeout only covers async hangs (pending I/O/microtasks); a synchronous CPU
+  // Hang is not interruptible and cannot be caught here.
+  const project: ProjectConfig = await (async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+    try {
+      return await Promise.race([
+        Promise.resolve<ProjectConfig>(configFn(lib)),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new ConfigError(`config evaluation timed out after 30s: ${absolutePath}`, {
+                kind: "validation",
+                file: absolutePath,
+              }),
+            );
+          }, 30_000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  })();
 
   normalizeReadyOutputFlags(project);
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -14,6 +14,7 @@ import { expandOverrideSchema } from "./schema.js";
 import type {
   CombinedServiceMeta,
   LayoutNode,
+  NoticeSink,
   OptionalContext,
   ProjectConfig,
   ResolvedConfig,
@@ -565,7 +566,11 @@ function normalizeReadyOutputFlags(project: ProjectConfig): void {
 /**
  * Dynamically import and validate a zaps config file.
  */
-export async function loadConfig(configPath: string, invokeDir?: string): Promise<ResolvedConfig> {
+export async function loadConfig(
+  configPath: string,
+  invokeDir?: string,
+  onNotice?: NoticeSink,
+): Promise<ResolvedConfig> {
   const absolutePath = path.resolve(process.cwd(), configPath);
   const transform = await nativeTransform();
   const jiti = createJiti(import.meta.url, {
@@ -584,7 +589,7 @@ export async function loadConfig(configPath: string, invokeDir?: string): Promis
 
   const configDir = path.dirname(configPath);
   const resolvedInvokeDir = invokeDir ?? process.cwd();
-  const { lib, bindActions } = createZapsLib();
+  const { lib, bindActions } = createZapsLib({ onNotice });
 
   // The config function may be sync or async. Await it and bound the eval with a
   // Timeout so a hanging async config cannot block daemon reload forever. The

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type {
   CwdContext,
+  EnvValue,
   LayoutSplit,
   OptionalContext,
   ServiceContext,
@@ -71,8 +72,8 @@ const dockerConfigSchema = z.object({
 
 // === Env Config ===
 const envConfigSchema = z.union([
-  z.record(z.string(), z.string()),
-  z.custom<(ctx: ServiceContext) => Record<string, string>>((v) => typeof v === "function"),
+  z.record(z.string(), z.union([z.string(), z.null()])),
+  z.custom<(ctx: ServiceContext) => Record<string, EnvValue>>((v) => typeof v === "function"),
 ]);
 
 // === URL Config ===

--- a/src/config/templates/default.template.ts
+++ b/src/config/templates/default.template.ts
@@ -1,7 +1,7 @@
 const defaultTemplate = `import type { Library } from "{{ZAPS_PATH}}";
 
-export function config({ defineProject }: Library) {
-  return defineProject({
+export function config({ define }: Library) {
+  return define({
     services: {
       app: {
         start: "echo 'Replace with your start command'",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -140,6 +140,7 @@ export interface TaskRunContext {
   stdout: { write(text: string): void };
   services: ServiceContext;
   projectDir: string;
+  url(this: void, service: string, opts?: UrlOptions): string | null;
 }
 
 // === Tasks ===

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -224,8 +224,8 @@ export interface ProjectConfig {
 
 // === Library Namespaces ===
 export interface FindUpOptions {
-  /** Static absolute path to stop at, or `"config"` for the configDir boundary. */
-  stopAt?: string | "config";
+  /** Static absolute path to stop at, or the literal `"config"` for the configDir boundary. */
+  stopAt?: string;
   /** Message for the thrown `ConfigError` when the file is not found. */
   orFatal?: string;
 }
@@ -287,7 +287,6 @@ export interface LibraryActions {
   restartService: (name: string) => Promise<void>;
   stopService: (name: string) => Promise<void>;
   isServiceRunning: (name: string) => boolean;
-  openInBrowser: (url: string) => Promise<void>;
 }
 
 // === Resolved ===

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -69,7 +69,10 @@ export interface OptionalContext {
 }
 
 // === Env Config ===
-export type EnvConfig = Record<string, string> | ((ctx: ServiceContext) => Record<string, string>);
+export type EnvValue = string | null | undefined;
+export type EnvConfig =
+  | Record<string, EnvValue>
+  | ((ctx: ServiceContext) => Record<string, EnvValue>);
 
 // === Service Flags ===
 export interface ServiceFlags {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -50,6 +50,15 @@ export interface CombinedServiceMeta {
   isOwner: boolean;
 }
 
+// === URL Options ===
+export interface UrlOptions {
+  protocol?: string;
+  auth?: string;
+  host?: string;
+  port?: number;
+  path?: string;
+}
+
 // === Service Context ===
 export interface ServiceContext {
   services: Record<
@@ -61,6 +70,7 @@ export interface ServiceContext {
     }
   >;
   projectDir: string;
+  url(this: void, service: string, opts?: UrlOptions): string | null;
 }
 
 // === Optional Context ===
@@ -171,6 +181,9 @@ export interface CwdContext {
   invokeDir: string;
 }
 
+/** Resolver for the `cwd` field. Never returns null — throws `ConfigError` on not-found. */
+export type CwdResolver = (ctx: CwdContext) => string;
+
 // === UI Config ===
 /** Icon theme tier; resolved at startup (Phase 2 `IconTheme`). */
 export type UiIconTheme = "nerd" | "unicode" | "ascii";
@@ -208,17 +221,63 @@ export interface ProjectConfig {
   ui?: UiConfig;
 }
 
+// === Library Namespaces ===
+export interface FindUpOptions {
+  /** Static absolute path to stop at, or `"config"` for the configDir boundary. */
+  stopAt?: string | "config";
+  /** Message for the thrown `ConfigError` when the file is not found. */
+  orFatal?: string;
+}
+
+export interface FindHelpers {
+  up(this: void, filename: string, opts?: FindUpOptions): CwdResolver;
+}
+
+export interface CliHelpers {
+  /** Throws `ConfigError` (`kind: "fatal"`). Does NOT call `process.exit`. */
+  fatal(this: void, message: string, opts?: { field?: string }): never;
+  warn(this: void, message: string): void;
+  info(this: void, message: string): void;
+  success(this: void, message: string): void;
+}
+
+export interface TaskHelpers {
+  run(this: void, key: string): Promise<void>;
+}
+
+export interface ServiceHelpers {
+  start(this: void, name: string): Promise<void>;
+  stop(this: void, name: string): Promise<void>;
+  restart(this: void, name: string): Promise<void>;
+  isRunning(this: void, name: string): boolean;
+}
+
+export interface BrowserHelpers {
+  open(this: void, url: string): Promise<void>;
+}
+
+// === Config Notices ===
+/** `fatal` is a throw, not a notice. */
+export type NoticeLevel = "info" | "success" | "warn";
+export interface ConfigNotice {
+  level: NoticeLevel;
+  message: string;
+}
+export type NoticeSink = (notice: ConfigNotice) => void;
+
 // === Library ===
 export interface Library {
-  defineProject(this: void, config: ProjectConfig): ProjectConfig;
-  runTask(this: void, key: string): Promise<void>;
-  startService(this: void, name: string): Promise<void>;
-  restartService(this: void, name: string): Promise<void>;
-  stopService(this: void, name: string): Promise<void>;
-  isServiceRunning(this: void, name: string): boolean;
-  openInBrowser(this: void, url: string): Promise<void>;
+  define(this: void, config: ProjectConfig): ProjectConfig;
+  find: FindHelpers;
+  cli: CliHelpers;
+  task: TaskHelpers;
+  service: ServiceHelpers;
+  browser: BrowserHelpers;
   node: NodeModules;
 }
+
+// === Config Function ===
+export type ConfigFn = (lib: Library) => ProjectConfig | Promise<ProjectConfig>;
 
 // === Library Actions ===
 export interface LibraryActions {

--- a/src/daemon/handlers/daemon.ts
+++ b/src/daemon/handlers/daemon.ts
@@ -1,3 +1,4 @@
+import { logConfigError } from "#src/daemon/log-config-error.js";
 import type { SessionStore } from "#src/daemon/server.js";
 import { runShutdownHook } from "#src/daemon/shutdown.js";
 import { ipcErr, ipcOk } from "#src/lib/ipc/protocol.js";
@@ -73,6 +74,9 @@ export const daemonHandlers: Record<
         focusPane: session.focusPane,
       });
     } catch (error) {
+      // `buildSession` loads config first (server.ts) — a throw here leaves no
+      // Partial session registered. Log the full error before the IPC message.
+      logConfigError(error);
       return ipcErr(req.id, error instanceof Error ? error.message : String(error));
     }
   },

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -1,6 +1,7 @@
 import type { Socket } from "node:net";
 
 import type { Command, DockerConfig } from "#src/config/types.js";
+import { logConfigError } from "#src/daemon/log-config-error.js";
 import type { SessionStore } from "#src/daemon/server.js";
 import type { Session } from "#src/daemon/session.js";
 import { execCommand } from "#src/lib/exec.js";
@@ -131,6 +132,9 @@ export const sessionHandlers: Record<
       await session.reload();
       return ipcOk(req.id, { reloaded: true });
     } catch (error) {
+      // Log the full error (with ConfigError attribution) locally before sending
+      // The message-only IPC response — the running session is left intact (A1).
+      logConfigError(error);
       return ipcErr(req.id, error instanceof Error ? error.message : String(error));
     }
   },

--- a/src/daemon/log-config-error.ts
+++ b/src/daemon/log-config-error.ts
@@ -1,0 +1,29 @@
+import { ConfigError } from "#src/config/index.js";
+
+/**
+ * Log a config-eval failure to the daemon's stderr (redirected to the daemon log
+ * file). The full `ConfigError` attribution (kind/file/service/task/field) is
+ * recorded here because only `.message` crosses the IPC boundary back to the CLI.
+ */
+export function logConfigError(error: unknown): void {
+  if (error instanceof ConfigError) {
+    const parts = [`kind=${error.kind}`];
+    if (error.file !== undefined) {
+      parts.push(`file=${error.file}`);
+    }
+    if (error.service !== undefined) {
+      parts.push(`service=${error.service}`);
+    }
+    if (error.task !== undefined) {
+      parts.push(`task=${error.task}`);
+    }
+    if (error.field !== undefined) {
+      parts.push(`field=${error.field}`);
+    }
+    process.stderr.write(`ConfigError [${parts.join(" ")}]: ${error.message}\n`);
+    return;
+  }
+  process.stderr.write(
+    `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+  );
+}

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -421,8 +421,12 @@ export class Session {
 
   private async _reload(): Promise<void> {
     // 1. Load + validate the new config FIRST. No teardown yet — on failure this
-    // Throws verbatim and the running session is left fully intact (A1).
-    const newConfig = await loadConfig(this.configPath, this.projectDir);
+    // Throws verbatim and the running session is left fully intact (A1). The old
+    // Session is alive throughout the load, so cli.warn/info/success notices
+    // Broadcast to the attached TUI as toasts.
+    const newConfig = await loadConfig(this.configPath, this.projectDir, (notice) => {
+      this.broadcast({ session: this.id, event: "config.notice", data: notice });
+    });
     const newConfigLoadedAt = Date.now();
 
     // 2. Cooperatively abort any in-flight startAll, then await its settlement.

--- a/src/lib/ipc/protocol.ts
+++ b/src/lib/ipc/protocol.ts
@@ -1,9 +1,14 @@
+import type { ConfigNotice } from "#src/config/types.js";
+
 export interface IpcRequest {
   id: string;
   method: string;
   session?: string;
   params?: unknown;
 }
+
+/** Payload of the `config.notice` daemon event (cli.warn/info/success). */
+export type ConfigNoticeData = ConfigNotice;
 
 export interface IpcResponse {
   id: string;

--- a/src/lib/open.ts
+++ b/src/lib/open.ts
@@ -1,13 +1,11 @@
 import open from "open";
 
+/**
+ * Open a URL in the system's default browser. No reachability preflight — a
+ * service that is still booting should still open (the browser retries). A real
+ * failure (e.g. no browser available) rejects, so callers that have a notice
+ * sink can surface it instead of swallowing silently (Q-R4a).
+ */
 export async function openInBrowser(url: string): Promise<void> {
-  try {
-    await fetch(url, {
-      method: "HEAD",
-      signal: AbortSignal.timeout(2000),
-    });
-    await open(url);
-  } catch {
-    // Not reachable — silently ignore
-  }
+  await open(url);
 }

--- a/src/lib/service/env.ts
+++ b/src/lib/service/env.ts
@@ -31,10 +31,16 @@ export function resolveEnv(
   if (!envConfig) {
     return {};
   }
-  if (typeof envConfig === "function") {
-    return envConfig(ctx);
+  const record = typeof envConfig === "function" ? envConfig(ctx) : envConfig;
+  // Drop null/undefined values (e.g. an unresolved `ctx.url()`) so the variable
+  // Is omitted rather than spawned as an empty string.
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value !== null && value !== undefined) {
+      resolved[key] = value;
+    }
   }
-  return envConfig;
+  return resolved;
 }
 
 /**

--- a/src/lib/service/env.ts
+++ b/src/lib/service/env.ts
@@ -1,4 +1,6 @@
-import type { EnvConfig, ServiceContext, ServiceStatus } from "./types.js";
+import { buildUrl } from "#src/config/helpers/context.js";
+
+import type { EnvConfig, ServiceContext, ServiceStatus, UrlOptions } from "./types.js";
 
 /**
  * Build a ServiceContext from current service statuses. Each service's `cwd`
@@ -18,7 +20,11 @@ export function buildServiceContext(
       cwd: servicesConfig[name]?.cwd ?? projectDir,
     };
   }
-  return { services, projectDir };
+  return {
+    services,
+    projectDir,
+    url: (name: string, opts?: UrlOptions) => buildUrl(services, name, opts),
+  };
 }
 
 /**

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -215,7 +215,8 @@ async function tryAutoOpen(
 ): Promise<void> {
   if (serviceConfig.flags?.open && url && !autoOpened.has(name)) {
     autoOpened.add(name);
-    await openInBrowser(url);
+    // Best-effort auto-open; a launch failure must not break the ready flow.
+    await openInBrowser(url).catch(() => undefined);
   }
 }
 

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -352,7 +352,6 @@ export class ServiceManager extends EventEmitter {
         await this.stopService(name);
       },
       isServiceRunning: (name) => this.statuses.get(name)?.state === "ready",
-      openInBrowser: async (url) => openInBrowser(url),
     });
   }
 
@@ -586,10 +585,10 @@ export class ServiceManager extends EventEmitter {
     // The reflow entirely — non-lazy behavior is byte-identical to before.
     // CRITICAL: skip reflowInsert during shutdown (reload/destroy). Same deadlock
     // Class as the reflowRemove guard in `stopService` — a `onStop` hook is
-    // Allowed to call `lib.startService`/`lib.restartService` (config/builder.ts:49-53),
+    // Allowed to call `lib.service.start`/`lib.service.restart` (config/builder.ts:49-53),
     // And `onStop` fires during reload's stopAll loop. Without this guard:
     //   Reload holds withOpLock → manager.stopAll → stopService(svc1) →
-    //   StopServiceInternal → onStop hook → lib.startService(svc2) →
+    //   StopServiceInternal → onStop hook → lib.service.start(svc2) →
     //   Deps.reflowInsert(svc2) → Session.reflowInsert → withOpLock (not
     //   Re-entrant) → chains AFTER the outer reload fn → permanent hang.
     // Safe to skip during shutdown: services aren't meaningfully starting
@@ -1131,7 +1130,7 @@ export class ServiceManager extends EventEmitter {
     // (the common "restart the running worker") sees `paneMap[name]` already
     // Set and skips this — preserving the existing pane id (P04-T04 Flow E).
     // CRITICAL: same shuttingDown guard as `startService` — `onStop` hooks can
-    // Reach `lib.restartService` during reload's stopAll loop; without the
+    // Reach `lib.service.restart` during reload's stopAll loop; without the
     // Guard we'd re-enter withOpLock through reflowInsert and deadlock. See
     // `startService` for the full chain.
     const isLazy = this.config.lazyPaneByService.get(name) === true;

--- a/src/lib/service/types.ts
+++ b/src/lib/service/types.ts
@@ -10,6 +10,7 @@ export type {
   ReadyOutput,
   ReadyPort,
   ServiceContext,
+  UrlOptions,
 } from "#src/config/types.js";
 export { isReadyDocker, isReadyHttp, isReadyOutput, isReadyPort } from "#src/config/types.js";
 

--- a/src/lib/task/runner.ts
+++ b/src/lib/task/runner.ts
@@ -42,6 +42,7 @@ async function executeTask(t: TaskConfig, ctx: ExecuteContext): Promise<void> {
       },
       services: ctx.serviceCtx,
       projectDir: ctx.projectDir,
+      url: ctx.serviceCtx.url,
     });
   } else if (t.commands) {
     const commands = Array.isArray(t.commands) ? t.commands : [t.commands];

--- a/test/cli/errors.test.ts
+++ b/test/cli/errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderCliError } from "../../src/cli/errors.js";
+import { ConfigError } from "../../src/config/errors.js";
+
+function makeDeps() {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  return {
+    writes,
+    exits,
+    deps: {
+      write: (text: string) => {
+        writes.push(text);
+      },
+      exit: ((code: number) => {
+        exits.push(code);
+        return undefined as never;
+      }) as (code: number) => never,
+    },
+  };
+}
+
+describe("renderCliError", () => {
+  it("styles a ConfigError with a ✖ prefix and exits 1", () => {
+    const { writes, exits, deps } = makeDeps();
+    renderCliError(new ConfigError("bad config", { kind: "validation" }), deps);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("✖");
+    expect(writes[0]).toContain("bad config");
+    expect(exits).toEqual([1]);
+  });
+
+  it("renders a plain Error without the ✖ prefix and exits 1", () => {
+    const { writes, exits, deps } = makeDeps();
+    renderCliError(new Error("plain boom"), deps);
+    expect(writes).toEqual(["plain boom\n"]);
+    expect(writes[0]).not.toContain("✖");
+    expect(exits).toEqual([1]);
+  });
+
+  it("stringifies a non-Error value and exits 1", () => {
+    const { writes, exits, deps } = makeDeps();
+    renderCliError("just a string", deps);
+    expect(writes).toEqual(["just a string\n"]);
+    expect(exits).toEqual([1]);
+  });
+
+  it("uses default deps (process.stderr + process.exit) when none injected", () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    renderCliError(new Error("default path"));
+    expect(writeSpy).toHaveBeenCalledWith("default path\n");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    writeSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/test/client/daemon-client.test.ts
+++ b/test/client/daemon-client.test.ts
@@ -415,6 +415,20 @@ describe("DaemonClient", () => {
       expect(spy).toHaveBeenCalled();
     });
 
+    it("routes config.notice", () => {
+      const spy = vi.fn();
+      client.on("config.notice", spy);
+      client.connect();
+
+      eventHandler({
+        session: "sess1",
+        event: "config.notice",
+        data: { level: "warn", message: "deprecated option" },
+      });
+
+      expect(spy).toHaveBeenCalledWith("warn", "deprecated option");
+    });
+
     it("routes session.configReloaded", () => {
       const spy = vi.fn();
       client.on("session.configReloaded", spy);

--- a/test/components/Router.failed-output.test.tsx
+++ b/test/components/Router.failed-output.test.tsx
@@ -121,7 +121,7 @@ async function pressKey(stdin: { write: (data: string) => void }, data: string) 
  * Mounts only after an async `getTaskOutput` fetch resolves, so a fixed sleep
  * Races under full-suite load — wait on the actual condition instead.
  */
-async function waitFor(predicate: () => boolean, timeoutMs = 2000, pollMs = 10) {
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000, pollMs = 10) {
   const start = Date.now();
   while (!predicate()) {
     if (Date.now() - start >= timeoutMs) {
@@ -195,7 +195,7 @@ describe("Router failure → toast / notifier / failed-output overlay", () => {
     await waitFor(() => overlay?.top?.id === FAILED_OUTPUT_ID);
     expect(overlay?.top?.id).toBe(FAILED_OUTPUT_ID);
     expect(client.getTaskOutput).toHaveBeenCalledWith("run_1");
-  });
+  }, 20_000);
 
   it("`f` is a no-op when there is no sticky failure", async () => {
     const client = createMockClient();
@@ -229,5 +229,5 @@ describe("Router failure → toast / notifier / failed-output overlay", () => {
     expect(overlay?.isOpen).toBe(false);
     await waitFor(() => toasts?.toasts.filter((t) => t.sticky && t.runId === "run_1").length === 0);
     expect(toasts?.toasts.filter((t) => t.sticky && t.runId === "run_1").length).toBe(0);
-  });
+  }, 20_000);
 });

--- a/test/components/Router.failed-output.test.tsx
+++ b/test/components/Router.failed-output.test.tsx
@@ -116,6 +116,24 @@ async function pressKey(stdin: { write: (data: string) => void }, data: string) 
   });
 }
 
+/**
+ * Poll a predicate inside `act()` until it holds. The failed-output overlay
+ * Mounts only after an async `getTaskOutput` fetch resolves, so a fixed sleep
+ * Races under full-suite load — wait on the actual condition instead.
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000, pollMs = 10) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error("waitFor: condition not met within timeout");
+    }
+    // eslint-disable-next-line no-await-in-loop -- sequential poll
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    });
+  }
+}
+
 describe("Router failure → toast / notifier / failed-output overlay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -174,7 +192,7 @@ describe("Router failure → toast / notifier / failed-output overlay", () => {
     client.emit("task.complete", "build", "Build", "error", "run_1");
     await flush();
     await pressKey(stdin, "f");
-    await flush();
+    await waitFor(() => overlay?.top?.id === FAILED_OUTPUT_ID);
     expect(overlay?.top?.id).toBe(FAILED_OUTPUT_ID);
     expect(client.getTaskOutput).toHaveBeenCalledWith("run_1");
   });
@@ -203,11 +221,13 @@ describe("Router failure → toast / notifier / failed-output overlay", () => {
     client.emit("task.complete", "build", "Build", "error", "run_1");
     await flush();
     await pressKey(stdin, "f");
-    await flush();
+    await waitFor(() => overlay?.top?.id === FAILED_OUTPUT_ID);
     expect(overlay?.top?.id).toBe(FAILED_OUTPUT_ID);
     // Esc → OverlayHost pops → overlay unmounts → onClose acks run_1.
     await pressKey(stdin, "\x1B");
+    await waitFor(() => overlay?.isOpen === false);
     expect(overlay?.isOpen).toBe(false);
+    await waitFor(() => toasts?.toasts.filter((t) => t.sticky && t.runId === "run_1").length === 0);
     expect(toasts?.toasts.filter((t) => t.sticky && t.runId === "run_1").length).toBe(0);
   });
 });

--- a/test/components/Router.failed-output.test.tsx
+++ b/test/components/Router.failed-output.test.tsx
@@ -144,6 +144,30 @@ describe("Router failure → toast / notifier / failed-output overlay", () => {
     expect(notifyFailure).not.toHaveBeenCalled();
   });
 
+  it("surfaces a config.notice as a transient toast (success maps 1:1)", async () => {
+    const client = createMockClient();
+    renderRouter(client);
+    client.emit("config.notice", "success", "config reloaded");
+    await flush();
+    expect(
+      toasts?.toasts.some(
+        (t) => !t.sticky && t.level === "success" && t.message === "config reloaded",
+      ),
+    ).toBe(true);
+  });
+
+  it("maps a warn config.notice to a non-sticky info toast", async () => {
+    const client = createMockClient();
+    renderRouter(client);
+    client.emit("config.notice", "warn", "deprecated option");
+    await flush();
+    expect(
+      toasts?.toasts.some(
+        (t) => !t.sticky && t.level === "info" && t.message === "deprecated option",
+      ),
+    ).toBe(true);
+  });
+
   it("`f` opens the failed-output overlay for the latest sticky failure", async () => {
     const client = createMockClient();
     const { stdin } = renderRouter(client);

--- a/test/components/Router.test.tsx
+++ b/test/components/Router.test.tsx
@@ -20,7 +20,7 @@ import type { ServiceStatus } from "../../src/lib/service/types.js";
 // ── mocks ──────────────────────────────────────────────────────────────
 
 vi.mock("../../src/lib/open.js", () => ({
-  openInBrowser: vi.fn(),
+  openInBrowser: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../src/lib/tmux.js", () => ({

--- a/test/config/builder.browser.test.ts
+++ b/test/config/builder.browser.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/open.js", () => ({ openInBrowser: vi.fn() }));
+
+import { createZapsLib } from "../../src/config/builder.js";
+import type { ConfigNotice } from "../../src/config/types.js";
+import { openInBrowser } from "../../src/lib/open.js";
+
+const mockOpen = vi.mocked(openInBrowser);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("lib.browser.open", () => {
+  it("emits a warn notice when opening the browser fails", async () => {
+    mockOpen.mockRejectedValue(new Error("no browser"));
+    const notices: ConfigNotice[] = [];
+    const { lib } = createZapsLib({ onNotice: (n) => notices.push(n) });
+
+    await lib.browser.open("http://localhost:3000");
+
+    expect(mockOpen).toHaveBeenCalledWith("http://localhost:3000");
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.level).toBe("warn");
+    expect(notices[0]?.message).toContain("http://localhost:3000");
+    expect(notices[0]?.message).toContain("no browser");
+  });
+
+  it("does not emit a notice on success", async () => {
+    mockOpen.mockResolvedValue(undefined);
+    const notices: ConfigNotice[] = [];
+    const { lib } = createZapsLib({ onNotice: (n) => notices.push(n) });
+
+    await lib.browser.open("http://localhost:3000");
+
+    expect(notices).toHaveLength(0);
+  });
+});

--- a/test/config/builder.test.ts
+++ b/test/config/builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createZapsLib } from "../../src/config/builder.js";
+import { ConfigError } from "../../src/config/errors.js";
 
 describe("createZapsLib", () => {
   it("defineProject returns the parsed config (input fields preserved + ui defaults)", () => {
@@ -35,6 +36,23 @@ describe("createZapsLib", () => {
         },
       } as never),
     ).toThrow();
+  });
+
+  it("throws ConfigError(validation) with the offending field path", () => {
+    const { lib } = createZapsLib();
+    let caught: unknown;
+    try {
+      lib.defineProject({
+        name: "test",
+        services: {
+          app: { start: 42 },
+        },
+      } as never);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect(caught).toMatchObject({ kind: "validation", field: "services.app.start" });
   });
 
   it("throws when service has no start/run/docker", () => {

--- a/test/config/builder.test.ts
+++ b/test/config/builder.test.ts
@@ -4,7 +4,7 @@ import { createZapsLib } from "../../src/config/builder.js";
 import { ConfigError } from "../../src/config/errors.js";
 
 describe("createZapsLib", () => {
-  it("defineProject returns the parsed config (input fields preserved + ui defaults)", () => {
+  it("define returns the parsed config (input fields preserved + ui defaults)", () => {
     const { lib } = createZapsLib();
     const cfg = {
       name: "test",
@@ -13,7 +13,7 @@ describe("createZapsLib", () => {
       },
     };
 
-    expect(lib.defineProject(cfg)).toEqual({
+    expect(lib.define(cfg)).toEqual({
       ...cfg,
       // The schema resolves the optional `ui` block to its defaults.
       ui: {
@@ -29,7 +29,7 @@ describe("createZapsLib", () => {
   it("throws readable error for invalid config", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: {
           app: { start: 42 },
@@ -42,7 +42,7 @@ describe("createZapsLib", () => {
     const { lib } = createZapsLib();
     let caught: unknown;
     try {
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: {
           app: { start: 42 },
@@ -58,7 +58,7 @@ describe("createZapsLib", () => {
   it("throws when service has no start/run/docker", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: { api: {} },
       }),
@@ -68,21 +68,21 @@ describe("createZapsLib", () => {
   it("throws when services is empty", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: {},
       }),
     ).toThrow("Project must have at least one service");
   });
 
-  it("runTask throws before binding", async () => {
+  it("task.run throws before binding", async () => {
     const { lib } = createZapsLib();
-    await expect(lib.runTask("test")).rejects.toThrow(
-      "runTask is not available outside of service hooks",
+    await expect(lib.task.run("test")).rejects.toThrow(
+      "task.run is not available outside of service hooks",
     );
   });
 
-  it("runTask delegates to bound actions after binding", async () => {
+  it("task.run delegates to bound actions after binding", async () => {
     const { lib, bindActions } = createZapsLib();
     const runTask = vi.fn().mockResolvedValue(undefined);
     bindActions({
@@ -91,22 +91,21 @@ describe("createZapsLib", () => {
       restartService: vi.fn(),
       stopService: vi.fn(),
       isServiceRunning: vi.fn(),
-      openInBrowser: vi.fn(),
     });
 
-    await lib.runTask("my-task");
+    await lib.task.run("my-task");
 
     expect(runTask).toHaveBeenCalledWith("my-task");
   });
 
-  it("startService throws before binding", async () => {
+  it("service.start throws before binding", async () => {
     const { lib } = createZapsLib();
-    await expect(lib.startService("svc")).rejects.toThrow(
-      "startService is not available outside of service hooks",
+    await expect(lib.service.start("svc")).rejects.toThrow(
+      "service.start is not available outside of service hooks",
     );
   });
 
-  it("startService delegates after binding", async () => {
+  it("service.start delegates after binding", async () => {
     const { lib, bindActions } = createZapsLib();
     const startService = vi.fn().mockResolvedValue(undefined);
     bindActions({
@@ -115,22 +114,21 @@ describe("createZapsLib", () => {
       restartService: vi.fn(),
       stopService: vi.fn(),
       isServiceRunning: vi.fn(),
-      openInBrowser: vi.fn(),
     });
 
-    await lib.startService("db");
+    await lib.service.start("db");
 
     expect(startService).toHaveBeenCalledWith("db");
   });
 
-  it("restartService throws before binding", async () => {
+  it("service.restart throws before binding", async () => {
     const { lib } = createZapsLib();
-    await expect(lib.restartService("svc")).rejects.toThrow(
-      "restartService is not available outside of service hooks",
+    await expect(lib.service.restart("svc")).rejects.toThrow(
+      "service.restart is not available outside of service hooks",
     );
   });
 
-  it("restartService delegates after binding", async () => {
+  it("service.restart delegates after binding", async () => {
     const { lib, bindActions } = createZapsLib();
     const restartService = vi.fn().mockResolvedValue(undefined);
     bindActions({
@@ -139,22 +137,21 @@ describe("createZapsLib", () => {
       restartService,
       stopService: vi.fn(),
       isServiceRunning: vi.fn(),
-      openInBrowser: vi.fn(),
     });
 
-    await lib.restartService("api");
+    await lib.service.restart("api");
 
     expect(restartService).toHaveBeenCalledWith("api");
   });
 
-  it("stopService throws before binding", async () => {
+  it("service.stop throws before binding", async () => {
     const { lib } = createZapsLib();
-    await expect(lib.stopService("svc")).rejects.toThrow(
-      "stopService is not available outside of service hooks",
+    await expect(lib.service.stop("svc")).rejects.toThrow(
+      "service.stop is not available outside of service hooks",
     );
   });
 
-  it("stopService delegates after binding", async () => {
+  it("service.stop delegates after binding", async () => {
     const { lib, bindActions } = createZapsLib();
     const stopService = vi.fn().mockResolvedValue(undefined);
     bindActions({
@@ -163,18 +160,17 @@ describe("createZapsLib", () => {
       restartService: vi.fn(),
       stopService,
       isServiceRunning: vi.fn(),
-      openInBrowser: vi.fn(),
     });
 
-    await lib.stopService("worker");
+    await lib.service.stop("worker");
 
     expect(stopService).toHaveBeenCalledWith("worker");
   });
 
-  it("isServiceRunning throws before binding", () => {
+  it("service.isRunning throws before binding", () => {
     const { lib } = createZapsLib();
-    expect(() => lib.isServiceRunning("svc")).toThrow(
-      "isServiceRunning is not available outside of service hooks",
+    expect(() => lib.service.isRunning("svc")).toThrow(
+      "service.isRunning is not available outside of service hooks",
     );
   });
 
@@ -188,7 +184,7 @@ describe("createZapsLib", () => {
     expect(typeof lib.node.child_process.exec).toBe("function");
   });
 
-  it("isServiceRunning delegates after binding", () => {
+  it("service.isRunning delegates after binding", () => {
     const { lib, bindActions } = createZapsLib();
     const isServiceRunning = vi.fn().mockReturnValue(true);
     bindActions({
@@ -197,26 +193,26 @@ describe("createZapsLib", () => {
       restartService: vi.fn(),
       stopService: vi.fn(),
       isServiceRunning,
-      openInBrowser: vi.fn(),
     });
 
-    const result = lib.isServiceRunning("db");
+    const result = lib.service.isRunning("db");
 
     expect(isServiceRunning).toHaveBeenCalledWith("db");
     expect(result).toBe(true);
   });
 
-  it("openInBrowser works without binding (calls lib/open directly)", async () => {
+  it("exposes find and cli namespaces", () => {
     const { lib } = createZapsLib();
-    // OpenInBrowser should not throw even without bindActions
-    // It calls the lib/open module directly, not through actions
-    await expect(lib.openInBrowser("http://localhost:3000")).resolves.toBeUndefined();
+    expect(typeof lib.find.up).toBe("function");
+    expect(typeof lib.cli.fatal).toBe("function");
+    expect(typeof lib.cli.warn).toBe("function");
+    expect(typeof lib.browser.open).toBe("function");
   });
 
   it("throws when task has both commands and run", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: { app: { start: "npm start" } },
         tasks: {
@@ -235,7 +231,7 @@ describe("createZapsLib", () => {
   it("throws when task has neither commands nor run", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: { app: { start: "npm start" } },
         tasks: {
@@ -250,7 +246,7 @@ describe("createZapsLib", () => {
   it("throws when task has popup with run", () => {
     const { lib } = createZapsLib();
     expect(() =>
-      lib.defineProject({
+      lib.define({
         name: "test",
         services: { app: { start: "npm start" } },
         tasks: {

--- a/test/config/errors.test.ts
+++ b/test/config/errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigError } from "../../src/config/errors.js";
+
+describe("ConfigError", () => {
+  it("defaults kind to validation", () => {
+    const err = new ConfigError("boom");
+    expect(err.kind).toBe("validation");
+  });
+
+  it("accepts a custom kind", () => {
+    const err = new ConfigError("boom", { kind: "fatal" });
+    expect(err.kind).toBe("fatal");
+  });
+
+  it("carries attribution fields", () => {
+    const err = new ConfigError("boom", {
+      kind: "notFound",
+      file: "/abs/.zaps.ts",
+      service: "api",
+      task: "seed",
+      field: "cwd",
+    });
+    expect(err.file).toBe("/abs/.zaps.ts");
+    expect(err.service).toBe("api");
+    expect(err.task).toBe("seed");
+    expect(err.field).toBe("cwd");
+  });
+
+  it("leaves attribution fields undefined by default", () => {
+    const err = new ConfigError("boom");
+    expect(err.file).toBeUndefined();
+    expect(err.service).toBeUndefined();
+    expect(err.task).toBeUndefined();
+    expect(err.field).toBeUndefined();
+  });
+
+  it("sets name to ConfigError and extends Error", () => {
+    const err = new ConfigError("boom");
+    expect(err.name).toBe("ConfigError");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ConfigError);
+  });
+
+  it("keeps message plain (no ANSI escape codes)", () => {
+    const err = new ConfigError("config evaluation timed out");
+    expect(err.message).toBe("config evaluation timed out");
+    expect(err.message).not.toContain(String.fromCharCode(27));
+  });
+});

--- a/test/config/helpers/cli.test.ts
+++ b/test/config/helpers/cli.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfigError } from "../../../src/config/errors.js";
+import { createCliHelpers, createStderrSink } from "../../../src/config/helpers/cli.js";
+import type { ConfigNotice } from "../../../src/config/types.js";
+
+describe("createCliHelpers", () => {
+  it("fatal throws ConfigError(kind:fatal) with the field passthrough", () => {
+    const notices: ConfigNotice[] = [];
+    const cli = createCliHelpers((n) => notices.push(n));
+    let caught: unknown;
+    try {
+      cli.fatal("boom", { field: "services.api" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect(caught).toMatchObject({ kind: "fatal", field: "services.api" });
+    // Does NOT route through the sink.
+    expect(notices).toHaveLength(0);
+  });
+
+  it("fatal without opts leaves field undefined", () => {
+    const cli = createCliHelpers(vi.fn());
+    expect(() => cli.fatal("boom")).toThrow(ConfigError);
+    try {
+      cli.fatal("boom");
+    } catch (error) {
+      expect((error as ConfigError).field).toBeUndefined();
+    }
+  });
+
+  it("warn/info/success emit a ConfigNotice through the sink and return void", () => {
+    const notices: ConfigNotice[] = [];
+    const cli = createCliHelpers((n) => notices.push(n));
+    expect(cli.warn("w")).toBeUndefined();
+    expect(cli.info("i")).toBeUndefined();
+    expect(cli.success("s")).toBeUndefined();
+    expect(notices).toEqual([
+      { level: "warn", message: "w" },
+      { level: "info", message: "i" },
+      { level: "success", message: "s" },
+    ]);
+  });
+});
+
+describe("createStderrSink", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes a styled line per level to stderr", () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const sink = createStderrSink();
+    sink({ level: "warn", message: "careful" });
+    sink({ level: "info", message: "fyi" });
+    sink({ level: "success", message: "done" });
+
+    expect(writes).toHaveLength(3);
+    expect(writes[0]).toContain("⚠");
+    expect(writes[0]).toContain("careful");
+    expect(writes[1]).toContain("ℹ");
+    expect(writes[1]).toContain("fyi");
+    expect(writes[2]).toContain("✔");
+    expect(writes[2]).toContain("done");
+  });
+});

--- a/test/config/helpers/context.test.ts
+++ b/test/config/helpers/context.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigError } from "../../../src/config/errors.js";
+import { buildUrl } from "../../../src/config/helpers/context.js";
+import type { ServiceContext } from "../../../src/config/types.js";
+
+type Services = ServiceContext["services"];
+
+const services: Services = {
+  api: { port: 3000, ports: [3000], cwd: undefined },
+  db: { port: 5432, ports: [5432], cwd: undefined },
+  noPort: { port: undefined, ports: [], cwd: undefined },
+};
+
+describe("buildUrl", () => {
+  it("throws ConfigError(validation) for an unknown service", () => {
+    let caught: unknown;
+    try {
+      buildUrl(services, "ghost");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect(caught).toMatchObject({ kind: "validation", service: "ghost" });
+  });
+
+  it("returns null when the service has no detected port and no override", () => {
+    expect(buildUrl(services, "noPort")).toBeNull();
+  });
+
+  it("builds a default http://localhost URL from the detected port", () => {
+    expect(buildUrl(services, "api")).toBe("http://localhost:3000");
+  });
+
+  it("applies protocol, auth, and path overrides", () => {
+    expect(
+      buildUrl(services, "db", { protocol: "postgres", auth: "user:pass", path: "/mydb" }),
+    ).toBe("postgres://user:pass@localhost:5432/mydb");
+  });
+
+  it("overrides the detected port", () => {
+    expect(buildUrl(services, "api", { port: 8080 })).toBe("http://localhost:8080");
+  });
+
+  it("uses the port override when the service has no detected port", () => {
+    expect(buildUrl(services, "noPort", { port: 3000 })).toBe("http://localhost:3000");
+  });
+
+  it("honors a host override", () => {
+    expect(buildUrl(services, "api", { host: "example.com" })).toBe("http://example.com:3000");
+  });
+
+  it("prefixes a leading slash on a non-slash path", () => {
+    expect(buildUrl(services, "db", { protocol: "postgres", path: "mydb" })).toBe(
+      "postgres://localhost:5432/mydb",
+    );
+  });
+
+  it("keeps an already-slashed path as-is", () => {
+    expect(buildUrl(services, "api", { path: "/health" })).toBe("http://localhost:3000/health");
+  });
+
+  it("omits an empty path", () => {
+    expect(buildUrl(services, "api", { path: "" })).toBe("http://localhost:3000");
+  });
+
+  it("omits empty auth", () => {
+    expect(buildUrl(services, "api", { auth: "" })).toBe("http://localhost:3000");
+  });
+
+  it("brackets an IPv6 host", () => {
+    expect(buildUrl(services, "api", { host: "::1" })).toBe("http://[::1]:3000");
+  });
+
+  it("brackets an IPv6 host with auth and path", () => {
+    expect(buildUrl(services, "db", { host: "::1", auth: "u:p", path: "db" })).toBe(
+      "http://u:p@[::1]:5432/db",
+    );
+  });
+});

--- a/test/config/helpers/find.test.ts
+++ b/test/config/helpers/find.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ConfigError } from "../../../src/config/errors.js";
+import { createFindHelpers } from "../../../src/config/helpers/find.js";
+
+let tmpDir = "";
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "zaps-find-")));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function ctx(invokeDir: string, configDir = tmpDir) {
+  return { invokeDir, configDir };
+}
+
+describe("find.up", () => {
+  it("returns a CwdResolver function (never null)", () => {
+    const { up } = createFindHelpers();
+    expect(typeof up("package.json")).toBe("function");
+  });
+
+  it("returns the directory containing the file, walking upward", () => {
+    const nested = path.join(tmpDir, "a", "b", "c");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "a", "package.json"), "{}");
+
+    const { up } = createFindHelpers();
+    const resolver = up("package.json");
+    expect(resolver(ctx(nested))).toBe(path.join(tmpDir, "a"));
+  });
+
+  it("returns invokeDir itself when the file lives there", () => {
+    fs.writeFileSync(path.join(tmpDir, "Cargo.toml"), "");
+    const { up } = createFindHelpers();
+    expect(up("Cargo.toml")(ctx(tmpDir))).toBe(tmpDir);
+  });
+
+  it("throws ConfigError(notFound) with a default message when not found", () => {
+    const { up } = createFindHelpers();
+    const resolver = up("never-exists.json");
+    let caught: unknown;
+    try {
+      resolver(ctx(tmpDir));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect(caught).toMatchObject({ kind: "notFound", field: "cwd" });
+    expect((caught as ConfigError).message).toContain("never-exists.json");
+    expect((caught as ConfigError).message).toContain(tmpDir);
+  });
+
+  it("uses opts.orFatal as the thrown message", () => {
+    const { up } = createFindHelpers();
+    const resolver = up("Cargo.toml", { orFatal: "Run zaps inside a Rust crate" });
+    expect(() => resolver(ctx(tmpDir))).toThrow("Run zaps inside a Rust crate");
+  });
+
+  it("stops at a static stopAt path before reaching a higher match", () => {
+    const sub = path.join(tmpDir, "sub");
+    const deep = path.join(sub, "deep");
+    fs.mkdirSync(deep, { recursive: true });
+    // Match exists ABOVE the stopAt boundary — must NOT be found.
+    fs.writeFileSync(path.join(tmpDir, "marker"), "");
+
+    const { up } = createFindHelpers();
+    const resolver = up("marker", { stopAt: sub });
+    expect(() => resolver(ctx(deep))).toThrow(ConfigError);
+  });
+
+  it("stops at a static stopAt path that contains the file", () => {
+    const sub = path.join(tmpDir, "sub");
+    const deep = path.join(sub, "deep");
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(sub, "marker"), "");
+
+    const { up } = createFindHelpers();
+    const resolver = up("marker", { stopAt: sub });
+    expect(resolver(ctx(deep))).toBe(sub);
+  });
+
+  it('stopAt: "config" stops at ctx.configDir', () => {
+    const configDir = path.join(tmpDir, "cfg");
+    const deep = path.join(configDir, "x", "y");
+    fs.mkdirSync(deep, { recursive: true });
+    // Match above the configDir boundary — must NOT be found.
+    fs.writeFileSync(path.join(tmpDir, "package.json"), "{}");
+
+    const { up } = createFindHelpers();
+    const resolver = up("package.json", { stopAt: "config" });
+    expect(() => resolver(ctx(deep, configDir))).toThrow(ConfigError);
+  });
+});

--- a/test/config/loader.notice.test.ts
+++ b/test/config/loader.notice.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadConfig } from "../../src/config/loader.js";
+
+let tmpDir = "";
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zaps-loader-notice-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeConfig(content: string): string {
+  const filePath = path.join(tmpDir, ".zaps.ts");
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe("loadConfig notice sink", () => {
+  it("routes cli.warn through the injected onNotice sink", async () => {
+    const configPath = writeConfig(
+      `
+      export function config(z) {
+        z.cli.warn("heads up");
+        return z.define({
+          name: "notice-project",
+          services: { api: { start: "npm run dev" } },
+        });
+      }
+    `,
+    );
+
+    const notices: { level: string; message: string }[] = [];
+    await loadConfig(configPath, tmpDir, (n) => notices.push(n));
+    expect(notices).toEqual([{ level: "warn", message: "heads up" }]);
+  });
+
+  it("falls back to the stderr sink when no onNotice is provided", async () => {
+    const configPath = writeConfig(
+      `
+      export function config(z) {
+        z.cli.success("all good");
+        return z.define({
+          name: "stderr-notice",
+          services: { api: { start: "npm run dev" } },
+        });
+      }
+    `,
+    );
+
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    await loadConfig(configPath, tmpDir);
+    const written = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("all good");
+    stderr.mockRestore();
+  });
+});

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -164,6 +164,33 @@ describe("loadConfig", () => {
     expect(result.project.name).toBe("async-project");
   });
 
+  it("rejects with ConfigError when async config eval exceeds the timeout", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config() {
+        // Never resolves → exercises the 30s eval-timeout backstop.
+        return new Promise(() => {});
+      }
+    `,
+    );
+
+    vi.useFakeTimers();
+    try {
+      const project = loadConfig(configPath, tmpDir);
+      const assertion = expect(project).rejects.toMatchObject({
+        name: "ConfigError",
+        kind: "validation",
+        file: path.resolve(process.cwd(), configPath),
+      });
+      // Flush the jiti-import microtasks and fire the 30s backstop.
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("throws ConfigError when cwd function returns a non-string", async () => {
     const configPath = writeConfig(
       ".zaps.ts",

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -29,7 +29,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test-project",
           services: {
             api: { start: "npm run dev" },
@@ -50,7 +50,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export default function(z) {
-        return z.defineProject({
+        return z.define({
           name: "default-export",
           services: { app: { start: "node index.js" } },
         });
@@ -70,7 +70,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           services: {
             api: { start: "npm run dev" },
           },
@@ -91,7 +91,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           cwd: "./sub",
           services: {
             api: { start: "npm run dev" },
@@ -110,7 +110,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           cwd: "/absolute/path",
           services: {
             api: { start: "npm run dev" },
@@ -129,7 +129,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           cwd: ({ invokeDir }) => invokeDir,
           services: {
             api: { start: "npm run dev" },
@@ -152,7 +152,7 @@ describe("loadConfig", () => {
       `
       export async function config(z) {
         await Promise.resolve();
-        return z.defineProject({
+        return z.define({
           name: "async-project",
           services: { api: { start: "npm run dev" } },
         });
@@ -169,7 +169,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           cwd: () => undefined,
           services: { api: { start: "npm run dev" } },
         });
@@ -192,7 +192,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           cwd: () => "./rel",
           services: {
             api: { start: "npm run dev" },
@@ -211,7 +211,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           services: {
             api: { start: "npm run dev" },
           },
@@ -230,7 +230,7 @@ describe("loadConfig", () => {
       `
       export function config(z) {
         const dir = z.node.path.join("/foo", "bar");
-        return z.defineProject({
+        return z.define({
           name: "node-test",
           cwd: dir,
           services: {
@@ -253,7 +253,7 @@ describe("loadConfig", () => {
       `
       import { projectName } from "./helper.mts";
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: projectName,
           services: { api: { start: "npm run dev" } },
         });
@@ -278,7 +278,7 @@ describe("loadConfig", () => {
       configPath,
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "hash-path",
           services: { api: { start: "npm run dev" } },
         });
@@ -296,7 +296,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             db: { start: "start-db", flags: { start: false } },
@@ -320,7 +320,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: { api: { start: "npm start" } },
           tasks: {
@@ -348,7 +348,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             api: { start: "npm run dev", ready: { output: /listening/gy } },
@@ -383,7 +383,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: { api: {} },
         });
@@ -401,7 +401,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             api: { start: "npm start", dependsOn: ["redis"] },
@@ -421,7 +421,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             a: { start: "a", dependsOn: ["b"] },
@@ -440,7 +440,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: { api: { start: "npm start" } },
           layout: {
@@ -463,7 +463,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             db: { start: "docker compose up", detached: true },
@@ -491,7 +491,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             db: { start: "start-db" },
@@ -512,7 +512,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             db: { start: "start-db" },
@@ -533,7 +533,7 @@ describe("loadConfig", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: { api: { start: "npm start" } },
           tasks: {
@@ -556,7 +556,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: { service: ["postgres", "redis"], expand: true },
@@ -593,7 +593,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: { service: ["postgres", "redis"], expand: true },
@@ -618,7 +618,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: { service: ["api"], expand: true },
@@ -640,7 +640,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: { service: ["postgres", "redis"], expand: true },
@@ -668,7 +668,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: {
@@ -710,7 +710,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: {
@@ -734,7 +734,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             api: { start: "node server.js" },
           },
@@ -752,7 +752,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             db: {
               docker: { expand: true, service: "postgres" },
@@ -776,7 +776,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             cache: {
               docker: {
@@ -800,7 +800,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             cache: {
               docker: {
@@ -824,7 +824,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             cache: {
               docker: {
@@ -848,7 +848,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             cache: {
               docker: {
@@ -871,7 +871,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             infra: {
               docker: {
@@ -899,7 +899,7 @@ describe("docker expand", () => {
       ".zaps.ts",
       `
       export function config(lib) {
-        return lib.defineProject({
+        return lib.define({
           services: {
             stripe: { start: "stripe listen", optional: () => false },
             infra: {
@@ -928,7 +928,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: {
               cache: {
                 docker: {
@@ -954,7 +954,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: { api: { start: "npm dev" } },
           });
         }
@@ -969,7 +969,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: { worker: { start: "node w.js", flags: { start: false } } },
           });
         }
@@ -984,7 +984,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: { api: { start: "npm dev", lazyPane: true } },
           });
         }
@@ -999,7 +999,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: { worker: { start: "node w.js", flags: { start: false }, lazyPane: false } },
           });
         }
@@ -1014,7 +1014,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: {
               worker: { start: "node w.js", detached: true, flags: { start: false } },
             },
@@ -1031,7 +1031,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: {
               cache: {
                 docker: {
@@ -1057,7 +1057,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: {
               api: { start: "npm dev" },
               worker: { start: "node w.js", flags: { start: false } },
@@ -1080,7 +1080,7 @@ describe("docker expand", () => {
         ".zaps.ts",
         `
         export function config(lib) {
-          return lib.defineProject({
+          return lib.define({
             services: {
               cache: {
                 docker: {

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -146,6 +146,44 @@ describe("loadConfig", () => {
     expect(result.projectDir).toBe(invokeDir);
   });
 
+  it("loads an async config function", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export async function config(z) {
+        await Promise.resolve();
+        return z.defineProject({
+          name: "async-project",
+          services: { api: { start: "npm run dev" } },
+        });
+      }
+    `,
+    );
+
+    const result = await loadConfig(configPath, tmpDir);
+    expect(result.project.name).toBe("async-project");
+  });
+
+  it("throws ConfigError when cwd function returns a non-string", async () => {
+    const configPath = writeConfig(
+      ".zaps.ts",
+      `
+      export function config(z) {
+        return z.defineProject({
+          cwd: () => undefined,
+          services: { api: { start: "npm run dev" } },
+        });
+      }
+    `,
+    );
+
+    await expect(loadConfig(configPath, tmpDir)).rejects.toMatchObject({
+      name: "ConfigError",
+      kind: "validation",
+      field: "cwd",
+    });
+  });
+
   it("resolves relative cwd function result relative to configDir", async () => {
     const subDir = path.join(tmpDir, "rel");
     fs.mkdirSync(subDir, { recursive: true });

--- a/test/config/optional-services.test.ts
+++ b/test/config/optional-services.test.ts
@@ -547,7 +547,7 @@ describe("loadConfig with optional services", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             api: { start: "node server.js" },
@@ -574,7 +574,7 @@ describe("loadConfig with optional services", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             api: { start: "node server.js" },
@@ -603,7 +603,7 @@ describe("loadConfig with optional services", () => {
       ".zaps.ts",
       `
       export function config(z) {
-        return z.defineProject({
+        return z.define({
           name: "test",
           services: {
             api: { start: "node server.js", dependsOn: ["db"] },

--- a/test/config/scaffold.test.ts
+++ b/test/config/scaffold.test.ts
@@ -17,9 +17,9 @@ afterEach(() => {
 });
 
 describe("generateTemplate", () => {
-  it("returns valid TS string with defineProject", async () => {
+  it("returns valid TS string with define", async () => {
     const result = await generateTemplate();
-    expect(result).toContain("defineProject");
+    expect(result).toContain("define");
     expect(result).toContain("import type");
   });
 
@@ -43,7 +43,7 @@ describe("scaffoldConfig", () => {
     expect(fs.existsSync(expected)).toBe(true);
 
     const content = fs.readFileSync(expected, "utf8");
-    expect(content).toContain("defineProject");
+    expect(content).toContain("define");
   });
 
   it("throws if .zaps.mts already exists", async () => {

--- a/test/config/types.test.ts
+++ b/test/config/types.test.ts
@@ -95,7 +95,7 @@ describe("config types", () => {
     const cmd = config.services.app.start;
     expect(typeof cmd).toBe("function");
     if (typeof cmd === "function") {
-      expect(cmd({ services: {}, projectDir: "/tmp" })).toBe("npm start");
+      expect(cmd({ services: {}, projectDir: "/tmp", url: () => null })).toBe("npm start");
     }
   });
 

--- a/test/daemon/handlers/session.test.ts
+++ b/test/daemon/handlers/session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ConfigError } from "../../../src/config/errors.js";
 import { sessionHandlers } from "../../../src/daemon/handlers/session.js";
 import type { IpcRequest } from "../../../src/lib/ipc/protocol.js";
 import { createMockSession, createMockStore } from "../../_helpers/mock-session.js";
@@ -90,6 +91,34 @@ describe("session handlers", () => {
       const req: IpcRequest = { id: "r-reload3", method: "session.reload", session: session.id };
       const res = await sessionHandlers["session.reload"](req, store, socket as never);
       expect(res.error).toBe("Config invalid");
+    });
+
+    it("logs the full ConfigError and keeps the session, surfacing only the message", async () => {
+      const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      const session = createMockSession();
+      const managerBefore = session.manager;
+      const paneMapBefore = session.paneMap;
+      session.reload = vi.fn().mockRejectedValue(
+        new ConfigError("cwd function returned a non-string value (undefined)", {
+          kind: "validation",
+          field: "cwd",
+          file: "/proj/.zaps.ts",
+        }),
+      );
+      const store = createMockStore([session]);
+      const socket = createMockSocket();
+      const req: IpcRequest = { id: "r-reload4", method: "session.reload", session: session.id };
+      const res = await sessionHandlers["session.reload"](req, store, socket as never);
+
+      expect(res.error).toBe("cwd function returned a non-string value (undefined)");
+      const logged = stderr.mock.calls.map((c) => String(c[0])).join("");
+      expect(logged).toContain("kind=validation");
+      expect(logged).toContain("field=cwd");
+      expect(logged).toContain("file=/proj/.zaps.ts");
+      // The running session is left fully intact (A1).
+      expect(session.manager).toBe(managerBefore);
+      expect(session.paneMap).toBe(paneMapBefore);
+      stderr.mockRestore();
     });
   });
 

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "node:events";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ConfigError } from "../../src/config/errors.js";
+
 // eslint-disable-next-line no-unsafe-type-assertion -- Test boundary
 vi.mock("node:net", () => {
   // eslint-disable-next-line no-require-imports, global-require, no-var-requires -- vi.mock factory requires synchronous require
@@ -218,6 +220,21 @@ describe("DaemonServer", () => {
     // Exactly one config load + one layout build for the shared promise.
     expect(mockLoadConfig).toHaveBeenCalledTimes(1);
     expect(mockCreateLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves no session registered when the config throws a ConfigError", async () => {
+    mockLoadConfig.mockRejectedValueOnce(
+      new ConfigError("invalid config", { kind: "validation", field: "services" }),
+    );
+    const params = {
+      configPath: "/test/.zaps.mts",
+      projectDir: "/test",
+      tmuxSession: "main",
+      originPane: "%0",
+    };
+
+    await expect(server.create(params)).rejects.toBeInstanceOf(ConfigError);
+    expect(server.sessionCount).toBe(0);
   });
 
   it("clears the in-flight entry on failure so a retry rebuilds (D3)", async () => {

--- a/test/integration/binary/jiti-reload.test.ts
+++ b/test/integration/binary/jiti-reload.test.ts
@@ -57,8 +57,8 @@ describe.skipIf(!hasBinary())("binary jiti reload", () => {
     await writeFile(
       path.join(tmpDir, ".zaps.mts"),
       `import { projectName } from "./helper.mts";
-export function config({ defineProject }) {
-  return defineProject({
+export function config({ define }) {
+  return define({
     name: projectName,
     services: { api: { start: "npm run dev" } },
   });

--- a/test/integration/binary/smoke.test.ts
+++ b/test/integration/binary/smoke.test.ts
@@ -75,8 +75,8 @@ describe.skipIf(!hasBinary() || !hasTmux() || isCI)("binary smoke", { timeout: 9
     const { port, release } = await reservePort();
 
     // Write a .zaps.mts config (discovery supports .mts/.ts only)
-    const configContent = `export function config({ defineProject }) {
-  return defineProject({
+    const configContent = `export function config({ define }) {
+  return define({
     name: "smoke-test",
     services: {
       web: {

--- a/test/integration/daemon/detached-lifecycle.test.ts
+++ b/test/integration/daemon/detached-lifecycle.test.ts
@@ -26,7 +26,7 @@ function writeDetachedConfig(dir: string, port: number): string {
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "test-detached",',
       "    services: {",
       "      worker: {",

--- a/test/integration/daemon/reload.test.ts
+++ b/test/integration/daemon/reload.test.ts
@@ -29,7 +29,7 @@ function writeConfig(
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       `    name: ${JSON.stringify(name)},`,
       "    services: {",
       ...svcEntries.map((e) => `${e},`),
@@ -185,8 +185,8 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
 
-    // Break the config: unterminated defineProject call.
-    fs.writeFileSync(configPath, "export function config(lib) { return lib.defineProject({ \n");
+    // Break the config: unterminated define call.
+    fs.writeFileSync(configPath, "export function config(lib) { return lib.define({ \n");
 
     const reloadRes = await ipcRequest(daemon.socketPath, "session.reload", undefined, 30_000, sid);
     expect(reloadRes.error).toBeDefined();
@@ -207,7 +207,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
     // Layout's FIRST leaf is a service, @tui second — the A2 trigger.
     const configText = [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "layout-reload",',
       "    services: {",
       `      web: { start: ${JSON.stringify(cmd)}, ready: { port: ${port1} }, raw: true },`,

--- a/test/integration/daemon/run-in-pane.test.ts
+++ b/test/integration/daemon/run-in-pane.test.ts
@@ -27,7 +27,7 @@ function writeRunInPaneConfig(dir: string, port: number): string {
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "test-runinpane",',
       "    services: {",
       "      web: {",

--- a/test/integration/helpers/daemon.ts
+++ b/test/integration/helpers/daemon.ts
@@ -42,7 +42,7 @@ export function writeTestConfig(dir: string, port: number): string {
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "test-daemon",',
       "    services: {",
       "      web: {",
@@ -70,7 +70,7 @@ export function writeMultiServiceConfig(dir: string, port1: number, port2: numbe
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "test-multi",',
       "    services: {",
       "      api: {",

--- a/test/integration/service-manager/raw-and-crash.test.ts
+++ b/test/integration/service-manager/raw-and-crash.test.ts
@@ -55,7 +55,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       configPath,
       [
         "export function config(lib) {",
-        "  return lib.defineProject({",
+        "  return lib.define({",
         '    name: "test-raw",',
         "    services: {",
         "      svc: {",
@@ -99,7 +99,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       configPath,
       [
         "export function config(lib) {",
-        "  return lib.defineProject({",
+        "  return lib.define({",
         '    name: "test-crash",',
         "    services: {",
         "      svc: {",
@@ -148,7 +148,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       configPath,
       [
         "export function config(lib) {",
-        "  return lib.defineProject({",
+        "  return lib.define({",
         '    name: "test-crash-no-restart",',
         "    services: {",
         "      svc: {",

--- a/test/integration/service-manager/wrapper.test.ts
+++ b/test/integration/service-manager/wrapper.test.ts
@@ -26,7 +26,7 @@ function writeWrapperConfig(dir: string, port: number): string {
     configPath,
     [
       "export function config(lib) {",
-      "  return lib.defineProject({",
+      "  return lib.define({",
       '    name: "test-wrapper",',
       "    services: {",
       "      svc: {",

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -622,7 +622,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
         tmpDir,
         `
           export function config(lib) {
-            return lib.defineProject({
+            return lib.define({
               services: {
                 workerA: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
                 workerB: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
@@ -682,7 +682,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
         tmpDir,
         `
           export function config(lib) {
-            return lib.defineProject({
+            return lib.define({
               services: {
                 worker: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
               },
@@ -714,19 +714,19 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
   });
 
   // ===========================================================================
-  // Hook-during-reload SEAL: onStop → lib.restartService re-entrance fix
+  // Hook-during-reload SEAL: onStop → lib.service.restart re-entrance fix
   // ===========================================================================
 
-  it("SEAL (hook deadlock): reload with onStop→lib.restartService(other lazy) completes under bounded timeout", async () => {
+  it("SEAL (hook deadlock): reload with onStop→lib.service.restart(other lazy) completes under bounded timeout", async () => {
     // The DEEPER deadlock class the shuttingDown guard on reflowInsert closes:
     //   `reload` holds withOpLock → `manager.stopAll()` → `stopService(svc1)`
     //   → `stopServiceInternal` → `onStop` hook (config/builder.ts:49-53
-    //   Exposes `lib.startService`/`lib.restartService` to hooks) →
+    //   Exposes `lib.service.start`/`lib.service.restart` to hooks) →
     //   `manager.restartService(svc2)` → wrapper `await deps.reflowInsert(svc2)`
     //   → `Session.reflowInsert` → `withOpLock` (not re-entrant) → chains
     //   AFTER the outer reload fn → permanent hang.
     // With the guard: reflowInsert is skipped during shutdown, the hook's
-    // `restartService` call's internal `startServiceInternal` throws
+    // `service.restart` call's internal `startServiceInternal` throws
     // `Unknown service` (pane-less + non-detached). `onStop` catches that
     // Into `lastError` (manager.ts:1029-1034) and the stop continues.
     // Reload converges; post-reload `createLayout` rebuilds the layout
@@ -739,7 +739,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
         tmpDir,
         `
           export function config(lib) {
-            return lib.defineProject({
+            return lib.define({
               services: {
                 svc1: {
                   start: ${JSON.stringify(idleCmd)},
@@ -748,7 +748,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
                     // Hook calls back into the library mid-stop. This is the
                     // Path that would have deadlocked the reload before the
                     // ShuttingDown guard on reflowInsert.
-                    return lib.restartService("svc2").catch(() => {
+                    return lib.service.restart("svc2").catch(() => {
                       // Throws \`Unknown service\` because svc2 is pane-less +
                       // The guard skips reflowInsert during shutdown. We
                       // Catch so the hook doesn't propagate a noisy error.
@@ -781,7 +781,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
       expect(live.session.paneMap.svc2).toBeUndefined();
 
       // The seal: reload must complete (its stopAll fires svc1's onStop which
-      // Calls lib.restartService("svc2") which would re-enter withOpLock).
+      // Calls lib.service.restart("svc2") which would re-enter withOpLock).
       // Without the guard, hangs forever. With it, completes sub-second.
       await raceTimeout(live.session.reload(), 10_000, "Session.reload (hook-driven re-entrance)");
     } finally {
@@ -1009,7 +1009,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
         tmpDir,
         `
           export function config(lib) {
-            return lib.defineProject({
+            return lib.define({
               services: {
                 worker: { start: ${JSON.stringify(idleCmd)}, raw: true, flags: { start: false } },
               },

--- a/test/lib/open.test.ts
+++ b/test/lib/open.test.ts
@@ -17,31 +17,19 @@ afterEach(() => {
 });
 
 describe("openInBrowser", () => {
-  it("calls open when fetch succeeds", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+  it("opens the url directly, without a reachability preflight", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     mockOpen.mockResolvedValue(undefined as never);
 
     await openInBrowser("http://localhost:3000");
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      "http://localhost:3000",
-      expect.objectContaining({ method: "HEAD" }),
-    );
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(mockOpen).toHaveBeenCalledWith("http://localhost:3000");
   });
 
-  it("silently ignores when fetch fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
-
-    await openInBrowser("http://localhost:3000");
-
-    expect(mockOpen).not.toHaveBeenCalled();
-  });
-
-  it("silently ignores when open throws", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+  it("rejects when open fails so callers can surface it", async () => {
     mockOpen.mockRejectedValue(new Error("open failed"));
 
-    await expect(openInBrowser("http://localhost:3000")).resolves.toBeUndefined();
+    await expect(openInBrowser("http://localhost:3000")).rejects.toThrow("open failed");
   });
 });

--- a/test/lib/service/env.test.ts
+++ b/test/lib/service/env.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ConfigError } from "../../../src/config/errors.js";
 import {
   buildServiceContext,
   formatEnvForShell,
@@ -95,6 +96,37 @@ describe("buildServiceContext", () => {
 
     const ctx = buildServiceContext(statuses, "/dir", { svc: { cwd: "/dir/backend" } });
     expect(ctx.services.svc.cwd).toBe("/dir/backend");
+  });
+
+  it("exposes ctx.url() that builds a URL from the detected port", () => {
+    const statuses = new Map<string, ServiceStatus>([
+      ["api", { name: "api", state: "ready", ports: [3000], retryCount: 0 }],
+      ["db", { name: "db", state: "ready", ports: [5432], retryCount: 0 }],
+    ]);
+
+    const ctx = buildServiceContext(statuses, "/dir");
+
+    expect(typeof ctx.url).toBe("function");
+    expect(ctx.url("api")).toBe("http://localhost:3000");
+    expect(ctx.url("db", { protocol: "postgres", auth: "u:p", path: "/mydb" })).toBe(
+      "postgres://u:p@localhost:5432/mydb",
+    );
+  });
+
+  it("returns null from ctx.url() when no port is detected, dropping it from env", () => {
+    const statuses = new Map<string, ServiceStatus>([
+      ["worker", { name: "worker", state: "ready", ports: [], retryCount: 0 }],
+    ]);
+
+    const ctx = buildServiceContext(statuses, "/dir");
+    expect(ctx.url("worker")).toBeNull();
+    // A ctx.url() in an env callback → null is dropped (P01-T04 null-drop).
+    expect(resolveEnv(() => ({ WORKER_URL: ctx.url("worker") }), ctx)).toEqual({});
+  });
+
+  it("throws ConfigError from ctx.url() for an unknown service", () => {
+    const ctx = buildServiceContext(new Map(), "/dir");
+    expect(() => ctx.url("ghost")).toThrow(ConfigError);
   });
 });
 

--- a/test/lib/service/env.test.ts
+++ b/test/lib/service/env.test.ts
@@ -101,7 +101,7 @@ describe("buildServiceContext", () => {
 describe("resolveEnv", () => {
   it("returns static object as-is", () => {
     const env = { FOO: "bar", BAZ: "qux" };
-    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir", url: () => null };
     expect(resolveEnv(env, ctx)).toEqual({ FOO: "bar", BAZ: "qux" });
   });
 
@@ -111,6 +111,7 @@ describe("resolveEnv", () => {
         db: { port: 5432, ports: [5432], cwd: undefined },
       },
       projectDir: "/dir",
+      url: () => null,
     };
     const result = resolveEnv(
       (c: ServiceContext) => ({ DB_PORT: String(c.services.db?.port ?? "") }),
@@ -120,17 +121,17 @@ describe("resolveEnv", () => {
   });
 
   it("returns empty object when envConfig is undefined", () => {
-    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir", url: () => null };
     expect(resolveEnv(undefined, ctx)).toEqual({});
   });
 
   it("drops null/undefined values from a static object", () => {
-    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir", url: () => null };
     expect(resolveEnv({ A: "x", B: null, C: undefined }, ctx)).toEqual({ A: "x" });
   });
 
   it("drops null values returned by a function", () => {
-    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir", url: () => null };
     expect(resolveEnv(() => ({ A: "x", B: null }), ctx)).toEqual({ A: "x" });
   });
 });

--- a/test/lib/service/env.test.ts
+++ b/test/lib/service/env.test.ts
@@ -123,6 +123,16 @@ describe("resolveEnv", () => {
     const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
     expect(resolveEnv(undefined, ctx)).toEqual({});
   });
+
+  it("drops null/undefined values from a static object", () => {
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    expect(resolveEnv({ A: "x", B: null, C: undefined }, ctx)).toEqual({ A: "x" });
+  });
+
+  it("drops null values returned by a function", () => {
+    const ctx: ServiceContext = { services: {}, projectDir: "/dir" };
+    expect(resolveEnv(() => ({ A: "x", B: null }), ctx)).toEqual({ A: "x" });
+  });
 });
 
 describe("shellEscape", () => {

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -3464,10 +3464,10 @@ describe("lazy-pane lifecycle", () => {
     // Symmetric to the stopService shuttingDown guard. The deadlock the guard
     // Closes:
     //   `reload` holds withOpLock → `manager.stopAll()` → `stopService(svc1)`
-    //   → `onStop` hook → `lib.startService(svc2)` → wrapper-level
+    //   → `onStop` hook → `lib.service.start(svc2)` → wrapper-level
     //   `deps.reflowInsert(svc2)` → `Session.reflowInsert` → withOpLock
     //   (not re-entrant) → chains AFTER outer reload fn → permanent hang.
-    // `lib.startService`/`restartService` are exposed to hooks
+    // `lib.service.start`/`service.restart` are exposed to hooks
     // (config/builder.ts:49-53), so this is a real reachable footgun. The
     // Guard short-circuits reflowInsert when `shuttingDown` is true —
     // RunStopAll sets it BEFORE iterating, so every hook-driven start during
@@ -3489,7 +3489,7 @@ describe("lazy-pane lifecycle", () => {
   });
 
   it("restartService skips reflowInsert when shuttingDown (re-entrance guard)", async () => {
-    // Companion to the startService guard test. lib.restartService is also
+    // Companion to the startService guard test. lib.service.restart is also
     // Hook-reachable (config/builder.ts:49-53), so the wrapper carries the
     // Same shuttingDown short-circuit.
     const config = lazyConfig({ worker: { start: "node w.js" } }, ["worker"]);
@@ -3551,7 +3551,7 @@ describe("lazy-pane lifecycle", () => {
   it("restartService never calls the reflow hooks (pane kept by design)", async () => {
     // RestartServiceInternal re-sends the start command to the existing pane;
     // It never touches reflowInsert or reflowRemove. The public wrapper
-    // `restartService` (manager.ts:1070) only acquires `withServiceLock`,
+    // `service.restart` (manager.ts:1070) only acquires `withServiceLock`,
     // Bypassing the lazy-lifecycle wiring on the start/stop wrappers. This
     // Test pins that bypass by attempting a restart and asserting the hooks
     // Stayed dormant — we don't drive it to ready (that path is exercised

--- a/test/lib/task/runner.test.ts
+++ b/test/lib/task/runner.test.ts
@@ -289,6 +289,9 @@ describe("runTaskWithDeps", () => {
       ctx.stdout.write("output line\n");
       expect(ctx.projectDir).toBe("/test");
       expect(ctx.services).toBeDefined();
+      // Mirrored onto TaskRunContext from the service context (P02-T06).
+      expect(typeof ctx.url).toBe("function");
+      expect(ctx.url).toBe(ctx.services.url);
     });
 
     const onLine = vi.fn();


### PR DESCRIPTION
## Summary

Redesigns the config-author-facing **Library API** into a namespaced, daemon-safe, "bullet proof" shape ahead of going live, plus config-eval hardening. **Breaking change — no backwards-compat layer; all configs must migrate.**

Three phases, each verified green at its boundary:

### Phase 1 — Config-Eval Hardening (additive, non-breaking)
- New typed `ConfigError` (plain ANSI-free message + `kind` + attribution `file`/`service`/`task`/`field`) — config-eval failures **throw, never `process.exit`**, so they can't kill the long-lived daemon on reload.
- `loadConfig` now **awaits** async config and bounds eval with a **30s timeout** (async hangs only — documented limitation).
- Non-string `cwd` guard; `env` values may be `null`/`undefined` and are **dropped** (`EnvConfig` widened + schema + `resolveEnv`).
- `define()` Zod failures → `ConfigError(kind:"validation")`; centralized CLI `✖` rendering (chalk, in-process only); daemon logs the full `ConfigError` before relaying `.message` over IPC.

### Phase 2 — Namespaced Library API, Helpers & Notices (breaking)
- Library is now `{ define, find, cli, task, service, browser, node }`.
- `find.up(file, opts?)` — upward cwd resolver, throws `ConfigError` on not-found (never null).
- `cli.fatal` (throws) / `cli.warn|info|success` (route through an injected notice sink).
- `ctx.url(service, opts?) → string | null` — wired via the single `buildServiceContext` (+ `TaskRunContext` symmetry); total URL builder (IPv6 bracketing, path-slash normalization, unknown→throw, no-port→null).
- New `config.notice` IPC event → daemon reload broadcast → daemon-client → TUI toast (`warn`→`info`); create-path falls back to stderr.
- `.zaps.mts`, scaffold template, and all tests migrated.

### Phase 3 — Docs, Skills & Scaffold
- README (Library reference, error model, `ctx.url`, async config, migration table), `zaps-config` skill, scaffold template.

## Migration (old → new)
`defineProject`→`define` · `runTask`→`task.run` · `startService`→`service.start` · `stopService`→`service.stop` · `restartService`→`service.restart` · `isServiceRunning`→`service.isRunning` · `openInBrowser`→`browser.open` · custom `exit()`→`cli.fatal()` · manual URL building→`ctx.url()`.

## Intentional spec deviations (called out for reviewers)
1. **`browser.open` HEAD-preflight removed** — a still-booting URL now opens (browser retries); failures emit a `warn` notice instead of being silently swallowed (Q-R4a).
2. **`FindUpOptions.stopAt` typed `string`** (not `string | "config"`) — the literal is redundant under oxlint `no-redundant-type-constituents`; the `"config"` sentinel still works at runtime and is documented/tested.
3. **30s async-eval timeout** — config-eval uses 30s (the optional-service probe guard is 5s).

## Verification (`pnpm check`, fully green)
- `typecheck` clean · `lint` clean (oxfmt + oxlint type-aware, deny-warnings)
- **1874 tests pass** — coverage **Stmts 91.93% / Branches 86.68% / Funcs 89.33% / Lines 92.08%** (>85% gate, deterministic across 8 full runs)
- `build` + `build:native` compile

Integration suite (`pnpm test:integration`, needs tmux) not run in CI — the reload-keeps-session path is covered at unit level.
