### PR TITLE
docs: audit and correct all docs + skills against current implementation

### DIFF
--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zaps-config
-description: Use when creating or editing ZAPS config files (.zaps.mts/.zaps.ts and local./.local. variants) or the exported config() Library function. Covers service definitions (start/run/docker), ready detection, docker-compose integration, tasks, layout/panes, hooks, dependencies, environment, and the ui block. Trigger whenever the user adds or changes a service, task, ready check, dependency, or layout in a ZAPS project, scaffolds via `zaps init`, or asks how a ZAPS config option works — even if they don't name the file. For running or inspecting services use the zaps-usage skill instead.
+description: Use when creating or editing ZAPS config files (.zaps.mts/.zaps.ts and local./.local. variants) or the exported config() Library function. Covers service definitions (start/run/docker), making a service optional (binary/predicate checks), ready detection, docker-compose integration, tasks, layout/panes, hooks, dependencies, restart behavior (restartWith), environment, and the ui block. Trigger whenever the user adds, changes, or marks optional a service, task, ready check, dependency, or layout in a ZAPS project, scaffolds via `zaps init`, or asks how a ZAPS config option works — even if they don't name the file and even if the request sounds like an action ("make X optional", "add a redis service"). For running or inspecting services use the zaps-usage skill instead.
 ---
 
 # ZAPS Configuration Skill

