### PR TITLE
fix: complete @bosdev/zaps rename + idempotent npm publish

### DIFF
--- a/.claude/skills/zaps-config/SKILL.md
+++ b/.claude/skills/zaps-config/SKILL.md
@@ -35,7 +35,7 @@ Activate this skill when the user:
 ## Config Skeleton
 
 ```ts
-import type { Library } from "zaps";
+import type { Library } from "@bosdev/zaps";
 
 export function config({ define }: Library) {
   return define({
@@ -59,7 +59,7 @@ The `Library` object groups everything into namespaces — destructure what you 
 - The function receives a `Library` object and must call `define()`
 - At least one service is required in the `services` record
 - Each service needs exactly one of: `start`, `run`, or `docker`
-- Import the `Library` type from the `"zaps"` package
+- Import the `Library` type from the `"@bosdev/zaps"` package
 - The file must be `.zaps.mts` or `.zaps.ts` (TypeScript, ESM)
 
 ## Quick Reference

--- a/.claude/skills/zaps-config/references/01-getting-started.md
+++ b/.claude/skills/zaps-config/references/01-getting-started.md
@@ -26,7 +26,7 @@ ZAPS walks up from cwd to filesystem root, checking each directory for config fi
 Config files must export a `config` function (named or default export). The function receives a `Library` object and must return a `ProjectConfig` via `define()`.
 
 ```ts
