### PR TITLE
fix: make process-tree + PID detection work on macOS

### DIFF
--- a/src/daemon/detached-registry.ts
+++ b/src/daemon/detached-registry.ts
@@ -1,13 +1,15 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { daemonDir } from "./lifecycle.js";
 
-/** A `/proc`-derived identity used to detect PID reuse before reaping (R10). */
+/** A process identity used to detect PID reuse before reaping (R10). */
 interface ProcInfo {
-  /** `/proc/<pid>/stat` field 22 (starttime) — stable for a process's lifetime. */
+  /** Start-time (stable for a process's lifetime): Linux `/proc` field 22, or
+   * macOS `ps -o lstart`. Compared as an opaque string, never interpreted. */
   startTime: string;
-  /** `/proc/<pid>/cmdline`, NUL-separated args joined with spaces. */
+  /** Full command line (Linux `/proc/<pid>/cmdline`, macOS `ps -o command`). */
   cmdline: string;
 }
 
@@ -18,11 +20,10 @@ interface DetachedEntry {
 }
 
 /**
- * Parse `/proc/<pid>/stat` + `/proc/<pid>/cmdline` for the reuse-safe identity.
- * Returns null on any platform without `/proc` or when the pid is gone, so the
- * registry degrades to "don't reap" rather than risk killing an unrelated pid.
+ * Parse `/proc/<pid>/stat` + `/proc/<pid>/cmdline` for the reuse-safe identity
+ * (Linux). Returns null when `/proc` is absent or the pid is gone.
  */
-function defaultReadProcInfo(pid: number): ProcInfo | null {
+function readProcInfoFromProc(pid: number): ProcInfo | null {
   try {
     const stat = fs.readFileSync(`/proc/${String(pid)}/stat`, "utf8");
     // `comm` (field 2) may contain spaces and parens — parse after the final ')'.
@@ -43,6 +44,42 @@ function defaultReadProcInfo(pid: number): ProcInfo | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Derive the same reuse-safe identity from `ps` on macOS, which has no `/proc`.
+ * `lstart` is a fixed wall-clock start time (stable for the process's lifetime)
+ * and `command` is the full argv — together they detect PID reuse just like the
+ * Linux path. Queried separately so the space-containing `lstart` never has to
+ * be split out of a shared line. Returns null when the pid is gone.
+ */
+function psField(pid: number, field: string): string {
+  return execFileSync("ps", ["-o", `${field}=`, "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function readProcInfoFromPs(pid: number): ProcInfo | null {
+  try {
+    const startTime = psField(pid, "lstart");
+    if (!startTime) {
+      return null;
+    }
+    const cmdline = psField(pid, "command");
+    return { startTime, cmdline };
+  } catch {
+    // Process gone (ps exits non-zero) or ps unavailable — degrade to "don't reap".
+    return null;
+  }
+}
+
+/**
+ * Read a live PID's reuse-safe identity, or null when unavailable — so the
+ * registry degrades to "don't reap" rather than risk killing an unrelated pid.
+ */
+function defaultReadProcInfo(pid: number): ProcInfo | null {
+  return process.platform === "darwin" ? readProcInfoFromPs(pid) : readProcInfoFromProc(pid);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -172,3 +209,5 @@ export class DetachedRegistry {
     }
   }
 }
+
+export { defaultReadProcInfo };

--- a/src/lib/port.ts
+++ b/src/lib/port.ts
@@ -98,7 +98,14 @@ function parseDarwinLsof(output: string, pidSet: Set<number>): number[] {
  * Returns array including rootPid itself.
  */
 async function getDescendantPidsImpl(rootPid: number): Promise<number[]> {
-  const output = await exec("ps", ["-eo", "pid,ppid,sid"]);
+  // Linux/procps spells the session-id column `sid`; BSD `ps` (macOS) rejects
+  // That keyword ("ps: keyword sid not found"), exits non-zero, and the call
+  // Yields "" — losing the whole process tree, so every paned service looks
+  // Crashed ("Process exited unexpectedly") and port detection finds nothing.
+  // The BSD session-id keyword is `sess`. Pick per-platform, mirroring
+  // GetListeningPortsImpl below.
+  const sessionKeyword = process.platform === "darwin" ? "sess" : "sid";
+  const output = await exec("ps", ["-eo", `pid,ppid,${sessionKeyword}`]);
   if (!output) {
     return [];
   }

--- a/test/daemon/detached-registry.test.ts
+++ b/test/daemon/detached-registry.test.ts
@@ -1,11 +1,16 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DetachedRegistry } from "../../src/daemon/detached-registry.js";
+import { DetachedRegistry, defaultReadProcInfo } from "../../src/daemon/detached-registry.js";
 import type { DetachedRegistryDeps } from "../../src/daemon/detached-registry.js";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+const mockExecFileSync = vi.mocked(execFileSync);
 
 let tmpDir = "";
 let filePath = "";
@@ -70,6 +75,45 @@ describe("DetachedRegistry record/remove", () => {
     registry.record(1);
     registry.remove(999);
     expect(Object.keys(readFile())).toEqual(["1"]);
+  });
+});
+
+describe("defaultReadProcInfo platform dispatch", () => {
+  const originalPlatform = process.platform;
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+
+  it("reads identity from `ps` on macOS (no /proc)", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    mockExecFileSync
+      .mockReturnValueOnce("Mon Jun 30 14:51:34 2026\n")
+      .mockReturnValueOnce("node worker.js\n");
+
+    const info = defaultReadProcInfo(4321);
+
+    expect(info).toEqual({ startTime: "Mon Jun 30 14:51:34 2026", cmdline: "node worker.js" });
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      1,
+      "ps",
+      ["-o", "lstart=", "-p", "4321"],
+      expect.anything(),
+    );
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      "ps",
+      ["-o", "command=", "-p", "4321"],
+      expect.anything(),
+    );
+  });
+
+  it("returns null on macOS when the pid is gone (`ps` throws)", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("No such process");
+    });
+
+    expect(defaultReadProcInfo(4321)).toBeNull();
   });
 });
 