--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -164,6 +164,7 @@ services: {
 services: {
   "custom-tool": {
     optional: async () => {
+      const { execSync } = await import("node:child_process");
       try { execSync("docker image inspect my-tool"); return true; }
       catch { return false; }
     },

--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Use when working on ZAPS config files (.zaps.mts/.zaps.ts/local.zaps.ts) - provides service definitions, ready detection, docker integration, tasks, layout, hooks, dependencies, and environment configuration.
+name: zaps-config
+description: Use when creating or editing ZAPS config files (.zaps.mts/.zaps.ts and local./.local. variants) or the exported config() Library function. Covers service definitions (start/run/docker), ready detection, docker-compose integration, tasks, layout/panes, hooks, dependencies, environment, and the ui block. Trigger whenever the user adds or changes a service, task, ready check, dependency, or layout in a ZAPS project, scaffolds via `zaps init`, or asks how a ZAPS config option works — even if they don't name the file. For running or inspecting services use the zaps-usage skill instead.
 ---
 
 # ZAPS Configuration Skill

--- a/.claude/skills/zaps-config/references/01-getting-started.md
+++ b/.claude/skills/zaps-config/references/01-getting-started.md
@@ -66,7 +66,8 @@ export async function config({ define, node }: Library) {
 | `services` | `Record<string, ServiceConfig>`         | **Yes**  | Service definitions (at least one required)                              |
 | `tasks`    | `Record<string, TaskConfig>`            | No       | Runnable tasks                                                           |
 | `layout`   | `LayoutNode`                            | No       | Custom tmux pane layout                                                  |
-| `hooks`    | `HooksConfig`                           | No       | Lifecycle hooks (`onStart`, `onStop`, `onServiceStart`, `onServiceStop`) |
+| `hooks`    | `HooksConfig`                           | No       | Project lifecycle hooks: `onBeforeStart`, `onStart`, `onStop`            |
+| `ui`       | `UiConfig`                              | No       | TUI presentation (icons, notifications, task mode, …) — see `10-ui.md`  |
 
 ## CwdContext and Project Directory Resolution
 

--- a/.claude/skills/zaps-config/references/01-getting-started.md
+++ b/.claude/skills/zaps-config/references/01-getting-started.md
@@ -59,15 +59,15 @@ export async function config({ define, node }: Library) {
 
 ## ProjectConfig Top-Level Fields
 
-| Field      | Type                                    | Required | Description                                                              |
-| ---------- | --------------------------------------- | -------- | ------------------------------------------------------------------------ |
-| `name`     | `string`                                | No       | Project name. Defaults to `basename(projectDir)`                         |
-| `cwd`      | `string \| (ctx: CwdContext) => string` | No       | Override working directory for services                                  |
-| `services` | `Record<string, ServiceConfig>`         | **Yes**  | Service definitions (at least one required)                              |
-| `tasks`    | `Record<string, TaskConfig>`            | No       | Runnable tasks                                                           |
-| `layout`   | `LayoutNode`                            | No       | Custom tmux pane layout                                                  |
-| `hooks`    | `HooksConfig`                           | No       | Project lifecycle hooks: `onBeforeStart`, `onStart`, `onStop`            |
-| `ui`       | `UiConfig`                              | No       | TUI presentation (icons, notifications, task mode, …) — see `10-ui.md`  |
+| Field      | Type                                    | Required | Description                                                            |
+| ---------- | --------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `name`     | `string`                                | No       | Project name. Defaults to `basename(projectDir)`                       |
+| `cwd`      | `string \| (ctx: CwdContext) => string` | No       | Override working directory for services                                |
+| `services` | `Record<string, ServiceConfig>`         | **Yes**  | Service definitions (at least one required)                            |
+| `tasks`    | `Record<string, TaskConfig>`            | No       | Runnable tasks                                                         |
+| `layout`   | `LayoutNode`                            | No       | Custom tmux pane layout                                                |
+| `hooks`    | `HooksConfig`                           | No       | Project lifecycle hooks: `onBeforeStart`, `onStart`, `onStop`          |
+| `ui`       | `UiConfig`                              | No       | TUI presentation (icons, notifications, task mode, …) — see `10-ui.md` |
 
 ## CwdContext and Project Directory Resolution
 

--- a/.claude/skills/zaps-config/references/02-services.md
+++ b/.claude/skills/zaps-config/references/02-services.md
@@ -2,28 +2,28 @@
 
 ## Options
 
-| Field       | Type                                      | Default     | Description                                                                                |
-| ----------- | ----------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
-| `start`     | `string \| () => string`                  | —           | Long-running process command (server)                                                      |
-| `run`       | `string \| () => string`                  | —           | One-shot command                                                                           |
-| `stop`      | `string \| () => string`                  | —           | Custom stop command                                                                        |
-| `cwd`       | `string`                                  | —           | Working directory for the service                                                          |
-| `detached`  | `boolean`                                 | `false`     | Run pane-less (outside the tmux layout)                                                    |
-| `lazyPane`  | `boolean`                                 | _auto_      | Pane created on start, dropped on explicit stop (default `true` when `flags.start: false`) |
-| `docker`    | `DockerConfig`                            | —           | Docker Compose config (see docker reference)                                               |
-| `ready`     | `ReadyConfig`                             | —           | Ready detection (see ready reference)                                                      |
-| `dependsOn` | `string[]`                                | —           | Services that must be ready first                                                          |
-| `restartWith` | `string[]`                              | —           | Restart this service when a listed dependency restarts (must be a subset of `dependsOn`)    |
-| `env`       | `EnvConfig`                               | —           | Environment variables                                                                      |
-| `flags`     | `ServiceFlags`                            | —           | `{ start?: boolean, open?: boolean }`                                                      |
-| `url`       | `string \| false \| (ctx) => string`      | auto-detect | URL for the service                                                                        |
-| `raw`       | `boolean`                                 | `false`     | Bypass wrapper — show env vars inline in pane                                              |
-| `restart`   | `{ maxRetries?, backoff? }`               | —           | Restart policy with exponential backoff                                                    |
-| `onBeforeStart` | `() => void \| Promise<void>`         | —           | Hook: before the service command is sent                                                   |
-| `onReady`   | `() => void \| Promise<void>`             | —           | Hook: service reached ready state                                                          |
-| `onStop`    | `() => void \| Promise<void>`             | —           | Hook: service stopped                                                                      |
-| `onOutput`  | `(line: string) => void \| Promise<void>` | —           | Hook: new output line from tmux pane                                                       |
-| `optional`  | `boolean \| (ctx) => boolean \| Promise<boolean>` | —   | Mark service as optional (skip if unavailable); the function form gets `ctx.hasBinary(name)` |
+| Field           | Type                                              | Default     | Description                                                                                  |
+| --------------- | ------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `start`         | `string \| () => string`                          | —           | Long-running process command (server)                                                        |
+| `run`           | `string \| () => string`                          | —           | One-shot command                                                                             |
+| `stop`          | `string \| () => string`                          | —           | Custom stop command                                                                          |
+| `cwd`           | `string`                                          | —           | Working directory for the service                                                            |
+| `detached`      | `boolean`                                         | `false`     | Run pane-less (outside the tmux layout)                                                      |
+| `lazyPane`      | `boolean`                                         | _auto_      | Pane created on start, dropped on explicit stop (default `true` when `flags.start: false`)   |
+| `docker`        | `DockerConfig`                                    | —           | Docker Compose config (see docker reference)                                                 |
+| `ready`         | `ReadyConfig`                                     | —           | Ready detection (see ready reference)                                                        |
+| `dependsOn`     | `string[]`                                        | —           | Services that must be ready first                                                            |
+| `restartWith`   | `string[]`                                        | —           | Restart this service when a listed dependency restarts (must be a subset of `dependsOn`)     |
+| `env`           | `EnvConfig`                                       | —           | Environment variables                                                                        |
+| `flags`         | `ServiceFlags`                                    | —           | `{ start?: boolean, open?: boolean }`                                                        |
+| `url`           | `string \| false \| (ctx) => string`              | auto-detect | URL for the service                                                                          |
+| `raw`           | `boolean`                                         | `false`     | Bypass wrapper — show env vars inline in pane                                                |
+| `restart`       | `{ maxRetries?, backoff? }`                       | —           | Restart policy with exponential backoff                                                      |
+| `onBeforeStart` | `() => void \| Promise<void>`                     | —           | Hook: before the service command is sent                                                     |
+| `onReady`       | `() => void \| Promise<void>`                     | —           | Hook: service reached ready state                                                            |
+| `onStop`        | `() => void \| Promise<void>`                     | —           | Hook: service stopped                                                                        |
+| `onOutput`      | `(line: string) => void \| Promise<void>`         | —           | Hook: new output line from tmux pane                                                         |
+| `optional`      | `boolean \| (ctx) => boolean \| Promise<boolean>` | —           | Mark service as optional (skip if unavailable); the function form gets `ctx.hasBinary(name)` |
 
 **Required**: Every service must have at least one of `start`, `run`, or `docker`.
 

--- a/.claude/skills/zaps-config/references/02-services.md
+++ b/.claude/skills/zaps-config/references/02-services.md
@@ -13,15 +13,17 @@
 | `docker`    | `DockerConfig`                            | —           | Docker Compose config (see docker reference)                                               |
 | `ready`     | `ReadyConfig`                             | —           | Ready detection (see ready reference)                                                      |
 | `dependsOn` | `string[]`                                | —           | Services that must be ready first                                                          |
+| `restartWith` | `string[]`                              | —           | Restart this service when a listed dependency restarts (must be a subset of `dependsOn`)    |
 | `env`       | `EnvConfig`                               | —           | Environment variables                                                                      |
 | `flags`     | `ServiceFlags`                            | —           | `{ start?: boolean, open?: boolean }`                                                      |
 | `url`       | `string \| false \| (ctx) => string`      | auto-detect | URL for the service                                                                        |
 | `raw`       | `boolean`                                 | `false`     | Bypass wrapper — show env vars inline in pane                                              |
 | `restart`   | `{ maxRetries?, backoff? }`               | —           | Restart policy with exponential backoff                                                    |
+| `onBeforeStart` | `() => void \| Promise<void>`         | —           | Hook: before the service command is sent                                                   |
 | `onReady`   | `() => void \| Promise<void>`             | —           | Hook: service reached ready state                                                          |
 | `onStop`    | `() => void \| Promise<void>`             | —           | Hook: service stopped                                                                      |
 | `onOutput`  | `(line: string) => void \| Promise<void>` | —           | Hook: new output line from tmux pane                                                       |
-| `optional`  | `boolean \| () => Promise<boolean>`       | —           | Mark service as optional (skip if unavailable)                                             |
+| `optional`  | `boolean \| (ctx) => boolean \| Promise<boolean>` | —   | Mark service as optional (skip if unavailable); the function form gets `ctx.hasBinary(name)` |
 
 **Required**: Every service must have at least one of `start`, `run`, or `docker`.
 
@@ -147,8 +149,9 @@ url: "http://localhost:3000";
 // Disabled
 url: false;
 
-// Dynamic
-url: (ctx) => `http://localhost:${ctx.port}/admin`;
+// Dynamic — read the port from the service's own entry on the context
+// (there is no top-level `ctx.port`; use `ctx.services.<name>` or `ctx.url()`)
+url: (ctx) => `http://localhost:${ctx.services.admin.port}/admin`;
 ```
 
 ## Restart Policy
@@ -216,7 +219,7 @@ services: {
 services: {
   "custom-tool": {
     optional: async () => {
-      const { execSync } = await import("child_process");
+      const { execSync } = await import("node:child_process");
       try { execSync("docker image inspect my-tool"); return true; }
       catch { return false; }
     },

--- a/.claude/skills/zaps-config/references/02-services.md
+++ b/.claude/skills/zaps-config/references/02-services.md
@@ -107,8 +107,8 @@ services: {
     lazyPane: true,
   },
 
-  // Explicit opt-out: keep the legacy empty-reserved-pane-at-boot behavior.
-  legacyConsole: {
+  // Opt out of lazy panes: reserve an empty pane at boot even when not autostarted.
+  console: {
     start: "tail -f /var/log/app.log",
     flags: { start: false },
     lazyPane: false,

--- a/.claude/skills/zaps-config/references/04-docker.md
+++ b/.claude/skills/zaps-config/references/04-docker.md
@@ -38,6 +38,8 @@ Every compose invocation (`up`/`ps`/`start`/`stop`/`restart`/`config`) is pinned
 
 Switching to a pinned project recreates the containers once; if containers exist under the old unpinned name, ZAPS prints a one-time cleanup warning.
 
+**Tasks don't inherit the pin.** The `-p` project is applied only to the compose commands ZAPS runs for `docker` **services**. A task that shells out to bare `docker compose …` (in `commands` or `run`) uses Compose's own default project, so it won't act on the containers ZAPS started. Pass it explicitly — `docker compose -p "$ZAPS_COMPOSE_PROJECT" …` (set `ZAPS_COMPOSE_PROJECT` where the daemon spawns) — or prefer a logical operation (e.g. `prisma migrate reset`) over `docker compose down -v` in tasks.
+
 ## Auto-Command
 
 If a service has `docker` config but **no `start` or `run`**, ZAPS auto-generates the command from `buildDockerCommand()`. No manual command needed:

--- a/.claude/skills/zaps-config/references/06-dependencies.md
+++ b/.claude/skills/zaps-config/references/06-dependencies.md
@@ -59,16 +59,39 @@ Shutdown also uses `Promise.all()` per level for parallel stopping within a leve
 
 ## flags.start and the Dependency Graph
 
-`flags: { start: false }` excludes a service from **autostart** but does **not** remove it from the dependency graph. If another service depends on it, that dependent will fail to start (dependency not ready).
+`flags: { start: false }` excludes a service from **autostart** but does **not** remove it from the dependency graph. Two paths behave differently:
+
+- **During `zaps up` (autostart):** a `dependsOn` pointing at a non-autostart service is **treated as satisfied** — the dependent **still autostarts**, and ZAPS prints a load-time warning that the dep won't be started for you. The non-autostart service stays stopped until you start it.
+- **Explicit start** (`zaps start <dependent>` / `service.start()`): the real dependency state is enforced — the dependent waits for its deps to be `ready` and fails if they aren't.
 
 ```ts
 services: {
   db: { start: "...", ready: { port: 5432 }, flags: { start: false } },
   api: { start: "...", dependsOn: ["db"] },
 }
-// api won't autostart because db is excluded from autostart and won't be ready
-// Start db manually via TUI first, then api can start
+// `zaps up`: api autostarts; db is treated as satisfied (with a warning) and stays stopped.
+//   Warning: service 'api' depends on non-autostart service 'db'; 'db' is treated as
+//   satisfied during 'zaps up' (start it explicitly with 'zaps start db').
+// `zaps start api` later: enforces deps — db must be ready first.
 ```
+
+## restartWith — Cascade Restart
+
+`restartWith` ties a service to the restart of one of its **dependencies**: when a service you list here restarts (manually or after a crash), **this** service restarts too. It's the "follow the upstream" rule — e.g. restart `api` whenever `db` is recreated so it reconnects. Every `restartWith` entry **must also appear in `dependsOn`** (it is validated as a subset) — you can only follow something you already depend on.
+
+```ts
+services: {
+  db: { start: "...", ready: { port: 5432 } },
+  api: {
+    start: "...",
+    dependsOn: ["db"],
+    restartWith: ["db"], // when db restarts, api restarts too; "db" must be in dependsOn
+  },
+}
+```
+
+- The cascade is transitive — if `api` has `restartWith: ["db"]` and `web` has `restartWith: ["api"]`, restarting `db` cascades `db → api → web`.
+- A group name (from a docker `expand`) in `restartWith` expands to all of its children.
 
 ## Validation
 
@@ -108,6 +131,6 @@ Task dependency execution differs from services:
 
 - `dependsOn` entries must reference valid keys of the same type (services reference services, tasks reference tasks)
 - Circular deps throw with the full cycle path for debugging
-- `flags: { start: false }` only affects autostart — the service remains in the graph and must be manually started for dependents to proceed
+- `flags: { start: false }` only affects autostart — the service stays in the graph. On `zaps up`, dependents treat it as satisfied and start anyway (with a warning); an explicit `zaps start <dependent>` enforces the real dependency state
 - A dependency must be in `"ready"` state, not just `"starting"` — configure `ready` detection on deps
 - Shutdown uses `reverseTopoSort` on **all** services (not just autostart-filtered ones)

--- a/.claude/skills/zaps-config/references/08-layout.md
+++ b/.claude/skills/zaps-config/references/08-layout.md
@@ -63,7 +63,7 @@ Defaults to `@tui` if no pane has `focus: true`.
 When no `layout` is specified, ZAPS auto-generates:
 
 - `@tui` gets the main pane
-- Each non-detached service gets its own **background tmux window** (not a split in the `@tui` view)
+- Each non-detached service gets its own **vertical split pane in the `@tui` window** (split off the `@tui` pane via `split-window -v`)
 - Focus defaults to `@tui`
 
 ## Example — Nested Layout

--- a/.claude/skills/zaps-config/references/08-layout.md
+++ b/.claude/skills/zaps-config/references/08-layout.md
@@ -56,14 +56,14 @@ Defaults to `@tui` if no pane has `focus: true`.
 ## Validation Rules
 
 1. Every pane name must reference an existing service or `@tui`
-2. **Detached services must NOT appear in layout** — throws: `"Detached service '<name>' must not appear in layout"`
+2. **Detached services must NOT appear in layout** — throws: `"Detached service '<name>' cannot appear in the layout — detached services run pane-less."`
 
 ## Default Layout
 
 When no `layout` is specified, ZAPS auto-generates:
 
-- `@tui` gets the initial pane
-- Each non-detached service gets a vertical split pane
+- `@tui` gets the main pane
+- Each non-detached service gets its own **background tmux window** (not a split in the `@tui` view)
 - Focus defaults to `@tui`
 
 ## Example — Nested Layout

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zaps-usage
-description: Use when running or inspecting local dev services through the ZAPS CLI — starting/stopping/restarting services, attaching the TUI (`zaps up`/`attach`), running tasks, streaming logs, checking service state/ports, reloading config, or managing the daemon. Trigger whenever the user wants to bring up, tear down, restart, or check the status of their local dev environment with zaps, even phrased casually (e.g. "start my services", "why is the api down", "tail the web logs"). Not for authoring config files — use the zaps-config skill for that.
+description: Use when running or inspecting local dev services through the ZAPS CLI — starting/stopping/restarting services, attaching the TUI (`zaps up`/`attach`), running tasks, streaming logs, checking which services are running and on what ports, reloading config, or managing the daemon. Trigger whenever the user wants to bring up, tear down, restart, or check the status of their local dev environment with zaps — including single-command asks like "restart the api", "what ports are my services on", "list running services", or "tail the web logs" — so the exact zaps command, flags, and session targeting are correct. Not for authoring config files — use the zaps-config skill for that.
 ---
 
 # ZAPS Usage Skill

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Use when interacting with local dev sessions/services - start/stop/inspect services, run tasks, view logs via CLI
+name: zaps-usage
+description: Use when running or inspecting local dev services through the ZAPS CLI — starting/stopping/restarting services, attaching the TUI (`zaps up`/`attach`), running tasks, streaming logs, checking service state/ports, reloading config, or managing the daemon. Trigger whenever the user wants to bring up, tear down, restart, or check the status of their local dev environment with zaps, even phrased casually (e.g. "start my services", "why is the api down", "tail the web logs"). Not for authoring config files — use the zaps-config skill for that.
 ---
 
 # ZAPS Usage Skill

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -125,8 +125,8 @@ zaps --help # see all functions
   declared layout position; a `zaps stop <svc>` drops the pane and re-expands
   survivors. Crash + restart keep the pane. `zaps logs <svc>` returns `[]`
   before the first start, streams live while the service is running, and
-  returns the retained history after stop. To keep the legacy
-  idle-empty-reserved-pane behavior, set `lazyPane: false` on the service.
+  returns the retained history after stop. To reserve an empty pane at boot
+  instead, set `lazyPane: false` on the service.
 - **Config reload** is validate-then-swap: an invalid edit is reported and the running
   session keeps the old config (it is never torn down). In the TUI, a changed config
   shows a `config changed — press c to reload` header hint; press `c` (when idle) to apply.

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -14,7 +14,10 @@ When this skill loads, immediately run `zaps prime-agent` to get the current pro
 
 ## Output
 
-All commands automatically output TOON when `CLAUDECODE` is set.
+Query/service commands print a human table by default. For machine-readable output pass
+`--json` (pretty JSON) or `--toon` ([TOON](https://github.com/toon-format/toon)), or set
+`ZAPS_FORMAT=json|toon` to make it the default for every command. Coding agents are
+auto-detected (`CLAUDECODE` / `CURSOR_TRACE_DIR`) and default to **TOON** with no flag.
 
 ## Usage
 
@@ -47,12 +50,21 @@ zaps events       # stream daemon events (--filter <type>)
 ### Session & Daemon
 
 ```
-zaps up           # attach if running, else create + start + attach TUI
-zaps up -d        # create + start services detached (no TUI); attach later with `zaps attach`
-zaps down         # stop all services and destroy the session
-zaps daemon stop  # full cleanup: stops every service in every session, then shuts the daemon down
-                  #   prints `Stopped <n> session(s), <m> service(s).`
+zaps up             # attach if running, else create + start + attach TUI
+zaps up -d          # create + start services detached (no TUI); attach later with `zaps attach`
+zaps attach         # attach the TUI to a running session (use `-s <id|name>` to pick one)
+zaps reload         # reload config for the running session (CLI form of the dashboard `c`)
+zaps down           # stop all services and destroy the session
+zaps daemon start   # start the background daemon (usually implicit via `zaps up`)
+zaps daemon status  # daemon PID + session list (--json / --toon)
+zaps daemon ping    # check the daemon is responsive
+zaps daemon stop    # full cleanup: stops every service in every session, then shuts the daemon down
+                    #   prints `Stopped <n> session(s), <m> service(s).`
 ```
+
+Target a specific session with the global `-s, --session <id|name>` flag (before the
+command): `zaps -s my-app down`, `zaps -s my-app restart api`. Without it, ZAPS resolves
+the session for the current directory.
 
 ### TUI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ pnpm build:native             # bun native binary → dist/zaps
 
 - Path alias: `#src/*` → `./src/*`
 - IPC: JSON over Unix sockets (ndjson for log streaming)
-- JSX runtime: `react-jsx` (React 19 + Ink 6)
-- Config discovery walks up from CWD for `.zaps.mts`/`.zaps.ts`/`local.zaps.ts` variants
+- JSX runtime: `react-jsx` (React 19 + Ink 7)
+- Config discovery walks up from CWD, first match wins: `.local.zaps.mts`, `local.zaps.mts`, `.local.zaps.ts`, `local.zaps.ts`, `.zaps.mts`, `.zaps.ts`
 
 ## Skills & README
 
@@ -48,9 +48,9 @@ pnpm build:native             # bun native binary → dist/zaps
 
 ## Tech
 
-- TypeScript (ES2023, strict, ESM)
-- React 19 + Ink 6 (TUI)
+- TypeScript 6 (ES2023, strict, ESM)
+- React 19 + Ink 7 (TUI)
 - Zod 4 (config validation)
-- Commander 14 (CLI)
+- Commander 15 (CLI)
 - Vitest 4 (testing), oxlint/oxfmt (lint/format)
 - esbuild (bundle), bun (native binary)

--- a/README.md
+++ b/README.md
@@ -77,12 +77,18 @@ zaps               # Launch
 
 ### Config & Setup
 
-| Command                           | Description                                            |
-| --------------------------------- | ------------------------------------------------------ |
-| `zaps config`                     | Validate and print resolved config. `--json`, `--path` |
-| `zaps init`                       | Scaffold a starter `.zaps.mts` config                  |
-| `zaps attach [session]`           | Attach TUI to a running session                        |
-| `zaps daemon start\|stop\|status` | Daemon management                                      |
+| Command                                | Description                                                            |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `zaps config`                          | Validate and print resolved config. `--json`, `--toon`, `--path`      |
+| `zaps reload`                          | Reload config for the running session (CLI form of the dashboard `c`) |
+| `zaps init`                            | Scaffold a starter `.zaps.mts` config                                 |
+| `zaps attach`                          | Attach TUI to a running session (use `-s` to choose one)              |
+| `zaps daemon start\|stop\|status\|ping` | Daemon management (`ping` checks the daemon is responsive)             |
+
+### Selecting a session & output format
+
+- **`-s, --session <id\|name>`** is a global flag (place it before the command): `zaps -s my-app attach`, `zaps -s my-app down`. It matches by exact id, exact name, then id/name prefix. When omitted, ZAPS resolves the session for the current directory; if several match it lists them and asks you to disambiguate.
+- **Output format** — query/service commands print a human table by default. Pass `--json` (pretty JSON) or `--toon` ([TOON](https://github.com/toon-format/toon)) for machine output, or set `ZAPS_FORMAT=json|toon` to make it the default. Coding agents (detected via `CLAUDECODE` / `CURSOR_TRACE_DIR`) default to TOON automatically.
 
 ## Configuration
 
@@ -439,8 +445,8 @@ rename the calls — e.g. `({ defineProject }) => defineProject({…})` becomes
 
 | Option          | Type                                        | Default | Description                                                                                   |
 | --------------- | ------------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
-| `start`         | `string \| () => string`                    | —       | Command to start the service                                                                  |
-| `run`           | `string \| () => string`                    | —       | Alias for `start`                                                                             |
+| `start`         | `string \| () => string`                    | —       | Command to start the service (long-running process)                                           |
+| `run`           | `string \| () => string`                    | —       | Interchangeable with `start` — either satisfies the "needs a command" rule (`start` wins if both are set) |
 | `stop`          | `string \| () => string`                    | —       | Custom stop command (default: Ctrl-C)                                                         |
 | `docker`        | `DockerConfig`                              | —       | Docker Compose service config                                                                 |
 | `ready`         | `ReadyConfig`                               | —       | How to detect the service is ready                                                            |
@@ -673,6 +679,13 @@ can't be mistaken for each other. The project name is resolved by precedence:
 > containers once. If containers already exist under the old (unpinned) name,
 > ZAPS prints a one-time warning suggesting `docker compose -p <old> down`.
 
+> **Tasks don't inherit the pin.** Pinning is applied only to the compose commands
+> ZAPS runs for `docker` **services**. A task that shells out to bare `docker compose …`
+> runs under Compose's own default project name, so it won't see the containers ZAPS
+> started. Pass the project explicitly — `docker compose -p "$ZAPS_COMPOSE_PROJECT" …`
+> (set `ZAPS_COMPOSE_PROJECT` where the daemon spawns) — or operate logically (e.g.
+> `prisma migrate reset` instead of `docker compose down -v`).
+
 ### Expanded Docker Services
 
 When you have multiple Docker Compose services that can share a single tmux pane, use `expand: true` to split them into individually addressable services:
@@ -759,7 +772,9 @@ restart: {
 }
 ```
 
-Backoff doubles per retry: 2s → 4s → 8s → 16s → 32s. Crash monitoring polls every 2s.
+Backoff doubles per retry: 2s → 4s → 8s → 16s → 32s. Crash monitoring polls the
+pane every 2s for `raw`-mode services and every 10s for wrapper-mode ones (where the
+wrapper's exit notification is the primary signal, so the poll is just a backstop).
 
 ### Dynamic Environment
 
@@ -1073,14 +1088,16 @@ ui: {
 
 ## Service States
 
+Valid transitions (the manager rejects any other move):
+
 ```
-stopped ──> starting ──> ready ──> stopping ──> stopped
-               │            │
-               v            v
-             error      restarting ──> starting
-               │
-               v
-            starting (retry)
+stopped     → starting
+starting    → ready | error | stopping
+ready       → stopping | restarting | error
+stopping    → stopped
+restarting  → starting | stopping | error
+error       → starting           (retry / manual start)
+unavailable → —                  (terminal: optional service whose binary/check failed)
 ```
 
 | State                                  | Indicator      |

--- a/README.md
+++ b/README.md
@@ -964,10 +964,10 @@ layout: {
 - `direction`: `"rows"` (vertical split) or `"columns"` (horizontal split)
 - `size`: percentage of parent (defaults to equal split)
 - `focus`: set to `true` on one leaf pane to auto-focus it after layout creation (at most one)
-- Services not in the layout get their own background tmux window
+- Services not in the layout get their own vertical split pane in the `@tui` window
 - Detached services must **not** appear in the layout
 
-If no layout is specified, `@tui` gets the main pane and each service gets a background window.
+If no layout is specified, `@tui` gets the main pane and each non-detached service gets a vertical split pane in the same window.
 
 ## TUI
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ zaps               # Launch
 
 ### Config & Setup
 
-| Command                                | Description                                                            |
-| -------------------------------------- | --------------------------------------------------------------------- |
-| `zaps config`                          | Validate and print resolved config. `--json`, `--toon`, `--path`      |
-| `zaps reload`                          | Reload config for the running session (CLI form of the dashboard `c`) |
-| `zaps init`                            | Scaffold a starter `.zaps.mts` config                                 |
-| `zaps attach`                          | Attach TUI to a running session (use `-s` to choose one)              |
-| `zaps daemon start\|stop\|status\|ping` | Daemon management (`ping` checks the daemon is responsive)             |
+| Command                                 | Description                                                           |
+| --------------------------------------- | --------------------------------------------------------------------- |
+| `zaps config`                           | Validate and print resolved config. `--json`, `--toon`, `--path`      |
+| `zaps reload`                           | Reload config for the running session (CLI form of the dashboard `c`) |
+| `zaps init`                             | Scaffold a starter `.zaps.mts` config                                 |
+| `zaps attach`                           | Attach TUI to a running session (use `-s` to choose one)              |
+| `zaps daemon start\|stop\|status\|ping` | Daemon management (`ping` checks the daemon is responsive)            |
 
 ### Selecting a session & output format
 
@@ -443,27 +443,27 @@ rename the calls — e.g. `({ defineProject }) => defineProject({…})` becomes
 
 ### Options
 
-| Option          | Type                                        | Default | Description                                                                                   |
-| --------------- | ------------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
-| `start`         | `string \| () => string`                    | —       | Command to start the service (long-running process)                                           |
+| Option          | Type                                        | Default | Description                                                                                               |
+| --------------- | ------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `start`         | `string \| () => string`                    | —       | Command to start the service (long-running process)                                                       |
 | `run`           | `string \| () => string`                    | —       | Interchangeable with `start` — either satisfies the "needs a command" rule (`start` wins if both are set) |
-| `stop`          | `string \| () => string`                    | —       | Custom stop command (default: Ctrl-C)                                                         |
-| `docker`        | `DockerConfig`                              | —       | Docker Compose service config                                                                 |
-| `ready`         | `ReadyConfig`                               | —       | How to detect the service is ready                                                            |
-| `dependsOn`     | `string[]`                                  | `[]`    | Services that must be ready first                                                             |
-| `env`           | `Record<string, string> \| (ctx) => Record` | —       | Environment variables                                                                         |
-| `cwd`           | `string`                                    | —       | Working directory                                                                             |
-| `url`           | `string \| (ctx) => string`                 | —       | URL for browser open (`o` key)                                                                |
-| `flags`         | `{ start?: boolean, open?: boolean }`       | —       | `start`: auto-start on launch (default `true`), `open`: auto-open URL when ready              |
-| `detached`      | `boolean`                                   | `false` | Run outside tmux (no pane)                                                                    |
-| `lazyPane`      | `boolean`                                   | _auto_  | Create the pane on start, drop it on explicit stop (default `true` when `flags.start: false`) |
-| `raw`           | `boolean`                                   | `false` | Bypass wrapper — show env vars inline in pane                                                 |
-| `restart`       | `{ maxRetries?, backoff? }`                 | —       | Auto-restart on crash                                                                         |
-| `onBeforeStart` | `() => void \| Promise<void>`               | —       | Callback before command is sent                                                               |
-| `onReady`       | `() => void \| Promise<void>`               | —       | Callback when service becomes ready                                                           |
-| `onStop`        | `() => void \| Promise<void>`               | —       | Callback when service stops                                                                   |
-| `onOutput`      | `(line: string) => void \| Promise<void>`   | —       | Called for each new output line                                                               |
-| `optional`      | `boolean \| () => Promise<boolean>`         | —       | Mark service as optional (see below)                                                          |
+| `stop`          | `string \| () => string`                    | —       | Custom stop command (default: Ctrl-C)                                                                     |
+| `docker`        | `DockerConfig`                              | —       | Docker Compose service config                                                                             |
+| `ready`         | `ReadyConfig`                               | —       | How to detect the service is ready                                                                        |
+| `dependsOn`     | `string[]`                                  | `[]`    | Services that must be ready first                                                                         |
+| `env`           | `Record<string, string> \| (ctx) => Record` | —       | Environment variables                                                                                     |
+| `cwd`           | `string`                                    | —       | Working directory                                                                                         |
+| `url`           | `string \| (ctx) => string`                 | —       | URL for browser open (`o` key)                                                                            |
+| `flags`         | `{ start?: boolean, open?: boolean }`       | —       | `start`: auto-start on launch (default `true`), `open`: auto-open URL when ready                          |
+| `detached`      | `boolean`                                   | `false` | Run outside tmux (no pane)                                                                                |
+| `lazyPane`      | `boolean`                                   | _auto_  | Create the pane on start, drop it on explicit stop (default `true` when `flags.start: false`)             |
+| `raw`           | `boolean`                                   | `false` | Bypass wrapper — show env vars inline in pane                                                             |
+| `restart`       | `{ maxRetries?, backoff? }`                 | —       | Auto-restart on crash                                                                                     |
+| `onBeforeStart` | `() => void \| Promise<void>`               | —       | Callback before command is sent                                                                           |
+| `onReady`       | `() => void \| Promise<void>`               | —       | Callback when service becomes ready                                                                       |
+| `onStop`        | `() => void \| Promise<void>`               | —       | Callback when service stops                                                                               |
+| `onOutput`      | `(line: string) => void \| Promise<void>`   | —       | Called for each new output line                                                                           |
+| `optional`      | `boolean \| () => Promise<boolean>`         | —       | Mark service as optional (see below)                                                                      |
 
 ### Optional Services
 

--- a/README.md
+++ b/README.md
@@ -420,25 +420,6 @@ something that never resolves), the load fails with a `ConfigError` instead of b
 a reload forever. The timeout only covers async waits — a synchronous infinite loop
 isn't interruptible.
 
-### Migrating from the flat API
-
-Earlier versions exposed flat methods on the `Library`. They are now grouped into
-namespaces (a breaking change, with no compatibility shim):
-
-| Old                      | New                       |
-| ------------------------ | ------------------------- |
-| `defineProject(config)`  | `define(config)`          |
-| `runTask(key)`           | `task.run(key)`           |
-| `startService(name)`     | `service.start(name)`     |
-| `stopService(name)`      | `service.stop(name)`      |
-| `restartService(name)`   | `service.restart(name)`   |
-| `isServiceRunning(name)` | `service.isRunning(name)` |
-| `openInBrowser(url)`     | `browser.open(url)`       |
-
-`node` is unchanged. To migrate, update the destructure in your `config` function and
-rename the calls — e.g. `({ defineProject }) => defineProject({…})` becomes
-`({ define }) => define({…})`.
-
 ## Services
 
 ### Options
@@ -574,11 +555,6 @@ on explicit stop).
   `docker.service: [...]` with `expand`) — group members share one pane, so
   per-member lazy is ambiguous; apply `lazyPane` at the group level once
   group-granularity lazy ships.
-
-**Migration note.** Before this version, every non-autostart service got an
-empty reserved tmux pane at boot. Non-autostart services now boot **pane-less**
-by default. To keep the old behavior (an idle empty pane reserved at boot),
-set `lazyPane: false` on the service.
 
 ### Ready Detection
 
@@ -1230,7 +1206,7 @@ Add the following to your project's `CLAUDE.md` to help Claude use ZAPS effectiv
 - Use the `zaps-config` skill when editing ZAPS config files
 ```
 
-## Troubleshooting & Migration
+## Troubleshooting
 
 ### `zaps daemon stop` tears down services
 
@@ -1255,25 +1231,6 @@ down (`Stopped <n> session(s), <m> service(s).`). It is no longer a bare process
   ```
   Dependency "db" not ready
   ```
-
-### Removed environment variables
-
-`ZAPS_PANE_MAP` and `ZAPS_IPC_SOCKET` have been **removed**. These legacy env paths
-never functioned and there is no migration — delete any references to them. Pane and
-socket resolution is handled internally by the daemon.
-
-### Compose project pinning (one-time)
-
-Upgrading pins every compose invocation to a deterministic `-p` project name (see
-[Compose project pinning](#compose-project-pinning)). Existing containers started under
-the old, unpinned project name keep running but are no longer tracked. Clean them up
-once per affected project directory:
-
-```bash
-docker compose -p <old-project-name> down
-```
-
-ZAPS prints a best-effort one-time warning when it detects such leftover containers.
 
 ## License
 


### PR DESCRIPTION
Audits every doc/skill against the current `src/` implementation, fixes the drift, and recreates both skills via `/skill-creator`. Docs/skills only — **no `src/` changes**.

## What changed
Applied 28 drift findings (0 code bugs) across README, CLAUDE.md, and both skills:

- **README** — documented `reload` and `daemon ping`; documented the `--toon`/`ZAPS_FORMAT` output surface (+ agent auto-TOON); removed the nonexistent `attach [session]` positional (target via global `-s`); corrected crash-poll interval (2s raw / 10s wrapper); replaced the approximate state diagram with the exact `state.ts` transitions; added the task `docker compose -p` gotcha.
- **CLAUDE.md** — corrected tech versions (Ink 6→7, Commander 14→15, TS→6) and listed all 6 config-discovery variants.
- **zaps-config skill** — fixed hook names (`onBeforeStart/onStart/onStop`; dropped nonexistent `onServiceStart/onServiceStop`); fixed `ctx.port` → `ctx.services.<name>.port`; documented `restartWith`; corrected non-autostart dependency behavior; corrected default layout to **vertical split pane in `@tui`** (not a background window).
- **zaps-usage skill** — added `reload` + daemon `start/status/ping`; surfaced `--toon`/`ZAPS_FORMAT`; clarified `attach`/global `-s`.
- **Both skills** — added `name` frontmatter and optimized trigger descriptions with an explicit cross-skill boundary.

## Verification
- `pnpm typecheck` and `oxfmt --check` pass; no `src/`/`test/` changes.
- Every finding was independently re-verified against `src/` (file:line). Two report glosses were corrected during implementation: the `restartWith` cascade direction (verified vs `graph.ts`) and a layout false-positive (verified vs `tmux-layout.ts`).

> Note: full `pnpm check` currently fails only on a pre-existing flaky test (`test/components/Router.failed-output.test.tsx`, passes in isolation) unrelated to these docs-only changes.