-import type { Library } from "zaps";
+import type { Library } from "@bosdev/zaps";
 
 export function config({ define }: Library) {
   return define({
@@ -210,12 +210,12 @@ Run `zaps init` to create a starter `.zaps.mts` in the current directory.
 
 - Writes a `.zaps.mts` with a single placeholder service
 - Fails if any config variant already exists in the directory
-- Replaces `{{ZAPS_PATH}}` in the template with the resolved import path (defaults to `"zaps"`)
+- Replaces `{{ZAPS_PATH}}` in the template with the resolved import path (defaults to `"@bosdev/zaps"`)
 
 Generated file:
 
 ```ts
-import type { Library } from "zaps";
+import type { Library } from "@bosdev/zaps";
 
 export function config({ define }: Library) {
   return define({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,15 +79,29 @@ jobs:
         run: npm version "$ZAPS_VERSION" --no-git-tag-version --allow-same-version
       - name: Prepare platform packages
         run: node_modules/.bin/tsx scripts/prepare-npm-platform-packages.ts
+      # Idempotent: skip versions already on the registry so a re-run after a
+      # partial failure can complete (npm versions are immutable).
       - name: Publish platform packages
         run: |
           for dir in npm-platforms/*/; do
-            npm publish "$dir" --access public --provenance
+            name=$(node -p "require('./$dir/package.json').name")
+            version=$(node -p "require('./$dir/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version already published — skipping"
+            else
+              npm publish "$dir" --access public --provenance
+            fi
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish main package
-        run: npm publish --access public --provenance
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "@bosdev/zaps@$version" version >/dev/null 2>&1; then
+            echo "@bosdev/zaps@$version already published — skipping"
+          else
+            npm publish --access public --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
      
 <img src="https://raw.githubusercontent.com/boshold/zaps/main/assets/banner.png" alt="ZAPS" width="600">
 
-
    <p>
       <a href="https://github.com/boshold/zaps/blob/main/LICENSE">
          <picture>
@@ -142,7 +141,7 @@ ZAPS walks up from the current directory looking for these filenames (first matc
 ### Minimal Config
 
 ```typescript
-import type { Library } from "zaps";
+import type { Library } from "@bosdev/zaps";
 
 export function config({ define }: Library) {
   return define({
@@ -165,7 +164,7 @@ reference. The function may be **async** — declare it
 ### Full Config Reference
 
 ```typescript
-import type { Library } from "zaps";
+import type { Library } from "@bosdev/zaps";
 
 export function config({ define }: Library) {
   return define({

--- a/src/config/scaffold.ts
+++ b/src/config/scaffold.ts
@@ -15,25 +15,25 @@ const CONFIG_FILENAMES = [
 ];
 
 /**
- * Resolve the directory of the installed `zaps` package so a scaffolded config's
- * `import type { Library } from "..."` resolves for global/native installs where
- * a bare `"zaps"` specifier is not in the project's `node_modules` (G8). Resolves
- * `zaps/package.json` (an explicit subpath that works without an `exports`/`main`
- * field) via `createRequire().resolve` (a node builtin available in all three
- * runtimes — tsx dev, node bundle, bun native binary) and returns its directory;
- * the package's `types` field then points the editor/typechecker at the
- * declarations. Falls back to the bare `"zaps"` specifier on any failure (e.g.
- * `zaps` is a normal local dependency, or resolution is unavailable) so it never
- * crashes.
+ * Resolve the directory of the installed `@bosdev/zaps` package so a scaffolded
+ * config's `import type { Library } from "..."` resolves for global/native
+ * installs where a bare `"@bosdev/zaps"` specifier is not in the project's
+ * `node_modules` (G8). Resolves `@bosdev/zaps/package.json` (an explicit subpath
+ * that works without an `exports`/`main` field) via `createRequire().resolve` (a
+ * node builtin available in all three runtimes — tsx dev, node bundle, bun
+ * native binary) and returns its directory; the package's `types` field then
+ * points the editor/typechecker at the declarations. Falls back to the bare
+ * `"@bosdev/zaps"` specifier on any failure (e.g. `@bosdev/zaps` is a normal
+ * local dependency, or resolution is unavailable) so it never crashes.
  *
  * @internal Exported for testing.
  */
 export function getZapsPath(): string {
   try {
     const require = createRequire(import.meta.url);
-    return path.dirname(require.resolve("zaps/package.json"));
+    return path.dirname(require.resolve("@bosdev/zaps/package.json"));
   } catch {
-    return "zaps";
+    return "@bosdev/zaps";
   }
 }
 

--- a/test/config/scaffold-getzapspath.test.ts
+++ b/test/config/scaffold-getzapspath.test.ts
@@ -17,17 +17,17 @@ describe("getZapsPath (G8)", () => {
     vi.clearAllMocks();
   });
 
-  it("returns the package directory when zaps/package.json resolves", () => {
-    const pkgJson = path.join("/opt", "global", "node_modules", "zaps", "package.json");
+  it("returns the package directory when @bosdev/zaps/package.json resolves", () => {
+    const pkgJson = path.join("/opt", "global", "node_modules", "@bosdev", "zaps", "package.json");
     resolveMock.mockReturnValue(pkgJson);
     expect(getZapsPath()).toBe(path.dirname(pkgJson));
-    expect(resolveMock).toHaveBeenCalledWith("zaps/package.json");
+    expect(resolveMock).toHaveBeenCalledWith("@bosdev/zaps/package.json");
   });
 
-  it("falls back to the bare 'zaps' specifier when resolution throws", () => {
+  it("falls back to the bare '@bosdev/zaps' specifier when resolution throws", () => {
     resolveMock.mockImplementation(() => {
-      throw new Error("Cannot find module 'zaps/package.json'");
+      throw new Error("Cannot find module '@bosdev/zaps/package.json'");
     });
-    expect(getZapsPath()).toBe("zaps");
+    expect(getZapsPath()).toBe("@bosdev/zaps");
   });
 });

--- a/test/config/scaffold.test.ts
+++ b/test/config/scaffold.test.ts
@@ -25,7 +25,7 @@ describe("generateTemplate", () => {
 
   it("replaces zaps import path", async () => {
     const result = await generateTemplate();
-    expect(result).toContain('from "zaps"');
+    expect(result).toContain('from "@bosdev/zaps"');
     expect(result).not.toContain("{{ZAPS_PATH}}");
   });
 


### PR DESCRIPTION
Two release-correctness fixes:

**1. Complete the `@bosdev/zaps` rename.** `zaps init` resolved/scaffolded the old bare `"zaps"` specifier, so generated configs had a broken import for the scoped package. Now resolves `@bosdev/zaps/package.json` (fallback `"@bosdev/zaps"`), and the config import examples in the README + `zaps-config` skill use `@bosdev/zaps`.

**2. Idempotent npm publish.** npm versions are immutable, so the partial v0.8.1 publish (platform packages live, main package not) couldn't be recovered by re-running. Each publish step now skips any version already on the registry.

Verified: `getZapsPath` test updated + green, typecheck/lint clean, `generateTemplate` emits `import … from "@bosdev/zaps"`.