--- a/test/lib/port.test.ts
+++ b/test/lib/port.test.ts
@@ -88,6 +88,27 @@ describe("getDescendantPids", () => {
     const result = await getDescendantPids(1000);
     expect(result).toEqual([1000]);
   });
+
+  describe("ps session-id keyword is platform-specific", () => {
+    const originalPlatform = process.platform;
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    });
+
+    it("uses the `sid` keyword on Linux", async () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      mockExecFileOutput("  PID  PPID   SID\n 1000     1  1000");
+      await getDescendantPids(1000);
+      expect(mockExecFile).toHaveBeenCalledWith("ps", ["-eo", "pid,ppid,sid"]);
+    });
+
+    it("uses the `sess` keyword on macOS (BSD ps rejects `sid`)", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      mockExecFileOutput("  PID  PPID  SESS\n 1000     1  1000");
+      await getDescendantPids(1000);
+      expect(mockExecFile).toHaveBeenCalledWith("ps", ["-eo", "pid,ppid,sess"]);
+    });
+  });
 });
 
 describe("getListeningPorts — Linux", () => {


### PR DESCRIPTION
## What

ZAPS now detects process trees and PID identity correctly on macOS. Previously, on macOS a healthy service (e.g. a docker `postgres`) would come up fine but the dashboard flagged it `error: "Process exited unexpectedly"`, and port-based ready checks never resolved.

## Why

Two code paths used Linux-only system interfaces with no macOS fallback:

- **`getDescendantPids`** ran `ps -eo pid,ppid,sid`. `sid` is a GNU/procps keyword; BSD `ps` (macOS) rejects it, so the command exited non-zero and `exec()` returned `""` — collapsing the process tree to empty. The crash monitor then read "no descendants" as a crash, and `detectPorts` (used by `ready: { port }` / `ready: { http: <path> }`) found nothing. Now uses `sess` on darwin, mirroring the existing `ss`/`lsof` branch right below it.

- **Detached-service orphan reaping** read `/proc/<pid>/{stat,cmdline}` for a PID-reuse-safe identity. `/proc` doesn't exist on macOS, so it silently degraded to never reaping orphaned, port-holding children after a daemon crash. Now derives the same identity from `ps -o lstart=`/`command=` on darwin.

Both were invisible in CI because the matrix is `ubuntu-latest` only.

Checklist:

- [x] issue number linked above after pound (`#`)
  - no linked issue exists for this change
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
  - macOS `ps` keyword behavior verified against Apple's official man page; chain reproduced with a deterministic unit test
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable
