### PR TITLE
fix(native): embed jiti babel transform as inlined text

### DIFF
--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -20,9 +20,12 @@ import type { BunPlugin } from "bun";
 const require = createRequire(import.meta.url);
 
 // Jiti's exports map blocks the deep `jiti/dist/babel.cjs` import the loader
-// Embeds as a Bun file asset. Resolve it to the real path and force the `file`
-// Loader so it is embedded as an opaque asset (default export = runtime path)
-// Rather than bundled as a CJS module — embedding keeps `--bytecode` working.
+// Reads. Resolve it to the real path and force the `text` loader so its source
+// Is inlined into the bundle as a string literal (default export = source text).
+// A string literal survives the later `--compile --bytecode` step; a `file`
+// Asset does not (the compile re-parses the bundle and never re-discovers it,
+// Leaving a dangling build-time path) — so inlining is what keeps the babel
+// Transform reachable inside `dist/zaps`.
 const babelPath = path.join(
   path.dirname(require.resolve("jiti/package.json")),
   "dist",
@@ -36,8 +39,8 @@ const babelAssetPlugin: BunPlugin = {
       namespace: "babel-asset",
     }));
     build.onLoad({ filter: /.*/, namespace: "babel-asset" }, async () => ({
-      contents: await Bun.file(babelPath).bytes(),
-      loader: "file",
+      contents: await Bun.file(babelPath).text(),
+      loader: "text",
     }));
   },
 };

--- a/src/config/native-babel-asset.d.ts
+++ b/src/config/native-babel-asset.d.ts
@@ -1,7 +1,7 @@
 // Jiti's exports map does not expose `dist/babel.cjs`; Bun resolves the file
-// Asset directly. Declare it so TypeScript accepts the `type: "file"` import in
-// Native-babel.ts (the import evaluates to the asset's path string at runtime).
+// Directly. Declare it so TypeScript accepts the `type: "text"` import in
+// Native-babel.ts (the import evaluates to the file's source contents at runtime).
 declare module "jiti/dist/babel.cjs" {
-  const assetPath: string;
-  export default assetPath;
+  const source: string;
+  export default source;
 }

--- a/src/config/native-babel.ts
+++ b/src/config/native-babel.ts
@@ -1,32 +1,32 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import type { JitiOptions } from "jiti";
-import babelAsset from "jiti/dist/babel.cjs" with { type: "file" };
+import babelSource from "jiti/dist/babel.cjs" with { type: "text" };
 
 import { daemonDir } from "#src/daemon/lifecycle.js";
 
 /**
- * Native binary only: Bun embeds `babel.cjs` as a compile asset. `babelAsset`
- * is its path relative to this module inside the binary, so resolve it against
- * `import.meta.url`. jiti otherwise does a lazy `require("../dist/babel.cjs")`
- * that escapes Bun's bundler and fails inside `dist/zaps`. Copy the asset once
- * into the runtime dir and load it so it can be passed to `createJiti` via the
- * `transform` option.
+ * Native binary only: jiti otherwise does a lazy `require("../dist/babel.cjs")`
+ * that escapes Bun's bundler and fails inside `dist/zaps`. The build inlines
+ * `babel.cjs` as text (`type: "text"`), so `babelSource` is its source string —
+ * carried inside the binary, not a build-time path (a file asset is dropped by
+ * the `--compile --bytecode` step, leaving a dangling path; see scripts/build-native.ts).
+ * Write the source once into the runtime dir and `require` it so it can be passed
+ * to `createJiti` via the `transform` option.
  */
 export function getNativeTransform(): JitiOptions["transform"] {
-  const src = fileURLToPath(new URL(babelAsset, import.meta.url));
   const dest = path.join(daemonDir(), "babel.cjs");
-  let needsCopy = true;
+  const expectedSize = Buffer.byteLength(babelSource);
+  let needsWrite = true;
   try {
-    needsCopy = fs.statSync(dest).size !== fs.statSync(src).size;
+    needsWrite = fs.statSync(dest).size !== expectedSize;
   } catch {
-    // Dest missing — copy it
+    // Dest missing — write it
   }
-  if (needsCopy) {
-    fs.copyFileSync(src, dest);
+  if (needsWrite) {
+    fs.writeFileSync(dest, babelSource);
   }
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- require() is typed any; babel.cjs is jiti's transform fn
   return createRequire(import.meta.url)(dest) as JitiOptions["transform"];

--- a/test/integration/binary/babel-asset.test.ts
+++ b/test/integration/binary/babel-asset.test.ts
@@ -1,0 +1,78 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { hasBinary } from "../helpers/skip.js";
+
+const execFileAsync = promisify(execFile);
+const binaryPath = path.resolve("dist/zaps");
+const distDir = path.resolve("dist");
+
+// Config filenames that discoverConfig searches for
+const CONFIG_FILENAMES = [
+  ".local.zaps.mts",
+  "local.zaps.mts",
+  ".local.zaps.ts",
+  "local.zaps.ts",
+  ".zaps.mts",
+  ".zaps.ts",
+];
+
+function cleanStaleConfigs(): void {
+  for (const name of CONFIG_FILENAMES) {
+    try {
+      fs.unlinkSync(path.join(os.tmpdir(), name));
+    } catch {
+      // Doesn't exist
+    }
+  }
+}
+
+// Loading a `.mts` config in the native binary needs jiti's babel transform.
+// The transform source must travel *inside* `dist/zaps`, not as a sibling
+// `dist/babel-<hash>.cjs` asset: the old `loader: "file"` approach left a
+// Dangling build-time path that ENOENT'd on any machine but the build host.
+// Removing every `dist/*.cjs` before invoking the binary forces it to rely on
+// The embedded source (there should be none to begin with after the fix).
+describe.skipIf(!hasBinary())("binary babel transform is self-contained", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    cleanStaleConfigs();
+    for (const entry of fs.readdirSync(distDir)) {
+      if (entry.endsWith(".cjs")) {
+        fs.unlinkSync(path.join(distDir, entry));
+      }
+    }
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "zaps-babel-"));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+    cleanStaleConfigs();
+  });
+
+  it("loads a TS config with no sibling babel.cjs asset present", async () => {
+    await writeFile(
+      path.join(tmpDir, ".zaps.mts"),
+      `export function config({ define }) {
+  return define({
+    name: "embedded-babel",
+    services: { api: { start: "true" } },
+  });
+}
+`,
+    );
+
+    const { stdout } = await execFileAsync(binaryPath, ["config", "--json"], { cwd: tmpDir });
+    const parsed = JSON.parse(stdout) as { name: string };
+    expect(parsed.name).toBe("embedded-babel");
+  });
+});


