### PR TITLE
fix(test): eliminate flaky tmux integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
           path: dist/
       - run: tmux -V
       - run: docker info
+      # Pre-pull compose images so the cold-runner pull doesn't count against the
+      # per-test 60s timeout (the docker-expand/docker-ready flake).
+      - run: docker pull redis:7-alpine && docker pull memcached:1-alpine
       - run: pnpm test:integration --coverage
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -401,6 +401,15 @@ export class ServiceManager extends EventEmitter {
 
   private async runStartAll(): Promise<void> {
     this.startAllAborted = false;
+    // Capture-before-mutate: the constructor issues the original window title /
+    // Automatic-rename reads asynchronously, but `startAllServices` emits state
+    // Changes that drive `updateWindowTitle` → `renameWindow`, which flips
+    // Automatic-rename off and overwrites the name. Awaiting the captures here
+    // Guarantees they observe the pre-rename state so `stopAll` restores it
+    // Correctly (otherwise they race and record our own rename under load).
+    await Promise.all([this.originalWindowTitle, this.originalAutoRename]).catch(() => {
+      // Reads are best-effort; stopAll handles null/unknown originals.
+    });
     try {
       await this.startAllServices();
     } finally {

--- a/test/integration/global-setup.ts
+++ b/test/integration/global-setup.ts
@@ -9,6 +9,11 @@ function killTestServer() {
 }
 
 export default function setup() {
+  // Strip inherited tmux client env so the integration tmux commands don't nest
+  // When the suite is run from inside a tmux session locally (otherwise the test
+  // Server exits unexpectedly). CI runs outside tmux, so this is a no-op there.
+  delete process.env.TMUX;
+  delete process.env.TMUX_PANE;
   killTestServer();
   return () => {
     killTestServer();

--- a/test/integration/helpers/wait.ts
+++ b/test/integration/helpers/wait.ts
@@ -1,0 +1,24 @@
+/**
+ * Poll `read()` until `predicate(value)` is true or `timeoutMs` elapses, then
+ * return the last value read (whether or not it satisfied the predicate). Lets
+ * callers assert on the final observed value so a genuine failure surfaces the
+ * real data rather than a timeout. Shared by the real-tmux integration tests,
+ * whose assertions race async tmux/kernel state (SIGWINCH delivery, window
+ * rename propagation) that only settles after a few poll cycles under CI load.
+ */
+export async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 5000,
+  pollMs = 50,
+): Promise<T> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- polling */
+  let value = await read();
+  while (!predicate(value) && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    value = await read();
+  }
+  /* eslint-enable no-await-in-loop */
+  return value;
+}

--- a/test/integration/tmux/apply-geometry.test.ts
+++ b/test/integration/tmux/apply-geometry.test.ts
@@ -21,6 +21,7 @@ import {
 import { hasScriptPty, hasTmux, isCI } from "../helpers/skip.js";
 import type { AttachedClient, TestSession } from "../helpers/tmux.js";
 import { attachClient, createTestSession } from "../helpers/tmux.js";
+import { waitFor } from "../helpers/wait.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -66,24 +67,6 @@ async function listPaneGeoms(target: string): Promise<PaneGeom[]> {
     .map(({ id, pid, rect }) => ({ id, pid, rect }));
 }
 
-/** Poll until `predicate(geoms)` is true or `timeoutMs` elapses. */
-async function waitFor<T>(
-  read: () => Promise<T>,
-  predicate: (value: T) => boolean,
-  timeoutMs = 3000,
-  pollMs = 50,
-): Promise<T> {
-  const start = Date.now();
-  /* eslint-disable no-await-in-loop -- polling */
-  let value = await read();
-  while (!predicate(value) && Date.now() - start < timeoutMs) {
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-    value = await read();
-  }
-  /* eslint-enable no-await-in-loop */
-  return value;
-}
-
 /** Build a column-split 3-pane window: left=initial, middle, right. */
 async function buildThreeColumnWindow(session: TestSession): Promise<{
   paneMap: PaneMap;
@@ -102,19 +85,52 @@ async function buildThreeColumnWindow(session: TestSession): Promise<{
   };
 }
 
-/** Run `stty size` in `paneId` and parse the captured `rows cols` line. */
-async function probeStty(paneId: string): Promise<{ rows: number; cols: number }> {
+/**
+ * Run `stty size` once in `paneId` and return the LAST `rows cols` line in the
+ * buffer (earlier runs may have left other matches). Returns `{ rows: NaN }` if
+ * the shell hasn't rendered any size line yet — callers poll {@link probeSttyUntil}.
+ */
+async function probeSttyOnce(paneId: string): Promise<{ rows: number; cols: number }> {
   await sendKeys(paneId, "stty size");
-  // Wait for shell to render the output (poll capture-pane).
+  // Give the shell a beat to echo the result before we read the buffer.
   const found = await waitFor(
     async () => capturePane(paneId, 20),
     (out) => /^\d+\s+\d+$/m.test(out),
+    1000,
   );
-  // Take the LAST match — earlier runs may have left other matches in the buffer.
   const matches = found.match(/^\d+\s+\d+$/gm) ?? [];
   const last = matches.at(-1) ?? "";
   const [rows, cols] = last.split(/\s+/).map((n) => Number.parseInt(n, 10));
   return { rows, cols };
+}
+
+/**
+ * Probe the in-pane shell's perceived winsize, RE-running `stty size` each poll
+ * until it reports `expected` or `timeoutMs` elapses. Re-sending (not just
+ * re-capturing) is essential: the kernel pty winsize that `select-layout` pushes
+ * is delivered to the shell asynchronously via SIGWINCH, so the shell's first
+ * `stty size` can echo a stale intermediate size — only a fresh probe after the
+ * signal lands reflects the new geometry. Returns the final observed value so a
+ * genuine staleness bug still fails the assertion with the real number.
+ */
+async function probeSttyUntil(
+  paneId: string,
+  expected: { rows: number; cols: number },
+  timeoutMs = 10_000,
+  pollMs = 100,
+): Promise<{ rows: number; cols: number }> {
+  const start = Date.now();
+  /* eslint-disable no-await-in-loop -- polling until winsize settles */
+  let probed = await probeSttyOnce(paneId);
+  while (
+    (probed.rows !== expected.rows || probed.cols !== expected.cols) &&
+    Date.now() - start < timeoutMs
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    probed = await probeSttyOnce(paneId);
+  }
+  /* eslint-enable no-await-in-loop */
+  return probed;
 }
 
 function makeReflow(layout: LayoutNode, paneMap: PaneMap, sessionName: string): LayoutReflow {
@@ -241,9 +257,10 @@ describe.skipIf(!hasTmux())("LayoutReflow.applyGeometry — real tmux", () => {
     if (!apiRect) {
       return;
     }
-    const probed = await probeStty(paneMap.api);
+    const expectedSize = { rows: apiRect.height, cols: apiRect.width };
+    const probed = await probeSttyUntil(paneMap.api, expectedSize);
     // (4) shell `stty size` reports the new geometry (no SIGWINCH staleness).
-    expect(probed).toEqual({ rows: apiRect.height, cols: apiRect.width });
+    expect(probed).toEqual(expectedSize);
   });
 
   it("round-trips through windowLayout — the emitted layout string is what tmux now reports", async () => {
@@ -336,10 +353,11 @@ describe.skipIf(!canRunAttached)("LayoutReflow.applyGeometry — attached client
     if (!apiRect) {
       return;
     }
-    const probed = await probeStty(paneMap.api);
+    const expectedSize = { rows: apiRect.height, cols: apiRect.width };
+    const probed = await probeSttyUntil(paneMap.api, expectedSize);
     // If this assertion ever fails on a real attached terminal, that's the
     // Round-3 staleness edge — re-run with `{ resyncFallback: true }` and the
     // P02-T02 hook will resync the pty winsize.
-    expect(probed).toEqual({ rows: apiRect.height, cols: apiRect.width });
+    expect(probed).toEqual(expectedSize);
   });
 });

--- a/test/integration/tmux/window-title.test.ts
+++ b/test/integration/tmux/window-title.test.ts
@@ -19,6 +19,7 @@ import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
 import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
+import { waitFor } from "../helpers/wait.js";
 
 const deps = {
   sendKeys,
@@ -75,10 +76,11 @@ describe.skipIf(!hasTmux())("window-title integration", () => {
     mgr = new ServiceManager(config, paneMap, deps, session.name);
     await mgr.startAll();
 
-    // Wait for async window rename to complete
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    const title = await getWindowName(paneMap["@tui"]);
+    // Poll for the async window rename to settle (both services ready).
+    const title = await waitFor(
+      async () => getWindowName(paneMap["@tui"]),
+      (t) => t.includes("zaps") && t.includes("●2"),
+    );
     expect(title).toContain("zaps");
     expect(title).toContain("●2");
   });
@@ -99,15 +101,19 @@ describe.skipIf(!hasTmux())("window-title integration", () => {
     mgr = new ServiceManager(config, paneMap, deps, session.name);
     await mgr.startAll();
 
-    // Title should have changed
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    const runningTitle = await getWindowName(paneMap["@tui"]);
+    // Title should have changed — poll until the rename lands.
+    const runningTitle = await waitFor(
+      async () => getWindowName(paneMap["@tui"]),
+      (t) => t.includes("zaps"),
+    );
     expect(runningTitle).toContain("zaps");
 
     await mgr.stopAll();
-    await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const restoredTitle = await getWindowName(paneMap["@tui"]);
+    const restoredTitle = await waitFor(
+      async () => getWindowName(paneMap["@tui"]),
+      (t) => t === "my-custom-title",
+    );
     expect(restoredTitle).toBe("my-custom-title");
   });
 
@@ -126,9 +132,11 @@ describe.skipIf(!hasTmux())("window-title integration", () => {
     mgr = new ServiceManager(config, paneMap, deps, session.name);
     await mgr.startAll();
     await mgr.stopAll();
-    await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const autoRename = await getWindowOption(paneMap["@tui"], "automatic-rename");
+    const autoRename = await waitFor(
+      async () => getWindowOption(paneMap["@tui"], "automatic-rename"),
+      (v) => v === "on",
+    );
     expect(autoRename).toBe("on");
   });
 });


### PR DESCRIPTION
## What

Makes the **Integration Tests** CI job reliably green. Every recent failure was a timing race in a real-tmux/docker test; unit/lint/typecheck/build were always stable.

- **apply-geometry "in-pane pty winsize"** (the frequent one): the probe read the shell's perceived size once and only waited for *any* `rows cols` line, not the settled value. SIGWINCH delivery is async, so under load it captured the stale intermediate width (CI saw `109` vs expected `130`). It now re-sends `stty size` and polls until the size matches the expected geometry (or a 10s deadline), returning the final value so a genuine bug still fails with the real number.
- **window-title "automatic-rename restoration" / "restored on stopAll"**: a real product race. `ServiceManager` captured the original window title and `automatic-rename` option via un-awaited async tmux reads in the constructor; `startAll`'s state-change-driven `renameWindow` could win the race, so `stopAll` restored the wrong value. `runStartAll` now awaits both captures before any rename. The tests also poll instead of using fixed 500ms sleeps.
- **docker-expand / docker-ready timeout**: pre-pull `redis:7-alpine` + `memcached:1-alpine` in CI so a cold-runner image pull no longer counts against the 60s per-test timeout.

Also adds a shared `waitFor` poll helper and scrubs `TMUX`/`TMUX_PANE` in the integration `global-setup` so the suite can run locally from inside a tmux session.

## Why

These races blocked `main` and every PR intermittently. Reproduced the winsize flake locally 8/8 under CPU contention (`taskset -c 0` + busy loops); with the fix it passes 8/8 under the same load, window-title 6/6. The window-title fix targets the actual race in product code rather than only hardening the test. No vitest `retry` was added — the races are fixed, not hidden.

Checklist:

- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
    - no linked issue exists for this change
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable
