### PR TITLE
fix(release): correct npm storage-record payload (sha256 + bare repo name)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,25 +115,37 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           version=$(node -p "require('./package.json').version")
           names=$(node -p "['@bosdev/zaps', ...Object.keys(require('./package.json').optionalDependencies || {})].join('\n')")
           echo "$names" | while IFS= read -r name; do
             [ -n "$name" ] || continue
-            integrity=$(npm view "$name@$version" dist.integrity 2>/dev/null || true)
-            if [ -z "$integrity" ]; then
-              echo "$name@$version: no integrity on registry — skipping"
+            # Resolve the published tarball, retrying for registry propagation lag.
+            tarball=""
+            for i in 1 2 3 4 5; do
+              tarball=$(npm view "$name@$version" dist.tarball 2>/dev/null || true)
+              [ -n "$tarball" ] && break
+              echo "$name@$version: tarball not on registry yet (try $i) — waiting"
+              sleep 5
+            done
+            if [ -z "$tarball" ]; then
+              echo "$name@$version: tarball unavailable — skipping"
               continue
             fi
-            digest=$(node -e 'process.stdout.write("sha512:"+Buffer.from(process.argv[1].replace(/^sha512-/,""),"base64").toString("hex"))' "$integrity")
+            # Artifact Metadata API accepts only sha256 digests (algorithm:64-hex),
+            # and github_repository must be the bare repo name (no owner/slash).
+            digest="sha256:$(curl -fsSL "$tarball" | sha256sum | cut -d' ' -f1)"
             echo "registering storage record for $name@$version ($digest)"
-            curl -fsSL -X POST \
+            http=$(curl -sS -o /tmp/sr-resp.json -w "%{http_code}" -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "X-GitHub-Api-Version: 2026-03-10" \
               https://api.github.com/orgs/boshold/artifacts/metadata/storage-record \
-              -d "{\"name\":\"$name\",\"version\":\"$version\",\"digest\":\"$digest\",\"registry_url\":\"https://registry.npmjs.org\",\"artifact_url\":\"https://www.npmjs.com/package/$name/v/$version\",\"status\":\"active\"}" \
-              || echo "storage-record POST failed for $name@$version (non-fatal)"
+              -d "{\"name\":\"$name\",\"version\":\"$version\",\"digest\":\"$digest\",\"registry_url\":\"https://registry.npmjs.org\",\"artifact_url\":\"https://www.npmjs.com/package/$name/v/$version\",\"github_repository\":\"$REPO_NAME\",\"status\":\"active\"}" \
+              || true)
+            echo "  HTTP $http"
+            [ "$http" = "200" ] || { echo "  response:"; cat /tmp/sr-resp.json 2>/dev/null; echo " (non-fatal)"; }
           done
 
   release:


### PR DESCRIPTION
## Problem

The `Register npm storage records` step added in #38 failed with **HTTP 422** on
every package during the v0.8.4 release (best-effort, so the release still succeeded,
but no linked artifacts were created).

Verified the exact API errors with a throwaway probe workflow:

```
Invalid /digest: ... does not match /^sha256:[a-f0-9]{64}$/
Invalid /github_repository: boshold/zaps does not match /^[A-Za-z0-9.\-_]+$/
```

Two bugs:
1. The Artifact Metadata API accepts **only `sha256`** digests — we sent `sha512`.
2. `github_repository` must be the **bare repo name** (`zaps`), not `owner/repo`.

## Fix

- Compute `sha256` of the published tarball (`dist.tarball` → `sha256sum`).
- Pass `github_repository` as `${{ github.event.repository.name }}` (bare name).
- Retry `npm view dist.tarball` to absorb registry propagation lag (the main
  package was skipped in v0.8.4 because it queried too early).
- Print the response body + HTTP status on non-200 so future failures aren't opaque.

## Verification

Proven end-to-end against the **already-published v0.8.4** packages via the probe:
all 5 POSTs returned **HTTP 200**, and a read-back GET confirms the records exist.
As a side effect v0.8.4 is now linked on https://github.com/orgs/boshold/artifacts.
Future releases will populate automatically.

No version bump needed — this is a workflow-only fix.