### PR DESCRIPTION
## Problem

Installing `@bosdev/zaps` globally and running `zaps` crashes:

```
Error: ENOENT: no such file or directory, copyfile
'/home/runner/work/zaps/zaps/dist/babel-q17jazc3.cjs' -> '/run/user/1000/zaps/babel.cjs'
```

`/home/runner/work/zaps/...` is the GitHub Actions build dir — a build-time absolute path baked into the shipped native binary.

## Root cause

`scripts/build-native.ts` builds in two steps:
1. `Bun.build()` → `dist/cli.js` **+ a separate `dist/babel-<hash>.cjs`** (the `babelAssetPlugin` used `loader: "file"`); the import resolved to that asset's **path**.
2. `bun build dist/cli.js --compile --bytecode` → standalone binary.

The compile step only sees a *string literal* path in `cli.js`; it never re-discovers it as an asset, so the `.cjs` is **never embedded** into `dist/zaps`. The baked CI path is absent on users' machines → `getNativeTransform()`'s `copyFileSync` throws ENOENT.

The existing `binary/jiti-reload.test.ts` didn't catch it: right after build the file still exists at the baked path in the repo `dist/`, so the copy succeeds on CI.

## Fix

Embed the babel source as **inlined text** (`loader: "text"`) — a JS string literal that survives both build steps and `--bytecode`, so the content travels *inside* the binary. `native-babel.ts` writes the embedded source to the runtime dir and `require`s it (same proven load path; only the source of the content changed). No separate `dist/babel-*.cjs` is emitted anymore.

Node build is unaffected: `native-babel.ts` is `external` in the esbuild bundle and only imported when `process.versions.bun` is truthy.

## Verification

- **Host (linux-x64):** built the binary, copied it out, **deleted `dist/` entirely**, then loaded a `.mts` config — valid JSON, no ENOENT (the exact failure scenario).
- **All 4 release targets** cross-compiled (linux x64/arm64, darwin x64/arm64): each builds, emits **0** stray `dist/*.cjs`, and embeds the babel source (verified by grepping a babel-unique marker in each binary).
- New `test/integration/binary/babel-asset.test.ts`: removes every `dist/*.cjs` before loading a `.mts` config through the binary, forcing the embedded-source path. Fails on the old build, passes now.
- Full `test:integration` green (44 files, 209 passed, 1 skipped).