### PR TITLE
feat(release): platform READMEs + npm linked-artifacts storage records

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   build:
@@ -105,6 +107,34 @@ jobs:
           else
             npm publish --access public --provenance
           fi
+
+      # Register each published package on the org's Linked Artifacts page
+      # (https://github.com/orgs/boshold/artifacts) via the Artifact Metadata API.
+      # Best-effort: a failure here must never break a release.
+      - name: Register npm storage records
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(node -p "require('./package.json').version")
+          names=$(node -p "['@bosdev/zaps', ...Object.keys(require('./package.json').optionalDependencies || {})].join('\n')")
+          echo "$names" | while IFS= read -r name; do
+            [ -n "$name" ] || continue
+            integrity=$(npm view "$name@$version" dist.integrity 2>/dev/null || true)
+            if [ -z "$integrity" ]; then
+              echo "$name@$version: no integrity on registry — skipping"
+              continue
+            fi
+            digest=$(node -e 'process.stdout.write("sha512:"+Buffer.from(process.argv[1].replace(/^sha512-/,""),"base64").toString("hex"))' "$integrity")
+            echo "registering storage record for $name@$version ($digest)"
+            curl -fsSL -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              https://api.github.com/orgs/boshold/artifacts/metadata/storage-record \
+              -d "{\"name\":\"$name\",\"version\":\"$version\",\"digest\":\"$digest\",\"registry_url\":\"https://registry.npmjs.org\",\"artifact_url\":\"https://www.npmjs.com/package/$name/v/$version\",\"status\":\"active\"}" \
+              || echo "storage-record POST failed for $name@$version (non-fatal)"
+          done
 
   release:
     name: Release

--- a/scripts/prepare-npm-platform-packages.ts
+++ b/scripts/prepare-npm-platform-packages.ts
@@ -66,10 +66,23 @@ for (const platform of platforms) {
     repository: { type: "git", url: "git+https://github.com/boshold/zaps.git" },
     os: [platform.os],
     cpu: [platform.cpu],
-    files: ["zaps"],
+    files: ["zaps", "README.md"],
     publishConfig: { access: "public" },
   };
   writeFileSync(path.join(dir, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`);
+
+  const readme = `# ${platform.name}
+
+Prebuilt native \`zaps\` binary for **${platform.os}/${platform.cpu}**.
+
+You don't install this package directly — it's an \`optionalDependencies\` target of
+the main package, selected automatically for your platform.
+
+**Install [\`@bosdev/zaps\`](https://www.npmjs.com/package/@bosdev/zaps) instead.**
+
+Source & docs: https://github.com/boshold/zaps
+`;
+  writeFileSync(path.join(dir, "README.md"), readme);
   console.log(`prepared ${platform.name}@${version}`); // eslint-disable-line no-console -- build script output
 }
 


### PR DESCRIPTION
## What

Two release-workflow improvements for the npm distribution.

### 1. Per-platform package READMEs
`scripts/prepare-npm-platform-packages.ts` now emits a minimal `README.md` for each
`@bosdev/zaps-<platform>` package (and ships it via the package `files` list). Today
those packages publish with a bare npm page; now each one explains it's just the
prebuilt native binary and points users to install `@bosdev/zaps` instead.

### 2. npm linked artifacts (storage records)
After publishing, the `npm` job registers an org **Artifact Metadata** storage record
per published package (main + 4 platform) against `registry.npmjs.org`, so they surface
on the org's [Linked Artifacts page](https://github.com/orgs/boshold/artifacts). The
digest is the tarball `sha512` (matches the provenance attestation, so GitHub auto-links
it). The step is **best-effort** (`continue-on-error`) — a missing entitlement or API
rejection logs and moves on, never breaking a release. Adds `attestations: write` +
`artifact-metadata: write` permissions.

## Verification

- Ran the prepare script locally with dummy artifacts → correct per-platform README +
  `files`; `package.json` mutation reverted.
- Digest one-liner output exact-matches the real `@bosdev/zaps@0.8.3` tarball `sha512sum`.
- Org Artifact Metadata endpoint reachable (GET probe → `404 no artifacts found`).
- `bash -n` on the new step passes; YAML indentation checked.

## Notes

- Live verification of the storage-record POST only happens on the next tagged release
  (the local probe confirms the endpoint exists, not that the CI token is authorized).
- No changes to build output, GitHub Release assets, or install/optionalDependencies
  resolution.