### PR TITLE
feat: auto-spawn a managed tmux session when zaps runs outside tmux

### DIFF
--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -67,6 +67,36 @@ Target a specific session with the global `-s, --session <id|name>` flag (before
 command): `zaps -s my-app down`, `zaps -s my-app restart api`. Without it, ZAPS resolves
 the session for the current directory.
 
+### Managed tmux (running outside tmux)
+
+zaps no longer requires a tmux session. When `$TMUX` is unset it creates its own
+("managed") tmux session on a dedicated tmux server (`tmux -L zaps`), so it never
+touches the user's own tmux.
+
+```
+zaps up -d   # Session zaps-<name>-<id> started (detached, managed tmux). zaps attach to view.
+zaps ls      # LOCATION column shows `zaps-<name>-<id> (managed)` for those sessions
+zaps attach  # revives the TUI pane and attaches (never creates a session)
+zaps down    # stops services AND kills the managed tmux session
+             #   prints `Killed managed tmux session zaps-<name>-<id>.`
+```
+
+- **Prefer `zaps up -d` from an agent shell** — there is no TTY to attach a TUI to.
+  Against an already-running managed session it is a no-op that prints
+  `Session "<name>" is already running (managed tmux). zaps attach to view.` and exits 0.
+- **`q` in the TUI detaches** the tmux client (services keep running); only `zaps down`
+  / `Ctrl-D` tears the session down.
+- **Conflicts** — a session belongs to the tmux context it was created in; both refusals
+  exit 1 and are resolved by following the message, not by retrying:
+  - `Session "<name>" is running inside tmux session '<tmux>'. Attach from within tmux, or run zaps down first.`
+    (session lives in the user's own tmux; attach from there or `zaps down`)
+  - `Session "<name>" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`
+    (followed by a copy-pasteable `tmux -L zaps attach -t =<name>`)
+- **`zaps requires tmux (>= 3.5a) — install it and re-run.`** — tmux is missing or too
+  old; install it, nothing else will work.
+- `ZAPS_AUTO_TMUX=0` disables auto-spawn and restores the old behavior (`zaps must be run
+from inside a tmux session.`). Don't set it unless the user asks.
+
 ### TUI
 
 `zaps up` attaches the interactive dashboard. Key interactions:

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -92,7 +92,7 @@ zaps down    # stops services AND kills the managed tmux session
     (session lives in the user's own tmux; attach from there or `zaps down`)
   - `Session "<name>" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`
     (followed by a copy-pasteable `tmux -L zaps attach -t =<name>`)
-- **`zaps requires tmux (>= 3.5a) — install it and re-run.`** — tmux is missing or too
+- **`zaps requires tmux (>= 3.5) — install it and re-run.`** — tmux is missing or too
   old; install it, nothing else will work.
 - `ZAPS_AUTO_TMUX=0` disables auto-spawn and restores the old behavior (`zaps must be run
 from inside a tmux session.`). Don't set it unless the user asks.

--- a/.claude/skills/zaps-usage/SKILL.md
+++ b/.claude/skills/zaps-usage/SKILL.md
@@ -85,7 +85,7 @@ zaps down    # stops services AND kills the managed tmux session
   Against an already-running managed session it is a no-op that prints
   `Session "<name>" is already running (managed tmux). zaps attach to view.` and exits 0.
 - **`q` in the TUI detaches** the tmux client (services keep running); only `zaps down`
-  / `Ctrl-D` tears the session down.
+  / `Ctrl-D` tears the session down (`Ctrl-D` and the dashboard's `d` ask for a `y` first).
 - **Conflicts** — a session belongs to the tmux context it was created in; both refusals
   exit 1 and are resolved by following the message, not by retrying:
   - `Session "<name>" is running inside tmux session '<tmux>'. Attach from within tmux, or run zaps down first.`
@@ -109,7 +109,7 @@ Global
   f           open the latest failure's captured output
   x           acknowledge (clear sticky failure toasts)
   q / Ctrl-C  detach (services keep running)
-  Ctrl-D      shut down the session
+  Ctrl-D      shut down the session (confirm with y)
   Esc         close overlay / leave view
 
 Dashboard
@@ -118,7 +118,7 @@ Dashboard
   a / c       restart all / reload config
   l / o       logs / open URL
   R           docker rebuild     z / Z  zoom service / TUI pane
-  E           edit-capture pane  d      shut down session
+  E           edit-capture pane  d      shut down session (confirm with y)
 
 Task picker (t)
   type        fuzzy filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
           name: dist
           path: dist/
       - run: chmod +x dist/zaps
+      # Managed sessions (auto-tmux) need tmux >= 3.5; ubuntu-latest ships 3.4.
+      - name: Install tmux 3.5a
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libevent-dev libncurses-dev bison
+          curl -fsSL https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz | tar -xz -C /tmp
+          (cd /tmp/tmux-3.5a && ./configure --prefix=/usr/local >/dev/null && make -j"$(nproc)" >/dev/null && sudo make install >/dev/null)
       - run: tmux -V
       - run: docker info
       # Pre-pull compose images so the cold-runner pull doesn't count against the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install tmux 3.5a
         run: |
           sudo apt-get update
-          sudo apt-get install -y libevent-dev libncurses-dev bison
+          sudo apt-get install -y libevent-dev libncurses-dev bison ncurses-term
           curl -fsSL https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz | tar -xz -C /tmp
           (cd /tmp/tmux-3.5a && ./configure --prefix=/usr/local >/dev/null && make -j"$(nproc)" >/dev/null && sudo make install >/dev/null)
       - run: tmux -V
@@ -111,6 +111,8 @@ jobs:
       # per-test 60s timeout (the docker-expand/docker-ready flake).
       - run: docker pull redis:7-alpine && docker pull memcached:1-alpine
       - run: pnpm test:integration --coverage
+        env:
+          TERM: xterm-256color
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ conventions we follow.
 - [Node.js](https://nodejs.org) >= 22
 - [pnpm](https://pnpm.io) (the repo pins a version via `packageManager`)
 - [Bun](https://bun.sh) — used to build the native binary
-- [tmux](https://github.com/tmux/tmux/wiki) >= 3.5a — ZAPS runs inside tmux
+- [tmux](https://github.com/tmux/tmux/wiki) >= 3.5a — ZAPS runs inside tmux (it starts its own session when you aren't in one)
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ conventions we follow.
 - [Node.js](https://nodejs.org) >= 22
 - [pnpm](https://pnpm.io) (the repo pins a version via `packageManager`)
 - [Bun](https://bun.sh) — used to build the native binary
-- [tmux](https://github.com/tmux/tmux/wiki) >= 3.5a — ZAPS runs inside tmux (it starts its own session when you aren't in one)
+- [tmux](https://github.com/tmux/tmux/wiki) >= 3.5 — ZAPS runs inside tmux (it starts its own session when you aren't in one)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ zaps down     # stop the services and clean everything up
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `q`         | Leaves the dashboard. Services keep running in the background. Your terminal prints `detached — services still running. zaps to re-attach, zaps down to stop.` |
 | `zaps down` | Stops every service and removes the session, including the tmux session ZAPS created (`Killed managed tmux session zaps-<name>-<id>.`)                         |
-| `Ctrl-D`    | Same as `zaps down`, from inside the dashboard                                                                                                                 |
+| `Ctrl-D`    | Same as `zaps down`, from inside the dashboard (asks to confirm with `y`)                                                                                      |
 
 **Starting in the background**
 
@@ -1078,33 +1078,33 @@ failed-output), and a responsive layout that adapts to the pane size.
 
 Work from any base view; survive a disconnect; yield to an open overlay.
 
-| Key          | Action                                          |
-| ------------ | ----------------------------------------------- |
-| `Ctrl-K` `:` | Open the command palette (fuzzy actions)        |
-| `?`          | Toggle the help overlay                         |
-| `t`          | Open the task picker                            |
-| `f`          | Open the captured output of the latest failure  |
-| `x`          | Acknowledge — clear sticky failure toasts       |
-| `q` `Ctrl-C` | Detach (services keep running)                  |
-| `Ctrl-D`     | Shut down the session (stop services + destroy) |
-| `Esc`        | Close the top overlay / leave the current view  |
+| Key          | Action                                                             |
+| ------------ | ------------------------------------------------------------------ |
+| `Ctrl-K` `:` | Open the command palette (fuzzy actions)                           |
+| `?`          | Toggle the help overlay                                            |
+| `t`          | Open the task picker                                               |
+| `f`          | Open the captured output of the latest failure                     |
+| `x`          | Acknowledge — clear sticky failure toasts                          |
+| `q` `Ctrl-C` | Detach (services keep running)                                     |
+| `Ctrl-D`     | Shut down the session (stop services + destroy) — confirm with `y` |
+| `Esc`        | Close the top overlay / leave the current view                     |
 
 ### Dashboard
 
-| Key           | Action                               |
-| ------------- | ------------------------------------ |
-| `Up/Down/j/k` | Navigate services                    |
-| `r`           | Restart selected service             |
-| `s`           | Start/stop selected service          |
-| `l`           | View logs for selected service       |
-| `o`           | Open service URL in browser          |
-| `R`           | Docker rebuild (docker services)     |
-| `z` / `Z`     | Zoom the service pane / the TUI pane |
-| `E`           | Edit-capture the selected pane       |
-| `a`           | Restart all services                 |
-| `c`           | Reload config (when changed + idle)  |
-| `t`           | Open the task picker                 |
-| `d`           | Shut down the session                |
+| Key           | Action                                   |
+| ------------- | ---------------------------------------- |
+| `Up/Down/j/k` | Navigate services                        |
+| `r`           | Restart selected service                 |
+| `s`           | Start/stop selected service              |
+| `l`           | View logs for selected service           |
+| `o`           | Open service URL in browser              |
+| `R`           | Docker rebuild (docker services)         |
+| `z` / `Z`     | Zoom the service pane / the TUI pane     |
+| `E`           | Edit-capture the selected pane           |
+| `a`           | Restart all services                     |
+| `c`           | Reload config (when changed + idle)      |
+| `t`           | Open the task picker                     |
+| `d`           | Shut down the session (confirm with `y`) |
 
 On wide panes a **detail pane** shows the selected service's fields; it collapses
 when `cols < ui.wideThreshold` (default `100`). See [UI Config](#ui-config).

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
       </a>
       <a href="https://github.com/tmux/tmux/wiki#-is-awesome">
          <picture>
-            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/%3E%3D3.5a-94e2d5?logo=tmux&label=tmux&labelColor=313244&logoColor=94e2d5">
-            <img alt="Tmux >= 3.5a" src="https://img.shields.io/badge/%3E%3D3.5a-179299?logo=tmux&label=tmux&labelColor=ccd0da&logoColor=179299">
+            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/%3E%3D3.5-94e2d5?logo=tmux&label=tmux&labelColor=313244&logoColor=94e2d5">
+            <img alt="Tmux >= 3.5" src="https://img.shields.io/badge/%3E%3D3.5-179299?logo=tmux&label=tmux&labelColor=ccd0da&logoColor=179299">
          </picture>
        </a>
    </p>
@@ -45,7 +45,7 @@
 
 ## Prerequisites
 
-- [tmux](https://github.com/tmux/tmux/wiki#-is-awesome) (>= 3.5a) — it has to be
+- [tmux](https://github.com/tmux/tmux/wiki#-is-awesome) (>= 3.5) — it has to be
   installed, but you don't have to know it or start it yourself: `zaps` opens and
   manages its own session for you. See
   [Running without tmux (auto-tmux)](#running-without-tmux-auto-tmux).
@@ -164,7 +164,7 @@ Set `ZAPS_AUTO_TMUX=0` to disable auto-start; `zaps` then requires you to be ins
 tmux yourself and errors with `zaps must be run from inside a tmux session.`
 
 If tmux isn't installed at all, ZAPS says so instead of starting:
-`zaps requires tmux (>= 3.5a) — install it and re-run.`
+`zaps requires tmux (>= 3.5) — install it and re-run.`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@
 
 ## Prerequisites
 
-- [tmux](https://github.com/tmux/tmux/wiki#-is-awesome) (>= 3.5a)
+- [tmux](https://github.com/tmux/tmux/wiki#-is-awesome) (>= 3.5a) — it has to be
+  installed, but you don't have to know it or start it yourself: `zaps` opens and
+  manages its own session for you. See
+  [Running without tmux (auto-tmux)](#running-without-tmux-auto-tmux).
 
 ## Install
 
@@ -85,13 +88,83 @@ sha256sum --check --ignore-missing SHA256SUMS
 ## Quick Start
 
 ```bash
-# Inside a tmux session:
 zaps init          # Scaffold .zaps.mts config
 # Edit .zaps.mts to define your services
 zaps               # Launch
 ```
 
-> ZAPS must be run from inside a tmux session.
+Run it from any normal terminal. `zaps` starts your services and opens the
+dashboard; press `q` to get your terminal back (services keep running) and `zaps`
+again to come back. See
+[Running without tmux (auto-tmux)](#running-without-tmux-auto-tmux).
+
+## Running without tmux (auto-tmux)
+
+You can run `zaps` straight from a normal terminal — no tmux knowledge required.
+When you're not already in tmux, ZAPS starts a session for you, keeps it on its
+own private tmux server (so it can never disturb a tmux setup you may use for
+other things), and drops you into the dashboard.
+
+```bash
+zaps          # starts services + opens the dashboard
+# press q     → back to your shell, services keep running
+zaps          # back into the dashboard
+zaps down     # stop the services and clean everything up
+```
+
+**`q` vs `zaps down`**
+
+| Action      | What happens                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `q`         | Leaves the dashboard. Services keep running in the background. Your terminal prints `detached — services still running. zaps to re-attach, zaps down to stop.` |
+| `zaps down` | Stops every service and removes the session, including the tmux session ZAPS created (`Killed managed tmux session zaps-<name>-<id>.`)                         |
+| `Ctrl-D`    | Same as `zaps down`, from inside the dashboard                                                                                                                 |
+
+**Starting in the background**
+
+```bash
+zaps up -d    # Session zaps-<name>-<id> started (detached, managed tmux). zaps attach to view.
+zaps attach   # open the dashboard later
+```
+
+Services run inside the session ZAPS created, so they see that session's
+environment rather than a copy of your current shell. ZAPS forwards what it needs
+(its socket path and runtime dir); if a service depends on a variable you export
+per-shell, set it in the service's `env` in `.zaps.mts` instead of relying on
+inheritance — the background tmux server may be older than your shell.
+
+**Seeing where a session lives**
+
+`zaps ls` shows a location column: the tmux session hosting each project, marked
+`(managed)` when ZAPS created it (i.e. `zaps down` will remove it too).
+
+```
+a1b2c3d4e5f6  my-app  /home/me/my-app  zaps-my-app-a1b2c3d4e5f6 (managed)
+```
+
+**If you already use tmux**
+
+Nothing changes: run `zaps` inside your own tmux session and it uses that session's
+panes, exactly as before. ZAPS only creates a session of its own when you're not in
+one. A session belongs to the place it was started, so ZAPS refuses to mix them:
+
+- `Session "<name>" is running inside tmux session '<tmux>'. Attach from within tmux, or run zaps down first.`
+- `Session "<name>" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`
+
+In the second case ZAPS also prints a copy-pasteable line for tmux users who would
+rather attach by hand (`=` forces an exact name match):
+
+```bash
+tmux -L zaps attach -t =zaps-my-app-a1b2c3d4e5f6
+```
+
+**Turning it off**
+
+Set `ZAPS_AUTO_TMUX=0` to disable auto-start; `zaps` then requires you to be inside
+tmux yourself and errors with `zaps must be run from inside a tmux session.`
+
+If tmux isn't installed at all, ZAPS says so instead of starting:
+`zaps requires tmux (>= 3.5a) — install it and re-run.`
 
 ## Commands
 
@@ -1264,6 +1337,23 @@ Add the following to your project's `CLAUDE.md` to help Claude use ZAPS effectiv
 `zaps daemon stop` now performs a **full cleanup**: it stops every service in every
 session the daemon manages before shutting the daemon down, and reports what it tore
 down (`Stopped <n> session(s), <m> service(s).`). It is no longer a bare process kill.
+Sessions ZAPS started for you (see
+[Running without tmux (auto-tmux)](#running-without-tmux-auto-tmux)) are removed as
+part of that cleanup — each one prints `Killed managed tmux session <name>.`.
+Sessions running inside your own tmux are left alone.
+
+### A session ZAPS started is stuck
+
+`zaps down` is the normal way out, and it also removes the tmux session. If a
+session was left behind (e.g. the daemon was killed with `kill -9`), running `zaps`
+in that project detects the leftover and replaces it — no manual cleanup needed.
+To inspect or clean up by hand, everything ZAPS creates lives on its own tmux
+server:
+
+```bash
+tmux -L zaps ls                 # list the sessions ZAPS created
+tmux -L zaps kill-session -t =zaps-my-app-a1b2c3d4e5f6
+```
 
 ### Error messages you may see
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -19,7 +19,8 @@ import {
   runDown,
   withDaemon,
 } from "./cli/helpers.js";
-import { isCodingAgent, resolveFormat, writeData } from "./cli/output.js";
+import { isCodingAgent, resolveFormat, sessionRows, writeData } from "./cli/output.js";
+import { refuseManagedMessage, refusePersonalMessage } from "./cli/tmux-context.js";
 import { DaemonClient } from "./client/daemon-client.js";
 import { discoverConfig } from "./config/discovery.js";
 import { loadConfig } from "./config/loader.js";
@@ -639,9 +640,7 @@ const lsCommand = command(
       process.stdout.write("No active sessions.\n");
       return;
     }
-    for (const s of sessions) {
-      process.stdout.write(`${s.id}  ${s.name}  ${s.projectDir}\n`);
-    }
+    process.stdout.write(`${formatTable(sessionRows(sessions))}\n`);
   },
 );
 
@@ -1130,6 +1129,31 @@ const initCommand = command(
   },
 );
 
+/**
+ * Why `zaps attach` cannot reach `session`, if it cannot (F6/F7), as the message
+ * to print. Attach never creates or moves anything, so both conflicts are hard
+ * refusals — the user picks a terminal, or runs `zaps down`.
+ */
+async function attachConflict(session: SessionInfo): Promise<string | undefined> {
+  const view = {
+    name: session.name,
+    tmuxSession: session.tmuxSession ?? "",
+    managed: session.managed === true,
+  };
+  if (!getEnv("TMUX")) {
+    // Outside tmux: a session in the user's own tmux is only reachable there.
+    return view.managed ? undefined : refusePersonalMessage(view);
+  }
+  if (!view.managed) {
+    return undefined;
+  }
+  // Inside tmux: fine when this IS the managed session (the TUI attaches in the
+  // Current pane); refuse from any other tmux, where pane ops would target the
+  // Wrong server.
+  const current = await currentSession().catch(() => undefined);
+  return current === view.tmuxSession ? undefined : refuseManagedMessage(view);
+}
+
 const attachCommand = command(
   {
     name: "attach",
@@ -1160,17 +1184,18 @@ const attachCommand = command(
 
     try {
       const targetSession = resolveTargetSession(sessions, globalSession());
+      const conflict = await attachConflict(targetSession);
+      if (conflict) {
+        process.stderr.write(`${conflict}\n`);
+        // Exit via the code so the multi-line hint is flushed first.
+        process.exitCode = 1;
+        return;
+      }
       if (!getEnv("TMUX")) {
-        // Plain terminal: a managed session is re-entered by reviving its TUI
-        // Pane and attaching (F3). Attach never creates anything, so a session
-        // In the user's own tmux still errors (F6 wording lands in P03-T02).
-        if (!targetSession.managed) {
-          process.stderr.write("zaps must be run from inside a tmux session.\n");
-          process.exit(1);
-        }
+        // Plain terminal, managed session: revive its TUI pane and attach (F3).
         const result = await reattachManaged({
-          name: targetSession.tmuxSession,
-          tuiPane: targetSession.tuiPane,
+          name: targetSession.tmuxSession ?? "",
+          tuiPane: targetSession.tuiPane ?? null,
         });
         // See the `up` bootstrap: exit via the code, so buffered output flushes.
         process.exitCode = result.proceed ? 0 : result.exitCode;

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -335,6 +335,8 @@ async function upFlow(detach?: boolean): Promise<void> {
     projectDir: invokeDir,
     tmuxSession,
     originPane,
+    tmuxSocket: getEnv("ZAPS_TMUX_SOCKET") ?? null,
+    managedTmux: getEnv("ZAPS_MANAGED_TMUX") === "1",
   });
 
   if (res.error) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,7 +2,7 @@
 import { cli, command } from "cleye";
 import type { Command } from "cleye";
 
-import { ensureTmuxContext } from "./cli/bootstrap-tmux.js";
+import { ensureTmuxContext, reattachManaged } from "./cli/bootstrap-tmux.js";
 import { renderCliError } from "./cli/errors.js";
 import type { SessionInfo, SessionIpc } from "./cli/helpers.js";
 import {
@@ -445,7 +445,11 @@ const upCommand = command(
     // Anything else runs; inside tmux this falls straight through.
     const bootstrap = await bootstrapTmux(Boolean(opts.detach));
     if (!bootstrap.proceed) {
-      process.exit(bootstrap.exitCode);
+      // `process.exitCode` + return, never `process.exit()`: the bootstrap has
+      // Just written user-facing lines, and exiting outright discards whatever
+      // Is still buffered on a piped stdout/stderr.
+      process.exitCode = bootstrap.exitCode;
+      return;
     }
 
     // Smart default: if session already running for this project, attach
@@ -1135,10 +1139,6 @@ const attachCommand = command(
   async (parsed) => {
     adoptGlobalSession(parsed.flags.session);
     rejectExcessArgs("attach", parsed._, 0);
-    if (!getEnv("TMUX")) {
-      process.stderr.write("zaps must be run from inside a tmux session.\n");
-      process.exit(1);
-    }
 
     const sock = socketPath();
     if (!isDaemonRunning()) {
@@ -1160,6 +1160,22 @@ const attachCommand = command(
 
     try {
       const targetSession = resolveTargetSession(sessions, globalSession());
+      if (!getEnv("TMUX")) {
+        // Plain terminal: a managed session is re-entered by reviving its TUI
+        // Pane and attaching (F3). Attach never creates anything, so a session
+        // In the user's own tmux still errors (F6 wording lands in P03-T02).
+        if (!targetSession.managed) {
+          process.stderr.write("zaps must be run from inside a tmux session.\n");
+          process.exit(1);
+        }
+        const result = await reattachManaged({
+          name: targetSession.tmuxSession,
+          tuiPane: targetSession.tuiPane,
+        });
+        // See the `up` bootstrap: exit via the code, so buffered output flushes.
+        process.exitCode = result.proceed ? 0 : result.exitCode;
+        return;
+      }
       await runTui({ sessionId: targetSession.id, socketPath: sock });
     } catch (error) {
       if (error instanceof CliError) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,6 +2,7 @@
 import { cli, command } from "cleye";
 import type { Command } from "cleye";
 
+import { ensureTmuxContext } from "./cli/bootstrap-tmux.js";
 import { renderCliError } from "./cli/errors.js";
 import type { SessionInfo, SessionIpc } from "./cli/helpers.js";
 import {
@@ -169,17 +170,18 @@ async function runTui(opts: {
   process.stdout.write("\x1b[?1049h");
 
   if (showSplash) {
-    const { renderSplash } = await import("./components/logo.js");
+    const { managedSplashHint, renderSplash } = await import("./components/logo.js");
     const { resolveIconTier } = await import("./components/theme/IconTheme.js");
     const { listPanes } = await import("./lib/tmux.js");
     const splashTier = resolveIconTier(snapshot.ui?.icons);
+    const hint = managedSplashHint(getEnv("ZAPS_MANAGED_TMUX"));
     const tmuxSession = await currentSession();
     const panes = await listPanes(tmuxSession);
     const tuiPane = panes.find((p) => p.id === snapshot.paneMap["@tui"]);
     if (tuiPane) {
-      renderSplash({ cols: tuiPane.width, rows: tuiPane.height }, splashTier);
+      renderSplash({ cols: tuiPane.width, rows: tuiPane.height }, splashTier, hint);
     } else {
-      renderSplash(undefined, splashTier);
+      renderSplash(undefined, splashTier, hint);
     }
   }
 
@@ -319,11 +321,8 @@ async function upFlow(detach?: boolean): Promise<void> {
 
   const invokeDir = process.cwd();
 
-  if (!getEnv("TMUX")) {
-    process.stderr.write("zaps must be run from inside a tmux session.\n");
-    process.exit(1);
-  }
-
+  // Outside tmux we never get here: `upCommand` bootstraps a managed session
+  // First and only falls through once `$TMUX` is set.
   const originPane = await currentPaneId();
   const tmuxSession = await currentSession();
 
@@ -382,6 +381,24 @@ async function upFlow(detach?: boolean): Promise<void> {
   }
 }
 
+/**
+ * Resolve this process's tmux context for `zaps` / `zaps up`. Outside tmux this
+ * spawns (or re-attaches to, or refuses) the project's managed tmux session and
+ * the caller exits with the returned code; inside tmux it proceeds unchanged.
+ * A missing config fails here with the same message `upFlow` would print, so no
+ * tmux session is ever created for a non-project directory.
+ */
+async function bootstrapTmux(
+  detach: boolean,
+): Promise<{ proceed: true } | { exitCode: number; proceed: false }> {
+  const configPath = discoverConfig(process.cwd());
+  if (!configPath) {
+    process.stderr.write("No config found. Run `zaps init` to create one.\n");
+    process.exit(1);
+  }
+  return ensureTmuxContext({ configPath, projectDir: process.cwd(), detach });
+}
+
 // --- Smart default: attach if running, else up ---
 
 const upCommand = command(
@@ -424,6 +441,13 @@ const upCommand = command(
       }
     }
 
+    // Outside tmux, hand over to a zaps-managed tmux session (or refuse) before
+    // Anything else runs; inside tmux this falls straight through.
+    const bootstrap = await bootstrapTmux(Boolean(opts.detach));
+    if (!bootstrap.proceed) {
+      process.exit(bootstrap.exitCode);
+    }
+
     // Smart default: if session already running for this project, attach
     if (!opts.detach && isDaemonRunning()) {
       const configPath = discoverConfig(process.cwd());
@@ -435,10 +459,6 @@ const upCommand = command(
           const id = sessionId(configPath);
           const match = sessions.find((s) => s.id === id);
           if (match) {
-            if (!getEnv("TMUX")) {
-              process.stderr.write("zaps must be run from inside a tmux session.\n");
-              process.exit(1);
-            }
             await runTui({ sessionId: match.id, socketPath: sock });
             return;
           }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -215,7 +215,13 @@ async function runTui(opts: {
       configStale={snapshot.configStale}
       ui={snapshot.ui}
     />,
-    { patchConsole: false },
+    {
+      patchConsole: false,
+      // On a real pty, paint frames even when CI env vars leak into the pane
+      // (a tmux server started on CI hands CI=true to every pane, and Ink's
+      // Is-in-ci check would then skip every frame until unmount).
+      interactive: process.stdout.isTTY ? true : undefined,
+    },
   );
 
   await waitUntilExit();

--- a/src/cli/bootstrap-tmux.ts
+++ b/src/cli/bootstrap-tmux.ts
@@ -262,7 +262,11 @@ async function spawnAttached(deps: BootstrapDeps, name: string): Promise<Bootstr
  * exit, otherwise a fast failure (bad config) takes the pane — and with it the
  * exit code and the error text — down with it.
  */
-async function spawnDetached(deps: BootstrapDeps, name: string): Promise<BootstrapResult> {
+async function spawnDetached(
+  deps: BootstrapDeps,
+  name: string,
+  configPath: string,
+): Promise<BootstrapResult> {
   const args = buildCreateArgs({ name, detach: true, env: daemonEnv(), ...deps.size() });
   if ((await deps.runTmux(args, false)) !== 0) {
     deps.io.stderr(`Failed to create managed tmux session ${name}.\n`);
@@ -291,6 +295,20 @@ async function spawnDetached(deps: BootstrapDeps, name: string): Promise<Bootstr
   if (settlement.settled && settlement.exitCode === 0) {
     deps.io.stdout(`Session ${name} started (detached, managed tmux). zaps attach to view.\n`);
     return { proceed: false, exitCode: 0 };
+  }
+
+  // A dead pane with an unreadable status is NOT proof of failure: tmux reaps
+  // The pane's process lazily (an unreaped zombie can outlive any wait — seen
+  // Live on 3.5a through 3.7c), so `#{pane_dead_status}` may never materialize.
+  // The daemon is authoritative instead: it only registers the session once the
+  // Inner run got that far, and every pre-session failure (bad config, version
+  // Refusal, conflict) exits without one.
+  if (!settlement.settled && settlement.reason === "unknown-status") {
+    const view = await deps.daemonSession(configPath).catch(() => undefined);
+    if (view) {
+      deps.io.stdout(`Session ${name} started (detached, managed tmux). zaps attach to view.\n`);
+      return { proceed: false, exitCode: 0 };
+    }
   }
 
   // Replay what the inner run printed before it died — that text is the only
@@ -441,14 +459,14 @@ async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<Boo
     case "kill-stale-then-spawn": {
       await killStaleSession(decision.name, deps.tmux);
       return decision.detach
-        ? spawnDetached(deps, decision.name)
+        ? spawnDetached(deps, decision.name, options.configPath)
         : spawnAttached(deps, decision.name);
     }
     case "spawn": {
       return spawnAttached(deps, decision.name);
     }
     case "spawn-detached": {
-      return spawnDetached(deps, decision.name);
+      return spawnDetached(deps, decision.name, options.configPath);
     }
     case "reattach": {
       return reattachManaged({ name: decision.name, tuiPane: decision.tuiPane, deps });

--- a/src/cli/bootstrap-tmux.ts
+++ b/src/cli/bootstrap-tmux.ts
@@ -1,0 +1,352 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import { isDaemonRunning, socketPath } from "#src/daemon/lifecycle.js";
+import { sessionId } from "#src/daemon/session.js";
+import { getEnv } from "#src/lib/env.js";
+import { ipcRequest } from "#src/lib/ipc/client.js";
+import {
+  MANAGED_SOCKET,
+  buildAttachArgs,
+  buildCreateArgs,
+  buildRespawnArgs,
+  buildSetPaneOptionArgs,
+  buildSetSessionOptionArgs,
+  hasManagedSession,
+  killStaleSession,
+  managedSessionName,
+  tmuxAvailable,
+  waitForPaneSettled,
+} from "#src/lib/managed-tmux.js";
+import { tmuxFor } from "#src/lib/tmux.js";
+import type { TmuxHandle } from "#src/lib/tmux.js";
+
+import type { SessionInfo } from "./helpers.js";
+import { resolveCommandArgv } from "./helpers.js";
+import { decideTmuxContext } from "./tmux-context.js";
+import type { DaemonSessionView } from "./tmux-context.js";
+
+/** How long the inner `zaps up -d` may take to settle before we give up (F4). */
+const DETACHED_SETTLE_TIMEOUT_MS = 120_000;
+
+/** How long to wait for a foreground-created session to appear before options. */
+const SESSION_VISIBLE_TIMEOUT_MS = 5000;
+
+/** Gap between `has-session` probes while waiting for the session to appear. */
+const SESSION_POLL_MS = 25;
+
+interface BootstrapIo {
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+/** The tmux commands the bootstrap issues — always on {@link MANAGED_SOCKET}. */
+type BootstrapTmux = Pick<
+  TmuxHandle,
+  "capturePane" | "displayMessage" | "hasSession" | "killSession" | "listPanes" | "tmuxVersion"
+>;
+
+interface BootstrapDeps {
+  io: BootstrapIo;
+  tmux: BootstrapTmux;
+  /** Run `tmux <args>`; `inherit` hands the current TTY to the child. */
+  runTmux: (args: string[], inherit: boolean) => Promise<number>;
+  /** This project's live daemon session, or undefined (daemon down / none). */
+  daemonSession: (configPath: string) => Promise<DaemonSessionView | undefined>;
+  /** How to invoke zaps inside the managed pane, as argv (never a joined string). */
+  zapsArgv: () => string[];
+  /** Terminal size to create the session at, so panes start at the right size. */
+  size: () => { height: number; width: number } | undefined;
+  /** How long `up -d` may take to settle before the outer CLI gives up. */
+  settleTimeoutMs: number;
+  /** How long to wait for a foreground-created session before giving up on options. */
+  sessionVisibleTimeoutMs: number;
+}
+
+/** Outcome for the caller: continue with the normal in-tmux flow, or exit. */
+type BootstrapResult = { proceed: true } | { proceed: false; exitCode: number };
+
+interface EnsureTmuxContextOptions {
+  configPath: string;
+  projectDir: string;
+  detach: boolean;
+  deps?: Partial<BootstrapDeps>;
+}
+
+/** Run `tmux <args>` to completion, resolving its exit code. */
+async function spawnTmux(args: string[], inherit: boolean): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn("tmux", args, { stdio: inherit ? "inherit" : "ignore" });
+    child.on("error", () => resolve(1));
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+}
+
+/** Ask the daemon (if up) for this project's session — F6/F9 need it first. */
+async function daemonSessionFor(configPath: string): Promise<DaemonSessionView | undefined> {
+  if (!isDaemonRunning()) {
+    return undefined;
+  }
+  const res = await ipcRequest(socketPath(), "session.list").catch(() => null);
+  if (!res || res.error) {
+    return undefined;
+  }
+  // eslint-disable-next-line no-unsafe-type-assertion -- IPC boundary
+  const sessions = res.result as SessionInfo[];
+  const id = sessionId(configPath);
+  const match = sessions.find((s) => s.id === id);
+  return match && { name: match.name, tmuxSession: match.tmuxSession, managed: match.managed };
+}
+
+function defaultDeps(): BootstrapDeps {
+  return {
+    io: {
+      stdout: (text) => {
+        process.stdout.write(text);
+      },
+      stderr: (text) => {
+        process.stderr.write(text);
+      },
+    },
+    tmux: tmuxFor(MANAGED_SOCKET),
+    runTmux: spawnTmux,
+    daemonSession: daemonSessionFor,
+    zapsArgv: () => {
+      const { file, args } = resolveCommandArgv();
+      return [file, ...args];
+    },
+    size: () => {
+      const { columns, rows } = process.stdout;
+      return columns && rows ? { width: columns, height: rows } : undefined;
+    },
+    settleTimeoutMs: DETACHED_SETTLE_TIMEOUT_MS,
+    sessionVisibleTimeoutMs: SESSION_VISIBLE_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Env the managed session must carry beyond the two markers: whatever locates
+ * the daemon. The outer zaps decided F6/F9 against *its* daemon, so the inner
+ * one has to reach the same instance — a tmux server started long ago (or by
+ * another shell) would otherwise hand it a different environment.
+ */
+function daemonEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ["ZAPS_SOCKET_PATH", "XDG_RUNTIME_DIR"]) {
+    const value = getEnv(key);
+    if (value) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/** First pane of `name` on the managed socket — the bootstrap (TUI) pane. */
+async function bootstrapPaneId(deps: BootstrapDeps, name: string): Promise<string | undefined> {
+  const panes = await deps.tmux.listPanes(name).catch(() => []);
+  return panes[0]?.id;
+}
+
+/**
+ * Apply what a managed session needs, best-effort:
+ * - `destroy-unattached off`, so a user config that kills unattached sessions
+ *   can't take the services down the moment the client detaches;
+ * - pane-level `remain-on-exit on` on the bootstrap pane, which is what makes
+ *   the `-d` exit code readable and (in P03) the dead pane revivable.
+ */
+async function applyManagedOptions(
+  deps: BootstrapDeps,
+  name: string,
+  paneId: string | undefined,
+): Promise<void> {
+  await deps.runTmux(buildSetSessionOptionArgs(name, "destroy-unattached", "off"), false);
+  if (paneId) {
+    await deps.runTmux(buildSetPaneOptionArgs(paneId, "remain-on-exit", "on"), false);
+  }
+}
+
+/** Bounded poll for the session to exist — it is created by a child we don't await. */
+async function waitForSession(deps: BootstrapDeps, name: string): Promise<boolean> {
+  const deadline = Date.now() + deps.sessionVisibleTimeoutMs;
+  /* eslint-disable no-await-in-loop -- bounded poll on a real condition */
+  while (Date.now() < deadline) {
+    if (await hasManagedSession(name, deps.tmux)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, SESSION_POLL_MS));
+  }
+  /* eslint-enable no-await-in-loop */
+  return false;
+}
+
+/**
+ * Wait for a foreground-created session, then apply its options. Best-effort by
+ * design: a missing option never justifies failing the session the user is
+ * already looking at.
+ */
+async function applyOptionsWhenVisible(deps: BootstrapDeps, name: string): Promise<void> {
+  try {
+    if (await waitForSession(deps, name)) {
+      await applyManagedOptions(deps, name, await bootstrapPaneId(deps, name));
+    }
+  } catch {
+    // Nothing to recover: the session lives on without the option.
+  }
+}
+
+/**
+ * F1: create the managed session in the foreground and hand it the terminal.
+ * The child owns the TTY until the user detaches or the session ends, so the
+ * session options are applied concurrently as soon as the session shows up.
+ * The outer exit code mirrors the tmux client (per 50_api).
+ */
+async function spawnAttached(deps: BootstrapDeps, name: string): Promise<BootstrapResult> {
+  const args = buildCreateArgs({
+    name,
+    zapsArgv: [...deps.zapsArgv(), "up"],
+    env: daemonEnv(),
+  });
+  const attached = deps.runTmux(args, true);
+  const options = applyOptionsWhenVisible(deps, name);
+
+  const exitCode = await attached;
+  await options;
+  return { proceed: false, exitCode };
+}
+
+/**
+ * F4: create the session detached, wait for the inner `zaps up -d` to settle,
+ * then report. On failure the inner output is replayed and the half-created
+ * session is killed so no orphan is left behind.
+ *
+ * The session is created running the plain shell and only *then* respawned with
+ * the zaps command: `remain-on-exit` has to be in place before the command can
+ * exit, otherwise a fast failure (bad config) takes the pane — and with it the
+ * exit code and the error text — down with it.
+ */
+async function spawnDetached(deps: BootstrapDeps, name: string): Promise<BootstrapResult> {
+  const args = buildCreateArgs({ name, detach: true, env: daemonEnv(), ...deps.size() });
+  if ((await deps.runTmux(args, false)) !== 0) {
+    deps.io.stderr(`Failed to create managed tmux session ${name}.\n`);
+    return { proceed: false, exitCode: 1 };
+  }
+
+  const paneId = await bootstrapPaneId(deps, name);
+  await applyManagedOptions(deps, name, paneId);
+  if (!paneId) {
+    deps.io.stderr(`Managed tmux session ${name} vanished before it could start.\n`);
+    await killStaleSession(name, deps.tmux);
+    return { proceed: false, exitCode: 1 };
+  }
+
+  const zapsArgv = [...deps.zapsArgv(), "up", "-d"];
+  if ((await deps.runTmux(buildRespawnArgs(paneId, zapsArgv, { kill: true }), false)) !== 0) {
+    deps.io.stderr(`Failed to start zaps in managed tmux session ${name}.\n`);
+    await killStaleSession(name, deps.tmux);
+    return { proceed: false, exitCode: 1 };
+  }
+
+  const settlement = await waitForPaneSettled(paneId, {
+    timeoutMs: deps.settleTimeoutMs,
+    tmux: deps.tmux,
+  });
+  if (settlement.settled && settlement.exitCode === 0) {
+    deps.io.stdout(`Session ${name} started (detached, managed tmux). zaps attach to view.\n`);
+    return { proceed: false, exitCode: 0 };
+  }
+
+  // Replay what the inner run printed before it died — that text is the only
+  // Thing the user can act on, and the pane is about to be killed.
+  const output = await deps.tmux.capturePane(paneId, 200).catch(() => "");
+  if (output.trim()) {
+    deps.io.stderr(`${output.trimEnd()}\n`);
+  }
+  if (!settlement.settled) {
+    deps.io.stderr(
+      settlement.reason === "timeout"
+        ? `Timed out waiting for ${name} to start.\n`
+        : `Managed tmux session ${name} died before reporting a result.\n`,
+    );
+  }
+  await killStaleSession(name, deps.tmux);
+  return { proceed: false, exitCode: settlement.settled ? settlement.exitCode : 1 };
+}
+
+/**
+ * Decide and act on this process's tmux context before `up` / the smart default
+ * runs. `{ proceed: true }` means "carry on with today's in-tmux flow"; anything
+ * else means the terminal was handed to tmux (or a message was printed) and the
+ * caller must exit with the returned code.
+ */
+async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<BootstrapResult> {
+  const deps: BootstrapDeps = { ...defaultDeps(), ...options.deps };
+  const tmuxEnv = getEnv("TMUX");
+  const daemonSession = await deps.daemonSession(options.configPath);
+
+  // Named from the project DIRECTORY (not the config's display name) so the name
+  // Is stable across runs without loading the config here — that stability is
+  // What makes stale detection (F9) work at all.
+  const managedName = managedSessionName(
+    path.basename(options.projectDir),
+    sessionId(options.configPath),
+  );
+
+  // Both probes cost a subprocess, so only run them where the decision uses
+  // Them: outside tmux, and staleness only when the daemon knows no session.
+  const availability = tmuxEnv
+    ? ({ ok: true, version: "" } as const)
+    : await tmuxAvailable(deps.tmux);
+  const managedSessionExists =
+    !tmuxEnv && availability.ok && !daemonSession
+      ? await hasManagedSession(managedName, deps.tmux)
+      : false;
+
+  const decision = decideTmuxContext({
+    tmuxEnv,
+    autoTmuxEnv: getEnv("ZAPS_AUTO_TMUX"),
+    detach: options.detach,
+    tmuxAvailability: availability,
+    daemonSession,
+    managedName,
+    managedSessionExists,
+  });
+
+  switch (decision.kind) {
+    case "proceed-inside": {
+      return { proceed: true };
+    }
+    case "error-legacy":
+    case "error-no-tmux":
+    case "refuse-managed":
+    case "refuse-personal": {
+      deps.io.stderr(`${decision.message}\n`);
+      return { proceed: false, exitCode: 1 };
+    }
+    case "already-running": {
+      deps.io.stdout(`${decision.message}\n`);
+      return { proceed: false, exitCode: 0 };
+    }
+    case "kill-stale-then-spawn": {
+      await killStaleSession(decision.name, deps.tmux);
+      return decision.detach
+        ? spawnDetached(deps, decision.name)
+        : spawnAttached(deps, decision.name);
+    }
+    case "spawn": {
+      return spawnAttached(deps, decision.name);
+    }
+    case "spawn-detached": {
+      return spawnDetached(deps, decision.name);
+    }
+    case "reattach": {
+      return { proceed: false, exitCode: await deps.runTmux(buildAttachArgs(decision.name), true) };
+    }
+    default: {
+      // Unreachable: the union above is exhaustive.
+      return { proceed: true };
+    }
+  }
+}
+
+export { ensureTmuxContext };
+export type { BootstrapDeps, BootstrapIo, BootstrapResult, BootstrapTmux };

--- a/src/cli/bootstrap-tmux.ts
+++ b/src/cli/bootstrap-tmux.ts
@@ -102,14 +102,17 @@ async function daemonSessionFor(configPath: string): Promise<DaemonSessionView |
   const sessions = res.result as SessionInfo[];
   const id = sessionId(configPath);
   const match = sessions.find((s) => s.id === id);
-  return (
-    match && {
-      name: match.name,
-      tmuxSession: match.tmuxSession,
-      managed: match.managed,
-      tuiPane: match.tuiPane,
-    }
-  );
+  if (!match) {
+    return undefined;
+  }
+  // Defaults, not assumptions: an older daemon omits the newer fields, and
+  // "unknown" must read as "not managed" so nothing here touches its tmux.
+  return {
+    name: match.name,
+    tmuxSession: match.tmuxSession ?? "",
+    managed: match.managed === true,
+    tuiPane: match.tuiPane ?? null,
+  };
 }
 
 function defaultDeps(): BootstrapDeps {

--- a/src/cli/bootstrap-tmux.ts
+++ b/src/cli/bootstrap-tmux.ts
@@ -9,6 +9,7 @@ import {
   MANAGED_SOCKET,
   buildAttachArgs,
   buildCreateArgs,
+  buildNewWindowArgs,
   buildRespawnArgs,
   buildSetPaneOptionArgs,
   buildSetSessionOptionArgs,
@@ -18,6 +19,7 @@ import {
   tmuxAvailable,
   waitForPaneSettled,
 } from "#src/lib/managed-tmux.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
 import { tmuxFor } from "#src/lib/tmux.js";
 import type { TmuxHandle } from "#src/lib/tmux.js";
 
@@ -34,6 +36,9 @@ const SESSION_VISIBLE_TIMEOUT_MS = 5000;
 
 /** Gap between `has-session` probes while waiting for the session to appear. */
 const SESSION_POLL_MS = 25;
+
+/** Printed to the plain terminal after the tmux client goes away (F2). */
+const DETACHED_HINT = "detached — services still running. zaps to re-attach, zaps down to stop.";
 
 interface BootstrapIo {
   stdout: (text: string) => void;
@@ -53,6 +58,8 @@ interface BootstrapDeps {
   runTmux: (args: string[], inherit: boolean) => Promise<number>;
   /** This project's live daemon session, or undefined (daemon down / none). */
   daemonSession: (configPath: string) => Promise<DaemonSessionView | undefined>;
+  /** Name of the tmux session this process runs in (only asked for inside tmux). */
+  currentTmuxSession: () => Promise<string | undefined>;
   /** How to invoke zaps inside the managed pane, as argv (never a joined string). */
   zapsArgv: () => string[];
   /** Terminal size to create the session at, so panes start at the right size. */
@@ -95,7 +102,14 @@ async function daemonSessionFor(configPath: string): Promise<DaemonSessionView |
   const sessions = res.result as SessionInfo[];
   const id = sessionId(configPath);
   const match = sessions.find((s) => s.id === id);
-  return match && { name: match.name, tmuxSession: match.tmuxSession, managed: match.managed };
+  return (
+    match && {
+      name: match.name,
+      tmuxSession: match.tmuxSession,
+      managed: match.managed,
+      tuiPane: match.tuiPane,
+    }
+  );
 }
 
 function defaultDeps(): BootstrapDeps {
@@ -111,6 +125,15 @@ function defaultDeps(): BootstrapDeps {
     tmux: tmuxFor(MANAGED_SOCKET),
     runTmux: spawnTmux,
     daemonSession: daemonSessionFor,
+    // Env-based handle on purpose: this asks about the tmux we are INSIDE, which
+    // Is the managed server only when the marker env says so.
+    currentTmuxSession: async () => {
+      try {
+        return await defaultTmux.currentSession();
+      } catch {
+        return undefined;
+      }
+    },
     zapsArgv: () => {
       const { file, args } = resolveCommandArgv();
       return [file, ...args];
@@ -180,6 +203,17 @@ async function waitForSession(deps: BootstrapDeps, name: string): Promise<boolea
 }
 
 /**
+ * Print the post-detach line (F2) when the session outlived the tmux client.
+ * A session that is gone means teardown (`zaps down` / Ctrl-D), which prints its
+ * own summary — so the `has-session` probe is what tells the two apart.
+ */
+async function reportDetached(deps: BootstrapDeps, name: string): Promise<void> {
+  if (await hasManagedSession(name, deps.tmux)) {
+    deps.io.stdout(`${DETACHED_HINT}\n`);
+  }
+}
+
+/**
  * Wait for a foreground-created session, then apply its options. Best-effort by
  * design: a missing option never justifies failing the session the user is
  * already looking at.
@@ -211,6 +245,7 @@ async function spawnAttached(deps: BootstrapDeps, name: string): Promise<Bootstr
 
   const exitCode = await attached;
   await options;
+  await reportDetached(deps, name);
   return { proceed: false, exitCode };
 }
 
@@ -273,6 +308,75 @@ async function spawnDetached(deps: BootstrapDeps, name: string): Promise<Bootstr
 }
 
 /**
+ * State of the TUI pane we want to re-enter: `"alive"` (still running — nothing
+ * to do), `"dead"` (held by `remain-on-exit`, revive it), `"gone"` (the pane no
+ * longer exists at all).
+ */
+async function tuiPaneState(
+  deps: BootstrapDeps,
+  session: string,
+  paneId: string | null,
+): Promise<"alive" | "dead" | "gone"> {
+  if (!paneId) {
+    return "gone";
+  }
+  // Listing the SESSION's panes and looking ours up, rather than probing the
+  // Pane directly: tmux answers `display-message -t %99` for a pane that no
+  // Longer exists with an empty string and exit 0, which would read as "alive".
+  const livePanes = await deps.tmux.listPanes(session).catch(() => []);
+  const pane = livePanes.find((p) => p.id === paneId);
+  if (!pane) {
+    return "gone";
+  }
+  return pane.dead ? "dead" : "alive";
+}
+
+/**
+ * F3: put a live `zaps attach` back into the preserved TUI pane, then hand the
+ * terminal to tmux. The pane is respawned WITHOUT `-k`: it is dead-but-held, and
+ * demanding a kill would mask the case where the TUI is somehow still running.
+ * If the pane is gone entirely (user killed it by hand) a new window takes its
+ * place rather than failing the command — 70_risks fallback.
+ */
+async function reviveTuiPane(
+  deps: BootstrapDeps,
+  name: string,
+  paneId: string | null,
+): Promise<void> {
+  const zapsArgv = [...deps.zapsArgv(), "attach"];
+  const state = await tuiPaneState(deps, name, paneId);
+  if (state === "alive") {
+    return;
+  }
+  if (state === "dead" && paneId) {
+    if ((await deps.runTmux(buildRespawnArgs(paneId, zapsArgv), false)) === 0) {
+      return;
+    }
+    deps.io.stderr(`Could not revive the zaps pane; opening a new window instead.\n`);
+  } else {
+    deps.io.stderr(`zaps pane is gone; opening a new window instead.\n`);
+  }
+  await deps.runTmux(buildNewWindowArgs(name, zapsArgv), false);
+}
+
+/**
+ * Re-enter an existing managed session: revive its TUI pane, attach in the
+ * foreground, and report on the way out. Exported for `zaps attach`, which
+ * resolves its target itself (`-s`, or the cwd's project).
+ */
+async function reattachManaged(options: {
+  name: string;
+  tuiPane: string | null;
+  deps?: Partial<BootstrapDeps>;
+}): Promise<BootstrapResult> {
+  const deps: BootstrapDeps = { ...defaultDeps(), ...options.deps };
+  await reviveTuiPane(deps, options.name, options.tuiPane);
+  const exitCode = await deps.runTmux(buildAttachArgs(options.name), true);
+  await reportDetached(deps, options.name);
+  return { proceed: false, exitCode };
+}
+
+/**
  * Decide and act on this process's tmux context before `up` / the smart default
  * runs. `{ proceed: true }` means "carry on with today's in-tmux flow"; anything
  * else means the terminal was handed to tmux (or a message was printed) and the
@@ -282,6 +386,10 @@ async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<Boo
   const deps: BootstrapDeps = { ...defaultDeps(), ...options.deps };
   const tmuxEnv = getEnv("TMUX");
   const daemonSession = await deps.daemonSession(options.configPath);
+  // Only needed to tell "inside the project's own managed session" apart from
+  // "inside some other tmux" — so only asked for when both can be true.
+  const currentTmuxSession =
+    tmuxEnv && daemonSession?.managed ? await deps.currentTmuxSession() : undefined;
 
   // Named from the project DIRECTORY (not the config's display name) so the name
   // Is stable across runs without loading the config here — that stability is
@@ -307,6 +415,7 @@ async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<Boo
     detach: options.detach,
     tmuxAvailability: availability,
     daemonSession,
+    currentTmuxSession,
     managedName,
     managedSessionExists,
   });
@@ -339,7 +448,7 @@ async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<Boo
       return spawnDetached(deps, decision.name);
     }
     case "reattach": {
-      return { proceed: false, exitCode: await deps.runTmux(buildAttachArgs(decision.name), true) };
+      return reattachManaged({ name: decision.name, tuiPane: decision.tuiPane, deps });
     }
     default: {
       // Unreachable: the union above is exhaustive.
@@ -348,5 +457,5 @@ async function ensureTmuxContext(options: EnsureTmuxContextOptions): Promise<Boo
   }
 }
 
-export { ensureTmuxContext };
+export { DETACHED_HINT, ensureTmuxContext, reattachManaged };
 export type { BootstrapDeps, BootstrapIo, BootstrapResult, BootstrapTmux };

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -25,6 +25,10 @@ export interface SessionInfo {
   id: string;
   name: string;
   projectDir: string;
+  /** Tmux session hosting the panes — powers the `zaps ls` location column. */
+  tmuxSession: string;
+  /** True when zaps owns the hosting tmux session (managed-tmux mode). */
+  managed: boolean;
 }
 
 export interface SessionIpc {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -29,6 +29,8 @@ export interface SessionInfo {
   tmuxSession: string;
   /** True when zaps owns the hosting tmux session (managed-tmux mode). */
   managed: boolean;
+  /** `%N` of the TUI pane, or null when the layout has none (re-attach target). */
+  tuiPane: string | null;
 }
 
 export interface SessionIpc {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -25,12 +25,16 @@ export interface SessionInfo {
   id: string;
   name: string;
   projectDir: string;
-  /** Tmux session hosting the panes — powers the `zaps ls` location column. */
-  tmuxSession: string;
+  /**
+   * Tmux session hosting the panes — powers the `zaps ls` location column.
+   * Optional at runtime: a daemon from an older release omits it, and the CLI
+   * must degrade (blank location) rather than crash mid-command.
+   */
+  tmuxSession?: string;
   /** True when zaps owns the hosting tmux session (managed-tmux mode). */
-  managed: boolean;
+  managed?: boolean;
   /** `%N` of the TUI pane, or null when the layout has none (re-attach target). */
-  tuiPane: string | null;
+  tuiPane?: string | null;
 }
 
 export interface SessionIpc {
@@ -281,5 +285,10 @@ export async function runDown(deps: DownDeps): Promise<number> {
     return 1;
   }
   deps.stdout("Session destroyed.\n");
+  if (target.managed && target.tmuxSession) {
+    // The destroy also took the tmux session zaps owned — say so, since it is
+    // What just dropped an attached user back into their shell (F5).
+    deps.stdout(`Killed managed tmux session ${target.tmuxSession}.\n`);
+  }
   return 0;
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -7,11 +7,11 @@ const AGENT_ENV_VARS = [
   "CURSOR_TRACE_DIR", // Cursor IDE
 ];
 
-export function isCodingAgent(): boolean {
+function isCodingAgent(): boolean {
   return AGENT_ENV_VARS.some((key) => process.env[key]);
 }
 
-export function resolveFormat(opts: { json?: boolean; toon?: boolean }): OutputFormat {
+function resolveFormat(opts: { json?: boolean; toon?: boolean }): OutputFormat {
   if (opts.json) {
     return "json";
   }
@@ -28,7 +28,36 @@ export function resolveFormat(opts: { json?: boolean; toon?: boolean }): OutputF
   return "text";
 }
 
-export function writeData(data: unknown, format: OutputFormat): void {
+/** What `zaps ls` needs from a session to render one row. */
+interface SessionRowData {
+  id: string;
+  name: string;
+  projectDir: string;
+  tmuxSession?: string;
+  managed?: boolean;
+}
+
+/**
+ * The LOCATION cell for a session: the tmux session hosting it, marked when zaps
+ * owns that tmux (so `zaps down` there also takes the tmux session with it).
+ * Empty when an older daemon didn't report one.
+ */
+function sessionLocation(session: SessionRowData): string {
+  if (!session.tmuxSession) {
+    return "";
+  }
+  return session.managed ? `${session.tmuxSession} (managed)` : session.tmuxSession;
+}
+
+/**
+ * Rows for the `zaps ls` table: id, name, project dir, location. Column-aligned
+ * and header-less, exactly as before — only the LOCATION cell is new.
+ */
+function sessionRows(sessions: SessionRowData[]): string[][] {
+  return sessions.map((s) => [s.id, s.name, s.projectDir, sessionLocation(s)]);
+}
+
+function writeData(data: unknown, format: OutputFormat): void {
   if (format === "json") {
     process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
   } else if (format === "toon") {
@@ -36,4 +65,5 @@ export function writeData(data: unknown, format: OutputFormat): void {
   }
 }
 
-export type { OutputFormat };
+export { isCodingAgent, resolveFormat, sessionLocation, sessionRows, writeData };
+export type { OutputFormat, SessionRowData as SessionRow };

--- a/src/cli/tmux-context.ts
+++ b/src/cli/tmux-context.ts
@@ -85,7 +85,9 @@ function refusePersonalMessage(session: ConflictSession): string {
 function refuseManagedMessage(session: ConflictSession): string {
   return [
     `Session "${session.name}" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`,
-    `  tmux -L ${MANAGED_SOCKET} attach -t ${session.tmuxSession}`,
+    // `=` for the same reason zaps uses it internally: without it tmux
+    // Prefix-matches, so a hand-typed name can attach to the wrong session.
+    `  tmux -L ${MANAGED_SOCKET} attach -t =${session.tmuxSession}`,
   ].join("\n");
 }
 

--- a/src/cli/tmux-context.ts
+++ b/src/cli/tmux-context.ts
@@ -14,6 +14,8 @@ interface DaemonSessionView {
   tmuxSession: string;
   /** True when zaps owns the hosting tmux session. */
   managed: boolean;
+  /** `%N` of its TUI pane — the pane the re-attach path revives. */
+  tuiPane: string | null;
 }
 
 interface TmuxContextInput {
@@ -27,6 +29,12 @@ interface TmuxContextInput {
   tmuxAvailability: TmuxAvailability;
   /** Live session for this project, or undefined when the daemon has none. */
   daemonSession: DaemonSessionView | undefined;
+  /**
+   * Name of the tmux session we are currently inside, when `tmuxEnv` is set.
+   * Distinguishes "inside the project's own managed session" (carry on) from
+   * "inside some other tmux while the session lives in a managed one" (F7).
+   */
+  currentTmuxSession: string | undefined;
   /** Managed session name for this project (`zaps-<project>-<id>`). */
   managedName: string;
   /** True when `managedName` exists on the managed socket. */
@@ -43,7 +51,7 @@ type TmuxContextDecision =
   | { kind: "spawn"; name: string }
   | { kind: "spawn-detached"; name: string }
   | { kind: "kill-stale-then-spawn"; name: string; detach: boolean }
-  | { kind: "reattach"; name: string }
+  | { kind: "reattach"; name: string; tuiPane: string | null }
   | { kind: "already-running"; message: string }
   | { kind: "refuse-personal"; message: string }
   | { kind: "refuse-managed"; message: string }
@@ -88,9 +96,14 @@ function refuseManagedMessage(session: DaemonSessionView): string {
  */
 function decideTmuxContext(input: TmuxContextInput): TmuxContextDecision {
   if (input.tmuxEnv) {
-    // Already inside tmux: today's behavior, except a managed session can only
-    // Be driven from a plain terminal (F7).
-    if (input.daemonSession?.managed) {
+    // Inside the project's OWN managed session (the tmux-naive user who quit the
+    // TUI and is back at the pane's shell): carry on exactly like any in-tmux
+    // Run — the TUI attaches in the current pane. Only a managed session hosted
+    // By some OTHER tmux we are not in has to be refused (F7).
+    if (
+      input.daemonSession?.managed &&
+      input.currentTmuxSession !== input.daemonSession.tmuxSession
+    ) {
       return { kind: "refuse-managed", message: refuseManagedMessage(input.daemonSession) };
     }
     return { kind: "proceed-inside" };
@@ -114,7 +127,11 @@ function decideTmuxContext(input: TmuxContextInput): TmuxContextDecision {
     // With), everything else re-enters it (F3).
     return input.detach
       ? { kind: "already-running", message: alreadyRunningMessage(input.daemonSession) }
-      : { kind: "reattach", name: input.daemonSession.tmuxSession };
+      : {
+          kind: "reattach",
+          name: input.daemonSession.tmuxSession,
+          tuiPane: input.daemonSession.tuiPane,
+        };
   }
 
   if (input.managedSessionExists) {

--- a/src/cli/tmux-context.ts
+++ b/src/cli/tmux-context.ts
@@ -60,7 +60,7 @@ type TmuxContextDecision =
 
 /** F8 — one message for both "not installed" and "too old", per 50_api. */
 function noTmuxMessage(availability: TmuxAvailability): string {
-  const base = `zaps requires tmux (>= 3.5a) — install it and re-run.`;
+  const base = `zaps requires tmux (>= 3.5) — install it and re-run.`;
   const found =
     !availability.ok && availability.reason === "too-old"
       ? ` Found tmux ${availability.version}.`

--- a/src/cli/tmux-context.ts
+++ b/src/cli/tmux-context.ts
@@ -73,13 +73,16 @@ function alreadyRunningMessage(session: DaemonSessionView): string {
   return `Session "${session.name}" is already running (managed tmux). zaps attach to view.`;
 }
 
+/** The bits of a session both refusal messages name. */
+type ConflictSession = Pick<DaemonSessionView, "name" | "tmuxSession">;
+
 /** F6 — the session lives in the user's own tmux; only reachable from there. */
-function refusePersonalMessage(session: DaemonSessionView): string {
+function refusePersonalMessage(session: ConflictSession): string {
   return `Session "${session.name}" is running inside tmux session '${session.tmuxSession}'. Attach from within tmux, or run zaps down first.`;
 }
 
 /** F7 — the session lives in a managed tmux; re-attach from a plain terminal. */
-function refuseManagedMessage(session: DaemonSessionView): string {
+function refuseManagedMessage(session: ConflictSession): string {
   return [
     `Session "${session.name}" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`,
     `  tmux -L ${MANAGED_SOCKET} attach -t ${session.tmuxSession}`,
@@ -145,5 +148,11 @@ function decideTmuxContext(input: TmuxContextInput): TmuxContextDecision {
     : { kind: "spawn", name: input.managedName };
 }
 
-export { LEGACY_TMUX_ERROR, TMUX_INSTALL_URL, decideTmuxContext };
-export type { DaemonSessionView, TmuxContextDecision, TmuxContextInput };
+export {
+  LEGACY_TMUX_ERROR,
+  TMUX_INSTALL_URL,
+  decideTmuxContext,
+  refuseManagedMessage,
+  refusePersonalMessage,
+};
+export type { ConflictSession, DaemonSessionView, TmuxContextDecision, TmuxContextInput };

--- a/src/cli/tmux-context.ts
+++ b/src/cli/tmux-context.ts
@@ -1,0 +1,132 @@
+import { MANAGED_SOCKET } from "#src/lib/managed-tmux.js";
+import type { TmuxAvailability } from "#src/lib/managed-tmux.js";
+
+/** Where tmux install instructions live (F8). */
+const TMUX_INSTALL_URL = "https://github.com/tmux/tmux/wiki/Installing";
+
+/** The pre-auto-tmux error, still used by the `ZAPS_AUTO_TMUX=0` escape hatch. */
+const LEGACY_TMUX_ERROR = "zaps must be run from inside a tmux session.";
+
+/** The daemon's view of this project's session, as far as the bootstrap cares. */
+interface DaemonSessionView {
+  name: string;
+  /** Tmux session hosting it — the managed name, or a personal tmux session. */
+  tmuxSession: string;
+  /** True when zaps owns the hosting tmux session. */
+  managed: boolean;
+}
+
+interface TmuxContextInput {
+  /** `$TMUX` — set exactly when we already run inside some tmux. */
+  tmuxEnv: string | undefined;
+  /** `ZAPS_AUTO_TMUX`; `"0"` restores the pre-auto-tmux error. */
+  autoTmuxEnv: string | undefined;
+  /** True for `zaps up -d` — the headless create path (F4). */
+  detach: boolean;
+  /** Tmux presence + version gate; only consulted outside tmux. */
+  tmuxAvailability: TmuxAvailability;
+  /** Live session for this project, or undefined when the daemon has none. */
+  daemonSession: DaemonSessionView | undefined;
+  /** Managed session name for this project (`zaps-<project>-<id>`). */
+  managedName: string;
+  /** True when `managedName` exists on the managed socket. */
+  managedSessionExists: boolean;
+}
+
+/**
+ * What the CLI should do about its tmux context. Every branch of the F1/F4/F8/F9
+ * decision flow lands on exactly one of these; refusals and errors carry their
+ * user-facing text so the caller only has to print and exit.
+ */
+type TmuxContextDecision =
+  | { kind: "proceed-inside" }
+  | { kind: "spawn"; name: string }
+  | { kind: "spawn-detached"; name: string }
+  | { kind: "kill-stale-then-spawn"; name: string; detach: boolean }
+  | { kind: "reattach"; name: string }
+  | { kind: "already-running"; message: string }
+  | { kind: "refuse-personal"; message: string }
+  | { kind: "refuse-managed"; message: string }
+  | { kind: "error-no-tmux"; message: string }
+  | { kind: "error-legacy"; message: string };
+
+/** F8 — one message for both "not installed" and "too old", per 50_api. */
+function noTmuxMessage(availability: TmuxAvailability): string {
+  const base = `zaps requires tmux (>= 3.5a) — install it and re-run.`;
+  const found =
+    !availability.ok && availability.reason === "too-old"
+      ? ` Found tmux ${availability.version}.`
+      : "";
+  return `${base}${found} ${TMUX_INSTALL_URL}`;
+}
+
+/** `up -d` against an already-running managed session: report, don't re-create. */
+function alreadyRunningMessage(session: DaemonSessionView): string {
+  return `Session "${session.name}" is already running (managed tmux). zaps attach to view.`;
+}
+
+/** F6 — the session lives in the user's own tmux; only reachable from there. */
+function refusePersonalMessage(session: DaemonSessionView): string {
+  return `Session "${session.name}" is running inside tmux session '${session.tmuxSession}'. Attach from within tmux, or run zaps down first.`;
+}
+
+/** F7 — the session lives in a managed tmux; re-attach from a plain terminal. */
+function refuseManagedMessage(session: DaemonSessionView): string {
+  return [
+    `Session "${session.name}" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`,
+    `  tmux -L ${MANAGED_SOCKET} attach -t ${session.tmuxSession}`,
+  ].join("\n");
+}
+
+/**
+ * Pure decision flow for `zaps` / `zaps up` (10_functional "Decision Flow").
+ *
+ * Inside tmux nothing changes unless the project's session is managed (F7).
+ * Outside tmux the escape hatch wins first, then the tmux gate (F8), then any
+ * conflicting or reusable session (F6/F3), then staleness (F9), and finally the
+ * plain create path (F1/F4).
+ */
+function decideTmuxContext(input: TmuxContextInput): TmuxContextDecision {
+  if (input.tmuxEnv) {
+    // Already inside tmux: today's behavior, except a managed session can only
+    // Be driven from a plain terminal (F7).
+    if (input.daemonSession?.managed) {
+      return { kind: "refuse-managed", message: refuseManagedMessage(input.daemonSession) };
+    }
+    return { kind: "proceed-inside" };
+  }
+
+  if (input.autoTmuxEnv === "0") {
+    return { kind: "error-legacy", message: LEGACY_TMUX_ERROR };
+  }
+
+  if (!input.tmuxAvailability.ok) {
+    return { kind: "error-no-tmux", message: noTmuxMessage(input.tmuxAvailability) };
+  }
+
+  if (input.daemonSession) {
+    // A live session the daemon knows about: anything not managed lives in a
+    // Tmux we must not touch (F6).
+    if (!input.daemonSession.managed) {
+      return { kind: "refuse-personal", message: refusePersonalMessage(input.daemonSession) };
+    }
+    // Managed and already up: `-d` has nothing left to do (and no TTY to attach
+    // With), everything else re-enters it (F3).
+    return input.detach
+      ? { kind: "already-running", message: alreadyRunningMessage(input.daemonSession) }
+      : { kind: "reattach", name: input.daemonSession.tmuxSession };
+  }
+
+  if (input.managedSessionExists) {
+    // Name taken on the zaps socket with no daemon session behind it — a stale
+    // Leftover from a crashed daemon (F9). Ours to reap, then create fresh.
+    return { kind: "kill-stale-then-spawn", name: input.managedName, detach: input.detach };
+  }
+
+  return input.detach
+    ? { kind: "spawn-detached", name: input.managedName }
+    : { kind: "spawn", name: input.managedName };
+}
+
+export { LEGACY_TMUX_ERROR, TMUX_INSTALL_URL, decideTmuxContext };
+export type { DaemonSessionView, TmuxContextDecision, TmuxContextInput };

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -30,6 +30,7 @@ import type { DockerFlags } from "./overlay/DockerRebuildOverlay.js";
 import { DOCKER_REBUILD_ID, DockerRebuildOverlay } from "./overlay/DockerRebuildOverlay.js";
 import { FAILED_OUTPUT_ID, FailedOutputOverlay } from "./overlay/FailedOutputOverlay.js";
 import { HELP_OVERLAY_ID, HelpOverlay } from "./overlay/HelpOverlay.js";
+import { SHUTDOWN_CONFIRM_ID, ShutdownConfirmOverlay } from "./overlay/ShutdownConfirmOverlay.js";
 import { TASK_PICKER_ID, TaskPicker } from "./overlay/TaskPicker.js";
 import type { TaskRunRecord } from "./TaskRunRecord.js";
 
@@ -217,6 +218,21 @@ export function Router({
         client.disconnect();
         exit();
       });
+  }
+
+  // Every shutdown entry point (Ctrl-D, dashboard `d`, palette) goes through
+  // Here: destroying the session is irreversible, and the pane's stdin is not a
+  // Trusted source of intent — a tmux client attaching with its own stdin at EOF
+  // Makes the pty emit `VEOF` (0x04), which tmux delivers to the pane as Ctrl-D.
+  // One key must never be enough; the overlay asks for a second, distinct one.
+  function confirmShutdown() {
+    if (globalBusyRef.current || overlay.isTop(SHUTDOWN_CONFIRM_ID)) {
+      return;
+    }
+    overlay.push({
+      id: SHUTDOWN_CONFIRM_ID,
+      render: () => <ShutdownConfirmOverlay onConfirm={destroySession} />,
+    });
   }
 
   // Detach (services keep running) — shared by `q`/Ctrl-C and the palette.
@@ -465,7 +481,7 @@ export function Router({
         editCapture: editCaptureService,
         runTask: runTaskByKey,
         detach: detachSession,
-        shutdown: destroySession,
+        shutdown: confirmShutdown,
         help: openHelp,
       },
     });
@@ -518,9 +534,9 @@ export function Router({
         }
         return;
       }
-      // Ctrl+d: shut down — destroy session from any view.
+      // Ctrl+d: shut down — asks for confirmation first, from any view.
       if (key.ctrl && input === "d") {
-        destroySession();
+        confirmShutdown();
       }
     },
     { isActive: flags.global },
@@ -539,7 +555,7 @@ export function Router({
     reloadConfig: async () => client.reloadConfig(),
     goToLogs,
     openTaskPicker,
-    destroySession,
+    destroySession: confirmShutdown,
     paneMap,
     goToDockerRebuild: openDockerRebuild,
   };

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -13,6 +13,7 @@ import { useServices } from "#src/hooks/useServices.js";
 import { useToasts } from "#src/hooks/useToasts.js";
 import { useZaps } from "#src/hooks/useZaps.js";
 import { buildCommandRegistry } from "#src/lib/command-registry.js";
+import { detachManagedClient } from "#src/lib/managed-detach.js";
 import { notifyFailure } from "#src/lib/notifier.js";
 import { openInBrowser } from "#src/lib/open.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
@@ -219,13 +220,17 @@ export function Router({
   }
 
   // Detach (services keep running) — shared by `q`/Ctrl-C and the palette.
+  // In a zaps-managed tmux the client is detached first, so quitting drops the
+  // User back into their plain shell; in a personal tmux this is a no-op.
   function detachSession() {
     if (globalBusyRef.current) {
       return;
     }
     globalBusyRef.current = true;
-    client.disconnect();
-    exit();
+    void detachManagedClient().finally(() => {
+      client.disconnect();
+      exit();
+    });
   }
 
   // Run services.rebuild with the same per-service busy guard the quick keys use.

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -15,6 +15,18 @@ export const LOGO_ASCII = `
 /____/_/   \\_\\_|   |____/`.trimStart();
 
 /**
+ * Managed-tmux splash hint: in auto-tmux mode quitting only detaches, so say so
+ * once, where the user is already looking. Shown only when `ZAPS_MANAGED_TMUX=1`.
+ */
+export const MANAGED_TMUX_HINT =
+  "auto-tmux: q detaches (services keep running) - zaps down stops everything";
+
+/** The hint to render below the splash subtitle, or undefined outside managed mode. */
+export function managedSplashHint(managedEnv: string | undefined): string | undefined {
+  return managedEnv === "1" ? MANAGED_TMUX_HINT : undefined;
+}
+
+/**
  * Write ANSI splash to stdout — visible while Ink loads.
  * Accepts optional tmux pane dimensions (process.stdout doesn't reflect pane height)
  * and the icon tier so the `ascii` tier renders 7-bit-safe art.
@@ -22,6 +34,7 @@ export const LOGO_ASCII = `
 export function renderSplash(
   size?: { cols: number; rows: number },
   tier?: "nerd" | "unicode" | "ascii",
+  hint?: string,
 ): void {
   const rows = size?.rows || process.stdout.rows || 24;
   const cols = size?.cols || process.stdout.columns || 80;
@@ -32,7 +45,7 @@ export function renderSplash(
   const reset = "\x1b[0m";
   const subtitle = "Starting services...";
   const maxWidth = Math.max(...lines.map((l) => l.length));
-  const logoHeight = lines.length + 1; // +1 for subtitle
+  const logoHeight = lines.length + 1 + (hint ? 1 : 0); // +1 subtitle, +1 hint
   const topPad = Math.max(0, Math.floor((rows - logoHeight) / 2));
 
   const leftPad = " ".repeat(Math.max(0, Math.floor((cols - maxWidth) / 2)));
@@ -48,6 +61,10 @@ export function renderSplash(
   const subtitleRow = topPad + lines.length;
   if (subtitleRow < rows) {
     buffer[subtitleRow] = `${subPad}${dim}${subtitle}${reset}`;
+  }
+  if (hint && subtitleRow + 1 < rows - 1) {
+    const hintPad = " ".repeat(Math.max(0, Math.floor((cols - hint.length) / 2)));
+    buffer[subtitleRow + 1] = `${hintPad}${dim}${hint}${reset}`;
   }
 
   const sizeLabel = `${cols}x${rows}`;

--- a/src/components/overlay/HelpOverlay.tsx
+++ b/src/components/overlay/HelpOverlay.tsx
@@ -24,7 +24,7 @@ const KEYMAP: KeymapGroup[] = [
       ["Ctrl-K / :", "Command palette"],
       ["?", "Help (this)"],
       ["q / Ctrl-C", "Detach (services keep running)"],
-      ["Ctrl-D", "Shut down session"],
+      ["Ctrl-D", "Shut down session (confirm with y)"],
       ["Esc", "Close overlay / leave view"],
     ],
   },

--- a/src/components/overlay/ShutdownConfirmOverlay.tsx
+++ b/src/components/overlay/ShutdownConfirmOverlay.tsx
@@ -1,0 +1,78 @@
+import { Box, Text, useInput } from "ink";
+
+import { useDimensions } from "#src/hooks/useDimensions.js";
+import { useOverlay } from "#src/hooks/useOverlay.js";
+
+/** Overlay id — shared with the Router so it pushes/gates the same descriptor. */
+const SHUTDOWN_CONFIRM_ID = "shutdown-confirm";
+
+const POPUP_WIDTH = 54;
+const POPUP_HEIGHT = 7;
+
+interface ShutdownConfirmOverlayProps {
+  /** Runs the actual `session.destroy` (with its own busy guard) in the Router. */
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation gate in front of session shutdown (`Ctrl-D`, dashboard `d`, the
+ * palette's "Shut down session").
+ *
+ * Shutdown stops every service and destroys the session — irreversible, and
+ * previously one keystroke away. A tmux pane's stdin is not a trusted source of
+ * user intent: any client can push bytes into it, and a client whose own stdin
+ * is at EOF makes the pty emit `VEOF` (`0x04`) on attach, which tmux forwards to
+ * the pane as a plain Ctrl-D. So a single byte tore the whole session down with
+ * nobody asking for it. Requiring a second, distinct key (`y`) means no single
+ * stray byte can be destructive, whatever its source.
+ *
+ * `y` confirms; every other key cancels (Esc→pop is owned by `OverlayHost`).
+ * Enter deliberately does NOT confirm — `\r` is exactly the kind of byte that
+ * arrives unsolicited.
+ */
+function ShutdownConfirmOverlay({ onConfirm }: ShutdownConfirmOverlayProps) {
+  const { cols, rows } = useDimensions();
+  const { isTop, pop } = useOverlay();
+
+  useInput(
+    (input) => {
+      if (input === "y" || input === "Y") {
+        pop();
+        onConfirm();
+        return;
+      }
+      pop();
+    },
+    { isActive: isTop(SHUTDOWN_CONFIRM_ID) },
+  );
+
+  const popupWidth = Math.min(POPUP_WIDTH, Math.max(20, cols - 2));
+  const marginTop = Math.max(0, Math.floor((rows - POPUP_HEIGHT) / 2));
+  const marginLeft = Math.max(0, Math.floor((cols - popupWidth) / 2));
+
+  return (
+    <Box
+      position="absolute"
+      marginTop={marginTop}
+      marginLeft={marginLeft}
+      width={popupWidth}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="red"
+      backgroundColor="default"
+      paddingX={1}
+    >
+      <Text bold color="red">
+        Shut down session?
+      </Text>
+      <Box marginTop={1}>
+        <Text>Stops every service and destroys the session.</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>[y] shut down [esc] cancel</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export { SHUTDOWN_CONFIRM_ID, ShutdownConfirmOverlay };

--- a/src/daemon/handlers/daemon.ts
+++ b/src/daemon/handlers/daemon.ts
@@ -56,6 +56,9 @@ export const daemonHandlers: Record<
         createdAt: s.createdAt,
         tmuxSession: s.tmuxSession,
         managed: s.managedTmux,
+        // Lets an unattached client (the re-attach bootstrap) find the TUI pane
+        // Without subscribing to the session.
+        tuiPane: s.paneMap["@tui"] ?? null,
       })),
     );
   },

--- a/src/daemon/handlers/daemon.ts
+++ b/src/daemon/handlers/daemon.ts
@@ -4,6 +4,11 @@ import { runShutdownHook } from "#src/daemon/shutdown.js";
 import { ipcErr, ipcOk } from "#src/lib/ipc/protocol.js";
 import type { IpcRequest, IpcResponse } from "#src/lib/ipc/protocol.js";
 
+/** A tmux socket name is a non-empty, non-blank string (used verbatim for `-L`). */
+function isSocketName(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
 export const daemonHandlers: Record<
   string,
   (req: IpcRequest, store: SessionStore) => Promise<IpcResponse>
@@ -49,6 +54,8 @@ export const daemonHandlers: Record<
         configPath: s.configPath,
         projectDir: s.projectDir,
         createdAt: s.createdAt,
+        tmuxSession: s.tmuxSession,
+        managed: s.managedTmux,
       })),
     );
   },
@@ -59,14 +66,29 @@ export const daemonHandlers: Record<
       projectDir: string;
       tmuxSession: string;
       originPane: string;
+      tmuxSocket?: string | null;
+      managedTmux?: boolean;
     };
 
     if (!params?.configPath) {
       return ipcErr(req.id, "configPath required");
     }
 
+    // A socket is either absent/null (default server) or a non-empty name — an
+    // Empty string must never silently degrade into "default server".
+    const rawSocket = params.tmuxSocket;
+    if (rawSocket !== undefined && rawSocket !== null && !isSocketName(rawSocket)) {
+      return ipcErr(req.id, "tmuxSocket must be a non-empty string or null");
+    }
+    const tmuxSocket = typeof rawSocket === "string" ? rawSocket : null;
+    const managedTmux = params.managedTmux === true;
+    // The daemon must never kill-session on the user's default server (50_api).
+    if (managedTmux && tmuxSocket === null) {
+      return ipcErr(req.id, "managed session requires tmuxSocket");
+    }
+
     try {
-      const session = await store.create(params);
+      const session = await store.create({ ...params, tmuxSocket, managedTmux });
       return ipcOk(req.id, {
         id: session.id,
         name: session.name,

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -12,7 +12,6 @@ import type { ServiceStatus } from "#src/lib/service/types.js";
 import { newRunId } from "#src/lib/task/run-id.js";
 import { buildWrapperCommand, joinTaskCommands } from "#src/lib/task/run-in-pane.js";
 import { runTaskWithDeps } from "#src/lib/task/runner.js";
-import { newWindow, sendKeys, splitPane } from "#src/lib/tmux.js";
 
 function send(socket: Socket, msg: object): void {
   socket.write(`${JSON.stringify(msg)}\n`);
@@ -354,6 +353,7 @@ export const sessionHandlers: Record<
           ),
           projectDir: session.config.projectDir,
           services: session.config.project.services,
+          tmux: session.tmux,
           onLine: (_taskKey, line) => {
             session.taskOutput.append(runId, line);
             send(socket, { id: req.id, event: "line", data: line });
@@ -430,8 +430,8 @@ export const sessionHandlers: Record<
     try {
       paneId =
         target === "pane"
-          ? await splitPane(session.paneMap["@tui"] ?? session.originPane, "v")
-          : await newWindow(session.tmuxSession);
+          ? await session.tmux.splitPane(session.paneMap["@tui"] ?? session.originPane, "v")
+          : await session.tmux.newWindow(session.tmuxSession);
     } catch {
       return ipcErr(req.id, "tmux_failed");
     }
@@ -477,7 +477,7 @@ export const sessionHandlers: Record<
       runId,
     });
     try {
-      await sendKeys(paneId, command);
+      await session.tmux.sendKeys(paneId, command);
     } catch {
       session.paneRunInfo.delete(runId);
       session.taskOutput.finish(runId, "error", Date.now());

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
 
 import {
   IdleTimer,
@@ -19,6 +20,21 @@ import { DaemonServer } from "#src/daemon/server.js";
 import { registerShutdownHook } from "#src/daemon/shutdown.js";
 
 const IDLE_TIMEOUT_MS = 30_000;
+
+/**
+ * Working directory for the detached daemon. The invoking CLI's cwd is a project
+ * dir that can be deleted while the daemon outlives it — on Linux every later
+ * `spawn()` from a deleted cwd then fails with ENOENT (observed: a lingering
+ * daemon whose tmux calls all died). Home (or `/`) is stable.
+ */
+function daemonSpawnCwd(): string {
+  try {
+    const home = os.homedir();
+    return home && fs.existsSync(home) ? home : "/";
+  } catch {
+    return "/";
+  }
+}
 
 async function pingSocket(sock: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -278,6 +294,7 @@ async function ensureDaemon(command: { file: string; args: string[] }): Promise<
       detached: true,
       stdio: ["ignore", logFile, logFile],
       env: childEnv,
+      cwd: daemonSpawnCwd(),
     });
 
     // Capture a spawn failure (e.g. ENOENT) so it surfaces as a clear error

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -123,6 +123,15 @@ async function runDaemon(): Promise<void> {
   delete process.env.ZAPS_TMUX_SOCKET;
   delete process.env.TMUX;
 
+  // Same protection `ensureDaemon` gives the spawned path: never hold the
+  // Invoking project dir open, since deleting it makes every later spawn() fail
+  // With ENOENT. Matters for a manually started `zaps daemon run`.
+  try {
+    process.chdir(daemonSpawnCwd());
+  } catch {
+    // Unusable stable dir — keep the inherited cwd rather than refusing to boot.
+  }
+
   writePid();
 
   const logFile = fs.openSync(logPath(), "a");

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -122,6 +122,7 @@ async function runDaemon(): Promise<void> {
   // It (50_api sanitization rule). `ensureDaemon` strips these too.
   delete process.env.ZAPS_TMUX_SOCKET;
   delete process.env.TMUX;
+  delete process.env.TMUX_PANE;
 
   // Same protection `ensureDaemon` gives the spawned path: never hold the
   // Invoking project dir open, since deleting it makes every later spawn() fail
@@ -299,6 +300,7 @@ async function ensureDaemon(command: { file: string; args: string[] }): Promise<
     const childEnv: NodeJS.ProcessEnv = { ...process.env, ZAPS_COMMAND: zapsCommand };
     delete childEnv.ZAPS_TMUX_SOCKET;
     delete childEnv.TMUX;
+    delete childEnv.TMUX_PANE;
     const child = spawn(command.file, [...command.args, "daemon", "run"], {
       detached: true,
       stdio: ["ignore", logFile, logFile],

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -101,6 +101,12 @@ function createShutdownAll(
  * Run the daemon in the current process (called after fork+detach).
  */
 async function runDaemon(): Promise<void> {
+  // Socket selection is per-session only: a daemon started from inside a managed
+  // Tmux must never inherit that socket and route every session's tmux calls to
+  // It (50_api sanitization rule). `ensureDaemon` strips these too.
+  delete process.env.ZAPS_TMUX_SOCKET;
+  delete process.env.TMUX;
+
   writePid();
 
   const logFile = fs.openSync(logPath(), "a");
@@ -263,10 +269,15 @@ async function ensureDaemon(command: { file: string; args: string[] }): Promise<
   try {
     const logFile = fs.openSync(logPath(), "a");
     const zapsCommand = [command.file, ...command.args].join(" ");
+    // Strip the caller's tmux context: the daemon picks a socket per session via
+    // `tmuxFor(session.tmuxSocket)`, never from its own env (50_api).
+    const childEnv: NodeJS.ProcessEnv = { ...process.env, ZAPS_COMMAND: zapsCommand };
+    delete childEnv.ZAPS_TMUX_SOCKET;
+    delete childEnv.TMUX;
     const child = spawn(command.file, [...command.args, "daemon", "run"], {
       detached: true,
       stdio: ["ignore", logFile, logFile],
-      env: { ...process.env, ZAPS_COMMAND: zapsCommand },
+      env: childEnv,
     });
 
     // Capture a spawn failure (e.g. ENOENT) so it surfaces as a clear error

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -9,8 +9,8 @@ import type { IpcRequest, IpcResponse } from "#src/lib/ipc/protocol.js";
 import { checkPortPreflight } from "#src/lib/port-preflight.js";
 import { detectPorts, detectPortsForPid, getDescendantPids } from "#src/lib/port.js";
 import type { ExecInfo } from "#src/lib/service/types.js";
-import { defaultTmux } from "#src/lib/tmux-default.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
+import { tmuxFor } from "#src/lib/tmux.js";
 
 import { DetachedRegistry } from "./detached-registry.js";
 import { daemonHandlers } from "./handlers/daemon.js";
@@ -25,6 +25,10 @@ interface CreateParams {
   projectDir: string;
   tmuxSession: string;
   originPane: string;
+  /** Tmux socket hosting the session; omitted/null = the user's default server. */
+  tmuxSocket?: string | null;
+  /** True when zaps owns the hosting tmux session. Validated at the IPC boundary. */
+  managedTmux?: boolean;
 }
 
 interface SessionStore {
@@ -161,7 +165,10 @@ class DaemonServer implements SessionStore {
 
   private async buildSession(id: string, params: CreateParams): Promise<Session> {
     // Every tmux command for this session goes through one socket-bound handle.
-    const tmux = defaultTmux;
+    // The Session builds an identical one from `tmuxSocket`; this one covers the
+    // Layout build that has to happen before the Session exists.
+    const tmuxSocket = params.tmuxSocket ?? null;
+    const tmux = tmuxFor(tmuxSocket);
 
     // Load config
     const config = await loadConfig(params.configPath, params.projectDir);
@@ -206,6 +213,7 @@ class DaemonServer implements SessionStore {
       getWindowName: tmux.getWindowName,
       getWindowOption: tmux.getWindowOption,
       setWindowOption: tmux.setWindowOption,
+      displayPopup: tmux.displayPopup,
       exec: async (cmd: string, args: string[], cwd?: string) => {
         await execFileAsync(cmd, args, cwd ? { cwd } : {});
       },
@@ -247,7 +255,8 @@ class DaemonServer implements SessionStore {
       tmuxSession: params.tmuxSession,
       originPane: params.originPane,
       deps,
-      tmux,
+      tmuxSocket,
+      managedTmux: params.managedTmux ?? false,
     };
 
     const session = new Session(sessionParams, manager);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -9,21 +9,8 @@ import type { IpcRequest, IpcResponse } from "#src/lib/ipc/protocol.js";
 import { checkPortPreflight } from "#src/lib/port-preflight.js";
 import { detectPorts, detectPortsForPid, getDescendantPids } from "#src/lib/port.js";
 import type { ExecInfo } from "#src/lib/service/types.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
-import {
-  capturePane,
-  getWindowName,
-  getWindowOption,
-  killPane,
-  paneExists,
-  panePid,
-  renameWindow,
-  resyncPaneSizes,
-  selectPane,
-  sendCtrlC,
-  sendKeys,
-  setWindowOption,
-} from "#src/lib/tmux.js";
 
 import { DetachedRegistry } from "./detached-registry.js";
 import { daemonHandlers } from "./handlers/daemon.js";
@@ -160,7 +147,7 @@ class DaemonServer implements SessionStore {
       const existing = this.sessions.get(id);
       if (existing) {
         const tuiPane = existing.paneMap["@tui"];
-        if (tuiPane && (await paneExists(tuiPane))) {
+        if (tuiPane && (await existing.tmux.paneExists(tuiPane))) {
           return existing;
         }
         // The tmux window was closed externally — full teardown, then rebuild.
@@ -173,6 +160,9 @@ class DaemonServer implements SessionStore {
   }
 
   private async buildSession(id: string, params: CreateParams): Promise<Session> {
+    // Every tmux command for this session goes through one socket-bound handle.
+    const tmux = defaultTmux;
+
     // Load config
     const config = await loadConfig(params.configPath, params.projectDir);
 
@@ -188,23 +178,23 @@ class DaemonServer implements SessionStore {
       config.project.layout,
       config.project.services,
       config.groups,
-      { skip },
+      { skip, tmux },
     );
     // Splitting panes off @tui can leave its kernel pty winsize stale at the
     // Pre-split width, garbling the in-process TUI until a manual resize. Force
     // Tmux to re-push every pane's winsize now that the layout is final.
-    await resyncPaneSizes(paneMap["@tui"] ?? focusPane);
-    await selectPane(focusPane);
+    await tmux.resyncPaneSizes(paneMap["@tui"] ?? focusPane);
+    await tmux.selectPane(focusPane);
 
     // Late-bound ref so storeExecInfo closure can capture session before it's created
     const ref: { session: Session | null } = { session: null };
     const deps = {
-      sendKeys,
-      sendCtrlC,
-      panePid,
-      detectPorts,
+      sendKeys: tmux.sendKeys,
+      sendCtrlC: tmux.sendCtrlC,
+      panePid: tmux.panePid,
+      detectPorts: async (paneTarget: string) => detectPorts(paneTarget, tmux),
       detectPortsForPid,
-      capturePane,
+      capturePane: tmux.capturePane,
       getDescendantPids,
       recordDetached: (pid: number) => {
         this.detachedRegistry.record(pid);
@@ -212,10 +202,10 @@ class DaemonServer implements SessionStore {
       removeDetached: (pid: number) => {
         this.detachedRegistry.remove(pid);
       },
-      renameWindow,
-      getWindowName,
-      getWindowOption,
-      setWindowOption,
+      renameWindow: tmux.renameWindow,
+      getWindowName: tmux.getWindowName,
+      getWindowOption: tmux.getWindowOption,
+      setWindowOption: tmux.setWindowOption,
       exec: async (cmd: string, args: string[], cwd?: string) => {
         await execFileAsync(cmd, args, cwd ? { cwd } : {});
       },
@@ -257,6 +247,7 @@ class DaemonServer implements SessionStore {
       tmuxSession: params.tmuxSession,
       originPane: params.originPane,
       deps,
+      tmux,
     };
 
     const session = new Session(sessionParams, manager);
@@ -286,7 +277,7 @@ class DaemonServer implements SessionStore {
     // Kill non-origin, non-TUI panes
     for (const paneId of Object.values(session.paneMap)) {
       if (paneId !== session.originPane && paneId !== session.paneMap["@tui"]) {
-        await killPane(paneId).catch(() => {
+        await session.tmux.killPane(paneId).catch(() => {
           /* Best-effort cleanup */
         });
       }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -39,6 +39,30 @@ interface SessionStore {
   destroy(id: string): Promise<void>;
 }
 
+/**
+ * A cache hit must not silently hand back a session living somewhere else: the
+ * caller's panes, ports and teardown all assume the socket it asked for. Two
+ * zaps in different tmux contexts (personal vs managed) sharing a config path
+ * would otherwise "succeed" and then drive tmux commands at the wrong server.
+ */
+function describeTmuxContext(socket: string | null, managed: boolean): string {
+  const where = socket === null ? "the default tmux server" : `tmux socket '${socket}'`;
+  return managed ? `${where} (managed)` : where;
+}
+
+function assertSameTmuxContext(existing: Session, params: CreateParams): void {
+  const requestedSocket = params.tmuxSocket ?? null;
+  const requestedManaged = params.managedTmux === true;
+  if (existing.tmuxSocket === requestedSocket && existing.managedTmux === requestedManaged) {
+    return;
+  }
+  throw new Error(
+    `Session already running on ${describeTmuxContext(existing.tmuxSocket, existing.managedTmux)}; ` +
+      `this request asked for ${describeTmuxContext(requestedSocket, requestedManaged)}. ` +
+      `Run zaps down first.`,
+  );
+}
+
 class DaemonServer implements SessionStore {
   private server: net.Server | null = null;
   private readonly sessions = new Map<string, Session>();
@@ -150,6 +174,7 @@ class DaemonServer implements SessionStore {
     try {
       const existing = this.sessions.get(id);
       if (existing) {
+        assertSameTmuxContext(existing, params);
         const tuiPane = existing.paneMap["@tui"];
         if (tuiPane && (await existing.tmux.paneExists(tuiPane))) {
           return existing;

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -10,9 +10,9 @@ import type { ServiceManager, ServiceManagerDeps } from "#src/lib/service/manage
 import type { ExecInfo, ServiceStatus } from "#src/lib/service/types.js";
 import type { PaneRunInfo } from "#src/lib/task/run-in-pane.js";
 import { getTaskShortcuts } from "#src/lib/taskShortcuts.js";
-import { defaultTmux } from "#src/lib/tmux-default.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
 import { LayoutReflow } from "#src/lib/tmux-reflow.js";
+import { tmuxFor } from "#src/lib/tmux.js";
 import type { TmuxHandle } from "#src/lib/tmux.js";
 
 import { LogBuffer } from "./log-buffer.js";
@@ -95,8 +95,10 @@ export interface SessionCreateParams {
   tmuxSession: string;
   originPane: string;
   deps: ServiceManagerDeps;
-  /** Tmux surface bound to this session's server socket; defaults to the env-based handle. */
-  tmux?: TmuxHandle;
+  /** Tmux server socket hosting this session (`null` = the user's default server). */
+  tmuxSocket: string | null;
+  /** True when zaps spawned and owns the tmux session (teardown kills it). */
+  managedTmux: boolean;
 }
 
 export function sessionId(configPath: string): string {
@@ -122,6 +124,10 @@ export class Session {
   /** Retained per-run task output for post-mortem inspection (`tasks.output`). */
   public readonly taskOutput = new TaskOutputStore();
   public readonly deps: ServiceManagerDeps;
+  /** Tmux server socket hosting this session (`null` = the user's default server). */
+  public readonly tmuxSocket: string | null;
+  /** True when zaps spawned and owns the tmux session (teardown kills it). */
+  public readonly managedTmux: boolean;
   /** Every tmux command for this session runs through this socket-bound handle. */
   public readonly tmux: TmuxHandle;
 
@@ -179,7 +185,9 @@ export class Session {
     this.tmuxSession = params.tmuxSession;
     this.originPane = params.originPane;
     this.deps = params.deps;
-    this.tmux = params.tmux ?? defaultTmux;
+    this.tmuxSocket = params.tmuxSocket;
+    this.managedTmux = params.managedTmux;
+    this.tmux = tmuxFor(this.tmuxSocket);
     this.manager = manager;
     this.configLoadedAt = Date.now();
 
@@ -727,6 +735,7 @@ export class Session {
       name: this.name,
       paneMap: this.paneMap,
       tmuxSession: this.tmuxSession,
+      managed: this.managedTmux,
       originPane: this.originPane,
       statuses: this.manager.getAllStatuses(),
       logSnapshots,
@@ -758,6 +767,8 @@ export interface SessionSnapshot {
   name: string;
   paneMap: PaneMap;
   tmuxSession: string;
+  /** True when zaps owns the hosting tmux session (managed-tmux mode). */
+  managed: boolean;
   originPane: string;
   statuses: ServiceStatus[];
   logSnapshots: Record<string, string[]>;

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -10,9 +10,10 @@ import type { ServiceManager, ServiceManagerDeps } from "#src/lib/service/manage
 import type { ExecInfo, ServiceStatus } from "#src/lib/service/types.js";
 import type { PaneRunInfo } from "#src/lib/task/run-in-pane.js";
 import { getTaskShortcuts } from "#src/lib/taskShortcuts.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
 import { LayoutReflow } from "#src/lib/tmux-reflow.js";
-import { killPane } from "#src/lib/tmux.js";
+import type { TmuxHandle } from "#src/lib/tmux.js";
 
 import { LogBuffer } from "./log-buffer.js";
 import { LogMonitor } from "./log-monitor.js";
@@ -94,6 +95,8 @@ export interface SessionCreateParams {
   tmuxSession: string;
   originPane: string;
   deps: ServiceManagerDeps;
+  /** Tmux surface bound to this session's server socket; defaults to the env-based handle. */
+  tmux?: TmuxHandle;
 }
 
 export function sessionId(configPath: string): string {
@@ -119,6 +122,8 @@ export class Session {
   /** Retained per-run task output for post-mortem inspection (`tasks.output`). */
   public readonly taskOutput = new TaskOutputStore();
   public readonly deps: ServiceManagerDeps;
+  /** Every tmux command for this session runs through this socket-bound handle. */
+  public readonly tmux: TmuxHandle;
 
   public name: string;
   public config: ResolvedConfig;
@@ -174,6 +179,7 @@ export class Session {
     this.tmuxSession = params.tmuxSession;
     this.originPane = params.originPane;
     this.deps = params.deps;
+    this.tmux = params.tmux ?? defaultTmux;
     this.manager = manager;
     this.configLoadedAt = Date.now();
 
@@ -190,6 +196,7 @@ export class Session {
     // Bind through `this` for the same reason — they re-read `this.logMonitor`
     // And the log maps fresh on every fire, never closing over stale instances.
     this.reflow = new LayoutReflow({
+      tmux: this.tmux,
       getLayout: () => this.config.project.layout,
       getPaneMap: () => this.paneMap,
       getWindowTarget: () => this.tmuxSession,
@@ -410,7 +417,7 @@ export class Session {
         newConfig.project.layout,
         newConfig.project.services,
         newConfig.groups,
-        { reserveTuiPane: true, skip },
+        { reserveTuiPane: true, skip, tmux: this.tmux },
       );
       return paneMap;
     } catch (error) {
@@ -442,7 +449,7 @@ export class Session {
     const tuiPaneId = this.paneMap["@tui"];
     for (const [name, paneId] of Object.entries(this.paneMap)) {
       if (name !== "@tui") {
-        await killPane(paneId).catch(() => {
+        await this.tmux.killPane(paneId).catch(() => {
           /* Best-effort cleanup */
         });
       }

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -527,7 +527,34 @@ export class Session {
         sock.destroy();
       }
       this.subscribers.clear();
+
+      await this.killManagedTmuxSession();
     });
+  }
+
+  /**
+   * Kill the tmux session zaps owns, once its services are stopped (F5).
+   *
+   * Only for managed sessions, only by exact name, and only on this session's
+   * own socket handle — a session living in the user's tmux is never killed, and
+   * `kill-server` is never issued, so a sibling managed project on the same
+   * socket survives untouched (the tmux server exits by itself with its last
+   * session). An already-gone session is logged, not fatal: the post-condition
+   * ("no managed tmux session left") holds either way.
+   */
+  private async killManagedTmuxSession(): Promise<void> {
+    if (!this.managedTmux) {
+      return;
+    }
+    try {
+      await this.tmux.killSession(this.tmuxSession);
+    } catch (error) {
+      process.stderr.write(
+        `Managed tmux session ${this.tmuxSession} could not be killed (already gone?): ${
+          error instanceof Error ? error.message : String(error)
+        }\n`,
+      );
+    }
   }
 
   /**

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -12,7 +12,7 @@ import type { PaneRunInfo } from "#src/lib/task/run-in-pane.js";
 import { getTaskShortcuts } from "#src/lib/taskShortcuts.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
 import { LayoutReflow } from "#src/lib/tmux-reflow.js";
-import { tmuxFor } from "#src/lib/tmux.js";
+import { exactWindowTarget, tmuxFor } from "#src/lib/tmux.js";
 import type { TmuxHandle } from "#src/lib/tmux.js";
 
 import { LogBuffer } from "./log-buffer.js";
@@ -207,7 +207,10 @@ export class Session {
       tmux: this.tmux,
       getLayout: () => this.config.project.layout,
       getPaneMap: () => this.paneMap,
-      getWindowTarget: () => this.tmuxSession,
+      // `=name:` — exact session, its current window: every geometry command
+      // The reflow issues is window-scoped, and a bare name would prefix-match
+      // A longer-named session on the same server.
+      getWindowTarget: () => exactWindowTarget(this.tmuxSession),
       onPaneInserted: (name, paneId) => {
         this.allocatePaneLog(name, paneId);
         // Lazy panes are created/destroyed after the TUI captured its startup

--- a/src/lib/managed-detach.ts
+++ b/src/lib/managed-detach.ts
@@ -1,0 +1,46 @@
+import { getEnv } from "./env.js";
+import { detachClient } from "./tmux.js";
+
+interface DetachDeps {
+  /** `ZAPS_MANAGED_TMUX` — only `"1"` means "zaps owns this tmux session". */
+  managedEnv: string | undefined;
+  /** `TMUX_PANE` — the pane this process runs in, i.e. which client to detach. */
+  paneTarget: string | undefined;
+  detach: (paneTarget: string) => Promise<void>;
+}
+
+function defaultDeps(): DetachDeps {
+  return {
+    managedEnv: getEnv("ZAPS_MANAGED_TMUX"),
+    paneTarget: getEnv("TMUX_PANE"),
+    detach: detachClient,
+  };
+}
+
+/**
+ * Quit handling for a zaps-managed tmux session: detach the client so the user
+ * lands back in the plain shell they ran `zaps` from, instead of being left in
+ * a tmux session they never asked for. The TUI pane keeps `remain-on-exit on`
+ * (set at create), so it is held dead at its layout position for the re-attach
+ * revival while the services keep running.
+ *
+ * Returns true when a client was detached. In a personal tmux session — or with
+ * no pane to target — this is a no-op and today's quit path is untouched.
+ * Failures are swallowed on purpose: quitting must never be blocked by tmux.
+ */
+async function detachManagedClient(overrides: Partial<DetachDeps> = {}): Promise<boolean> {
+  const deps = { ...defaultDeps(), ...overrides };
+  if (deps.managedEnv !== "1" || !deps.paneTarget) {
+    return false;
+  }
+  try {
+    await deps.detach(deps.paneTarget);
+    return true;
+  } catch {
+    // Already detached, or tmux is gone: exiting is still the right next step.
+    return false;
+  }
+}
+
+export { detachManagedClient };
+export type { DetachDeps };

--- a/src/lib/managed-detach.ts
+++ b/src/lib/managed-detach.ts
@@ -4,15 +4,15 @@ import { detachClient } from "./tmux.js";
 interface DetachDeps {
   /** `ZAPS_MANAGED_TMUX` — only `"1"` means "zaps owns this tmux session". */
   managedEnv: string | undefined;
-  /** `TMUX_PANE` — the pane this process runs in, i.e. which client to detach. */
-  paneTarget: string | undefined;
-  detach: (paneTarget: string) => Promise<void>;
+  /** `TMUX` — present only inside tmux; it is what tmux resolves the client from. */
+  tmuxEnv: string | undefined;
+  detach: () => Promise<void>;
 }
 
 function defaultDeps(): DetachDeps {
   return {
     managedEnv: getEnv("ZAPS_MANAGED_TMUX"),
-    paneTarget: getEnv("TMUX_PANE"),
+    tmuxEnv: getEnv("TMUX"),
     detach: detachClient,
   };
 }
@@ -24,17 +24,17 @@ function defaultDeps(): DetachDeps {
  * (set at create), so it is held dead at its layout position for the re-attach
  * revival while the services keep running.
  *
- * Returns true when a client was detached. In a personal tmux session — or with
- * no pane to target — this is a no-op and today's quit path is untouched.
+ * Returns true when a client was detached. In a personal tmux session — or
+ * outside tmux entirely — this is a no-op and today's quit path is untouched.
  * Failures are swallowed on purpose: quitting must never be blocked by tmux.
  */
 async function detachManagedClient(overrides: Partial<DetachDeps> = {}): Promise<boolean> {
   const deps = { ...defaultDeps(), ...overrides };
-  if (deps.managedEnv !== "1" || !deps.paneTarget) {
+  if (deps.managedEnv !== "1" || !deps.tmuxEnv) {
     return false;
   }
   try {
-    await deps.detach(deps.paneTarget);
+    await deps.detach();
     return true;
   } catch {
     // Already detached, or tmux is gone: exiting is still the right next step.

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -4,7 +4,7 @@ import type { TmuxHandle } from "./tmux.js";
 /** Socket of the tmux server zaps owns. The user's own server is never touched. */
 const MANAGED_SOCKET = "zaps";
 
-/** Oldest tmux zaps supports (3.5a — the letter suffix is not part of the check). */
+/** Oldest tmux zaps supports (a release letter like 3.5a satisfies it). */
 const MIN_TMUX_VERSION = { major: 3, minor: 5 } as const;
 
 /** Longest sanitized project-name segment in a managed session name. */

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -233,6 +233,17 @@ const SETTLE_FORMAT = "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}";
 const MAX_PROBE_ERRORS = 3;
 
 /**
+ * Consecutive `1||` reads (dead, no status, no signal) tolerated before giving
+ * up. tmux marks the pane dead on pty EOF but reaps the child lazily — the
+ * process can sit as a zombie (parent: the tmux server) from milliseconds to
+ * indefinitely (verified live on 3.5a, 3.6a and 3.7c), and until the reap
+ * `#{pane_dead_status}` is unreadable. Callers must treat `unknown-status` as
+ * "exit code unknowable", not as failure — the bootstrap falls back to asking
+ * the daemon.
+ */
+const MAX_UNKNOWN_STATUS_READS = 20;
+
+/**
  * Poll `#{pane_dead}` until the bootstrap pane's command exits, then report the
  * inner exit code from `#{pane_dead_status}` (the pane must have
  * `remain-on-exit on`, else it vanishes and there is nothing left to read).
@@ -250,6 +261,7 @@ async function waitForPaneSettled(
   const { timeoutMs = 60_000, pollMs = 100, tmux = managedTmux() } = options;
   const deadline = Date.now() + timeoutMs;
   let probeErrors = 0;
+  let unknownStatusReads = 0;
 
   /* eslint-disable no-await-in-loop -- sequential polling is the point */
   while (Date.now() < deadline) {
@@ -274,7 +286,12 @@ async function waitForPaneSettled(
         if (!Number.isNaN(deadSignal)) {
           return { settled: true, exitCode: 128 + deadSignal };
         }
-        return { settled: false, reason: "unknown-status" };
+        unknownStatusReads += 1;
+        if (unknownStatusReads >= MAX_UNKNOWN_STATUS_READS) {
+          return { settled: false, reason: "unknown-status" };
+        }
+      } else {
+        unknownStatusReads = 0;
       }
     }
     await new Promise((resolve) => setTimeout(resolve, pollMs));

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -97,8 +97,22 @@ interface CreateArgsOptions {
   name: string;
   /** `-d`: create without attaching (the `up -d` path). */
   detach?: boolean;
-  /** The zaps invocation to run in the bootstrap pane, e.g. `["/usr/bin/zaps", "up"]`. */
-  zapsArgv: string[];
+  /**
+   * The zaps invocation for the bootstrap pane, e.g. `["/usr/bin/zaps", "up"]`.
+   * Omit to start the default shell — used by the detached path, which sets the
+   * pane options first and only then respawns the pane with the real command.
+   */
+  zapsArgv?: string[];
+  /**
+   * Extra `-e` session env on top of the two markers. Used to forward the
+   * daemon-locating vars so the inner zaps talks to the same daemon the outer
+   * one just consulted — a session created with `-e` does not inherit them from
+   * a tmux server that may long predate this process.
+   */
+  env?: Record<string, string>;
+  /** `-x`/`-y`: initial size, so panes are laid out at the real terminal size. */
+  width?: number;
+  height?: number;
 }
 
 /**
@@ -110,6 +124,9 @@ function buildCreateArgs(options: CreateArgsOptions): string[] {
   if (options.detach) {
     args.push("-d");
   }
+  if (options.width && options.height) {
+    args.push("-x", String(options.width), "-y", String(options.height));
+  }
   args.push(
     "-s",
     options.name,
@@ -117,9 +134,13 @@ function buildCreateArgs(options: CreateArgsOptions): string[] {
     `ZAPS_TMUX_SOCKET=${MANAGED_SOCKET}`,
     "-e",
     "ZAPS_MANAGED_TMUX=1",
-    "--",
-    ...options.zapsArgv,
   );
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    args.push("-e", `${key}=${value}`);
+  }
+  if (options.zapsArgv?.length) {
+    args.push("--", ...options.zapsArgv);
+  }
   return args;
 }
 
@@ -129,12 +150,23 @@ function buildAttachArgs(name: string): string[] {
 }
 
 /**
- * `tmux -L zaps respawn-pane -t <paneId> -- <zaps argv>` argv. The argv form is
- * mandatory: passing the command as one shell string misbehaved in live testing.
- * `paneId` must be a `%N` pane id — index targeting breaks under `pane-base-index`.
+ * `tmux -L zaps respawn-pane [-k] -t <paneId> -- <zaps argv>` argv. The argv form
+ * is mandatory: passing the command as one shell string misbehaved in live
+ * testing. `paneId` must be a `%N` pane id — index targeting breaks under
+ * `pane-base-index`. Pass `kill` when the pane is still ALIVE (bootstrap: the
+ * placeholder shell); tmux refuses to respawn a live pane without `-k`.
  */
-function buildRespawnArgs(paneId: string, zapsArgv: string[]): string[] {
-  return ["-L", MANAGED_SOCKET, "respawn-pane", "-t", paneId, "--", ...zapsArgv];
+function buildRespawnArgs(
+  paneId: string,
+  zapsArgv: string[],
+  options: { kill?: boolean } = {},
+): string[] {
+  const args = ["-L", MANAGED_SOCKET, "respawn-pane"];
+  if (options.kill) {
+    args.push("-k");
+  }
+  args.push("-t", paneId, "--", ...zapsArgv);
+  return args;
 }
 
 /**
@@ -158,7 +190,7 @@ function buildSetPaneOptionArgs(paneId: string, option: string, value: string): 
 /** Outcome of {@link waitForPaneSettled}. */
 type PaneSettlement =
   | { settled: true; exitCode: number }
-  | { settled: false; reason: "timeout" | "gone" };
+  | { settled: false; reason: "timeout" | "gone" | "unknown-status" };
 
 interface WaitForPaneSettledOptions {
   /** Give up after this long; the caller decides what a timeout means. */
@@ -168,11 +200,22 @@ interface WaitForPaneSettledOptions {
   tmux?: ManagedTmux;
 }
 
+/** Probe format: `|`-joined so an empty field survives the split. */
+const SETTLE_FORMAT = "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}";
+
+/** Consecutive probe errors tolerated before declaring the pane gone. */
+const MAX_PROBE_ERRORS = 3;
+
 /**
  * Poll `#{pane_dead}` until the bootstrap pane's command exits, then report the
  * inner exit code from `#{pane_dead_status}` (the pane must have
  * `remain-on-exit on`, else it vanishes and there is nothing left to read).
  * Bounded polling on a real condition — never a fixed sleep.
+ *
+ * A dead pane with no readable status is NEVER reported as exit 0: a pane killed
+ * by a signal exposes `#{pane_dead_signal}` instead, which maps to the usual
+ * `128 + signal`, and anything still unreadable settles as `unknown-status` so a
+ * SIGKILLed run can't be mistaken for success.
  */
 async function waitForPaneSettled(
   paneId: string,
@@ -180,21 +223,33 @@ async function waitForPaneSettled(
 ): Promise<PaneSettlement> {
   const { timeoutMs = 60_000, pollMs = 100, tmux = managedTmux() } = options;
   const deadline = Date.now() + timeoutMs;
+  let probeErrors = 0;
 
   /* eslint-disable no-await-in-loop -- sequential polling is the point */
   while (Date.now() < deadline) {
-    // Null signals the pane (or its session) disappeared — no exit code will
-    // Ever arrive, so stop polling for one.
-    const probe = await tmux
-      .displayMessage(paneId, "#{pane_dead} #{pane_dead_status}")
-      .catch(() => null);
+    // Null means this probe failed; only a RUN of failures means the pane (or
+    // Its session) is really gone — a single transient tmux error must not end
+    // The wait.
+    const probe = await tmux.displayMessage(paneId, SETTLE_FORMAT).catch(() => null);
     if (probe === null) {
-      return { settled: false, reason: "gone" };
-    }
-    const [dead, status] = probe.trim().split(/\s+/u);
-    if (dead === "1") {
-      const exitCode = Number.parseInt(status ?? "", 10);
-      return { settled: true, exitCode: Number.isNaN(exitCode) ? 0 : exitCode };
+      probeErrors += 1;
+      if (probeErrors >= MAX_PROBE_ERRORS) {
+        return { settled: false, reason: "gone" };
+      }
+    } else {
+      probeErrors = 0;
+      const [dead, status, signal] = probe.trim().split("|");
+      if (dead === "1") {
+        const exitCode = Number.parseInt(status ?? "", 10);
+        if (!Number.isNaN(exitCode)) {
+          return { settled: true, exitCode };
+        }
+        const deadSignal = Number.parseInt(signal ?? "", 10);
+        if (!Number.isNaN(deadSignal)) {
+          return { settled: true, exitCode: 128 + deadSignal };
+        }
+        return { settled: false, reason: "unknown-status" };
+      }
     }
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -1,0 +1,222 @@
+import { tmuxFor } from "./tmux.js";
+import type { TmuxHandle } from "./tmux.js";
+
+/** Socket of the tmux server zaps owns. The user's own server is never touched. */
+const MANAGED_SOCKET = "zaps";
+
+/** Oldest tmux zaps supports (3.5a — the letter suffix is not part of the check). */
+const MIN_TMUX_VERSION = { major: 3, minor: 5 } as const;
+
+/** Longest sanitized project-name segment in a managed session name. */
+const MAX_NAME_SEGMENT = 30;
+
+/** The tmux commands this module issues, always on {@link MANAGED_SOCKET}. */
+type ManagedTmux = Pick<
+  TmuxHandle,
+  "displayMessage" | "hasSession" | "killSession" | "tmuxVersion"
+>;
+
+/** Handle bound to the managed socket — never the env, never the default server. */
+function managedTmux(): ManagedTmux {
+  return tmuxFor(MANAGED_SOCKET);
+}
+
+/**
+ * Reduce a project name to the character set tmux accepts in a session name.
+ * tmux rejects `.` and `:` outright (they address windows/panes), so everything
+ * outside `[a-zA-Z0-9_-]` collapses to a single `-`. Lowercased and truncated so
+ * the name stays readable in `tmux ls`; an all-invalid name falls back to
+ * `project` rather than producing an empty segment.
+ */
+function sanitizeProjectName(projectName: string): string {
+  const sanitized = projectName
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_-]+/gu, "-")
+    .replaceAll(/-{2,}/gu, "-")
+    .replace(/^-+/u, "")
+    .replace(/-+$/u, "")
+    .slice(0, MAX_NAME_SEGMENT)
+    .replace(/-+$/u, "");
+  return sanitized || "project";
+}
+
+/**
+ * Deterministic managed session name: `zaps-<sanitized>-<sessionId>`. The
+ * `sessionId` (sha256 of the config path) keeps the name ↔ zaps session mapping
+ * 1:1, so two projects sharing a display name never collide.
+ */
+function managedSessionName(projectName: string, sessionIdValue: string): string {
+  return `zaps-${sanitizeProjectName(projectName)}-${sessionIdValue}`;
+}
+
+/** True when `name` exists on the managed server. */
+async function hasManagedSession(
+  name: string,
+  tmux: ManagedTmux = managedTmux(),
+): Promise<boolean> {
+  return tmux.hasSession(name);
+}
+
+/**
+ * Kill a managed session the daemon no longer knows about (F9). Callers MUST
+ * confirm via `session.list` that no live zaps session maps to `name` first —
+ * this only guarantees the target lives in the zaps-owned namespace on the
+ * zaps-owned socket. Returns true when a session was actually killed.
+ */
+async function killStaleSession(name: string, tmux: ManagedTmux = managedTmux()): Promise<boolean> {
+  try {
+    await tmux.killSession(name);
+    return true;
+  } catch {
+    // Already gone (or never existed) — the post-condition holds either way.
+    return false;
+  }
+}
+
+/** Result of the tmux presence + version gate; `reason` drives the F8 message. */
+type TmuxAvailability =
+  | { ok: true; version: string }
+  | { ok: false; reason: "missing" }
+  | { ok: false; reason: "too-old"; version: string };
+
+/** Tmux on PATH and new enough (>= {@link MIN_TMUX_VERSION}) to host a managed session. */
+async function tmuxAvailable(tmux: ManagedTmux = managedTmux()): Promise<TmuxAvailability> {
+  const version = await tmux.tmuxVersion();
+  if (!version) {
+    return { ok: false, reason: "missing" };
+  }
+  const label = `${version.major}.${version.minor}`;
+  const tooOld =
+    version.major < MIN_TMUX_VERSION.major ||
+    (version.major === MIN_TMUX_VERSION.major && version.minor < MIN_TMUX_VERSION.minor);
+  return tooOld ? { ok: false, reason: "too-old", version: label } : { ok: true, version: label };
+}
+
+interface CreateArgsOptions {
+  /** Managed session name from {@link managedSessionName}. */
+  name: string;
+  /** `-d`: create without attaching (the `up -d` path). */
+  detach?: boolean;
+  /** The zaps invocation to run in the bootstrap pane, e.g. `["/usr/bin/zaps", "up"]`. */
+  zapsArgv: string[];
+}
+
+/**
+ * `tmux -L zaps new-session …` argv. The two `-e` markers are what the inner
+ * zaps reads to route its tmux calls and to report `managedTmux` on create.
+ */
+function buildCreateArgs(options: CreateArgsOptions): string[] {
+  const args = ["-L", MANAGED_SOCKET, "new-session"];
+  if (options.detach) {
+    args.push("-d");
+  }
+  args.push(
+    "-s",
+    options.name,
+    "-e",
+    `ZAPS_TMUX_SOCKET=${MANAGED_SOCKET}`,
+    "-e",
+    "ZAPS_MANAGED_TMUX=1",
+    "--",
+    ...options.zapsArgv,
+  );
+  return args;
+}
+
+/** `tmux -L zaps attach-session -t <name>` argv. */
+function buildAttachArgs(name: string): string[] {
+  return ["-L", MANAGED_SOCKET, "attach-session", "-t", name];
+}
+
+/**
+ * `tmux -L zaps respawn-pane -t <paneId> -- <zaps argv>` argv. The argv form is
+ * mandatory: passing the command as one shell string misbehaved in live testing.
+ * `paneId` must be a `%N` pane id — index targeting breaks under `pane-base-index`.
+ */
+function buildRespawnArgs(paneId: string, zapsArgv: string[]): string[] {
+  return ["-L", MANAGED_SOCKET, "respawn-pane", "-t", paneId, "--", ...zapsArgv];
+}
+
+/**
+ * `tmux -L zaps set-option -t <name> <option> <value>` argv. Used at create for
+ * `destroy-unattached off`, which stops exotic user configs from killing the
+ * session (and its services) the moment the client detaches.
+ */
+function buildSetSessionOptionArgs(name: string, option: string, value: string): string[] {
+  return ["-L", MANAGED_SOCKET, "set-option", "-t", name, option, value];
+}
+
+/**
+ * `tmux -L zaps set-option -p -t <paneId> <option> <value>` argv. Pane-level
+ * (`-p`) so it wins over a global user setting — used for `remain-on-exit on`
+ * on the TUI pane, which holds the dead pane for re-attach revival.
+ */
+function buildSetPaneOptionArgs(paneId: string, option: string, value: string): string[] {
+  return ["-L", MANAGED_SOCKET, "set-option", "-p", "-t", paneId, option, value];
+}
+
+/** Outcome of {@link waitForPaneSettled}. */
+type PaneSettlement =
+  | { settled: true; exitCode: number }
+  | { settled: false; reason: "timeout" | "gone" };
+
+interface WaitForPaneSettledOptions {
+  /** Give up after this long; the caller decides what a timeout means. */
+  timeoutMs?: number;
+  /** Gap between `pane_dead` probes. */
+  pollMs?: number;
+  tmux?: ManagedTmux;
+}
+
+/**
+ * Poll `#{pane_dead}` until the bootstrap pane's command exits, then report the
+ * inner exit code from `#{pane_dead_status}` (the pane must have
+ * `remain-on-exit on`, else it vanishes and there is nothing left to read).
+ * Bounded polling on a real condition — never a fixed sleep.
+ */
+async function waitForPaneSettled(
+  paneId: string,
+  options: WaitForPaneSettledOptions = {},
+): Promise<PaneSettlement> {
+  const { timeoutMs = 60_000, pollMs = 100, tmux = managedTmux() } = options;
+  const deadline = Date.now() + timeoutMs;
+
+  /* eslint-disable no-await-in-loop -- sequential polling is the point */
+  while (Date.now() < deadline) {
+    // Null signals the pane (or its session) disappeared — no exit code will
+    // Ever arrive, so stop polling for one.
+    const probe = await tmux
+      .displayMessage(paneId, "#{pane_dead} #{pane_dead_status}")
+      .catch(() => null);
+    if (probe === null) {
+      return { settled: false, reason: "gone" };
+    }
+    const [dead, status] = probe.trim().split(/\s+/u);
+    if (dead === "1") {
+      const exitCode = Number.parseInt(status ?? "", 10);
+      return { settled: true, exitCode: Number.isNaN(exitCode) ? 0 : exitCode };
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  /* eslint-enable no-await-in-loop */
+
+  return { settled: false, reason: "timeout" };
+}
+
+export {
+  MANAGED_SOCKET,
+  MIN_TMUX_VERSION,
+  buildAttachArgs,
+  buildCreateArgs,
+  buildRespawnArgs,
+  buildSetPaneOptionArgs,
+  buildSetSessionOptionArgs,
+  hasManagedSession,
+  killStaleSession,
+  managedSessionName,
+  managedTmux,
+  sanitizeProjectName,
+  tmuxAvailable,
+  waitForPaneSettled,
+};
+export type { CreateArgsOptions, PaneSettlement, TmuxAvailability, WaitForPaneSettledOptions };

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -170,6 +170,15 @@ function buildRespawnArgs(
 }
 
 /**
+ * `tmux -L zaps new-window -t <name> -- <zaps argv>` argv. Fallback for the
+ * re-attach path when the TUI pane is gone entirely (user killed it by hand):
+ * a fresh window running `zaps attach` beats failing the command outright.
+ */
+function buildNewWindowArgs(name: string, zapsArgv: string[]): string[] {
+  return ["-L", MANAGED_SOCKET, "new-window", "-t", name, "--", ...zapsArgv];
+}
+
+/**
  * `tmux -L zaps set-option -t <name> <option> <value>` argv. Used at create for
  * `destroy-unattached off`, which stops exotic user configs from killing the
  * session (and its services) the moment the client detaches.
@@ -263,6 +272,7 @@ export {
   MIN_TMUX_VERSION,
   buildAttachArgs,
   buildCreateArgs,
+  buildNewWindowArgs,
   buildRespawnArgs,
   buildSetPaneOptionArgs,
   buildSetSessionOptionArgs,

--- a/src/lib/managed-tmux.ts
+++ b/src/lib/managed-tmux.ts
@@ -16,6 +16,15 @@ type ManagedTmux = Pick<
   "displayMessage" | "hasSession" | "killSession" | "tmuxVersion"
 >;
 
+/**
+ * `=name` — the exact-match form of a tmux session target. Without it tmux falls
+ * back to prefix (then fnmatch) matching, so a command aimed at a session that
+ * is already gone silently hits a longer-named neighbour on the same server.
+ */
+function exactSession(name: string): string {
+  return `=${name}`;
+}
+
 /** Handle bound to the managed socket — never the env, never the default server. */
 function managedTmux(): ManagedTmux {
   return tmuxFor(MANAGED_SOCKET);
@@ -144,9 +153,12 @@ function buildCreateArgs(options: CreateArgsOptions): string[] {
   return args;
 }
 
-/** `tmux -L zaps attach-session -t <name>` argv. */
+/**
+ * `tmux -L zaps attach-session -t =<name>` argv. The `=` forces an exact match:
+ * tmux would otherwise prefix-match the name and attach to a longer one.
+ */
 function buildAttachArgs(name: string): string[] {
-  return ["-L", MANAGED_SOCKET, "attach-session", "-t", name];
+  return ["-L", MANAGED_SOCKET, "attach-session", "-t", exactSession(name)];
 }
 
 /**
@@ -175,16 +187,21 @@ function buildRespawnArgs(
  * a fresh window running `zaps attach` beats failing the command outright.
  */
 function buildNewWindowArgs(name: string, zapsArgv: string[]): string[] {
-  return ["-L", MANAGED_SOCKET, "new-window", "-t", name, "--", ...zapsArgv];
+  return ["-L", MANAGED_SOCKET, "new-window", "-t", exactSession(name), "--", ...zapsArgv];
 }
 
 /**
- * `tmux -L zaps set-option -t <name> <option> <value>` argv. Used at create for
+ * `tmux -L zaps set-option -t =<name>: <option> <value>` argv. Used at create for
  * `destroy-unattached off`, which stops exotic user configs from killing the
  * session (and its services) the moment the client detaches.
+ *
+ * The target is `=<name>:` — with a trailing colon — because `set-option`
+ * resolves its `-t` as a pane target unless the spec names a window/session, and
+ * rejects a bare `=<name>` outright (`no such session: =name`). Verified live;
+ * the plain name would prefix-match and configure the wrong session.
  */
 function buildSetSessionOptionArgs(name: string, option: string, value: string): string[] {
-  return ["-L", MANAGED_SOCKET, "set-option", "-t", name, option, value];
+  return ["-L", MANAGED_SOCKET, "set-option", "-t", `${exactSession(name)}:`, option, value];
 }
 
 /**

--- a/src/lib/port.ts
+++ b/src/lib/port.ts
@@ -1,7 +1,11 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { panePid } from "./tmux.js";
+import { defaultTmux } from "./tmux-default.js";
+import type { TmuxHandle } from "./tmux.js";
+
+/** The tmux command port detection issues. */
+type PortTmux = Pick<TmuxHandle, "panePid">;
 
 const execFileAsync = promisify(execFile);
 
@@ -194,8 +198,11 @@ async function getListeningPortsImpl(pids: number[]): Promise<number[]> {
  * Detect listening ports for a tmux pane's process tree.
  * Returns deduplicated sorted port list.
  */
-async function detectPortsImpl(paneTarget: string): Promise<number[]> {
-  const rootPid = await panePid(paneTarget);
+async function detectPortsImpl(
+  paneTarget: string,
+  tmux: PortTmux = defaultTmux,
+): Promise<number[]> {
+  const rootPid = await tmux.panePid(paneTarget);
   const pids = await getDescendantPidsImpl(rootPid);
   const ports = await getListeningPortsImpl(pids);
   return [...new Set(ports)].toSorted((a, b) => a - b);

--- a/src/lib/port.ts
+++ b/src/lib/port.ts
@@ -1,7 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { defaultTmux } from "./tmux-default.js";
 import type { TmuxHandle } from "./tmux.js";
 
 /** The tmux command port detection issues. */
@@ -198,10 +197,7 @@ async function getListeningPortsImpl(pids: number[]): Promise<number[]> {
  * Detect listening ports for a tmux pane's process tree.
  * Returns deduplicated sorted port list.
  */
-async function detectPortsImpl(
-  paneTarget: string,
-  tmux: PortTmux = defaultTmux,
-): Promise<number[]> {
+async function detectPortsImpl(paneTarget: string, tmux: PortTmux): Promise<number[]> {
   const rootPid = await tmux.panePid(paneTarget);
   const pids = await getDescendantPidsImpl(rootPid);
   const ports = await getListeningPortsImpl(pids);

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -331,7 +331,7 @@ export class ServiceManager extends EventEmitter {
             statuses: this.statuses,
             projectDir: config.projectDir,
             services: config.project.services,
-            ...(this.deps.displayPopup ? { tmux: { displayPopup: this.deps.displayPopup } } : {}),
+            tmux: { displayPopup: this.deps.displayPopup },
             onLine: (_taskKey, line) => {
               this.emit("taskLine", runId, line);
             },
@@ -1589,7 +1589,7 @@ export interface ServiceManagerDeps {
   getWindowOption: (target: string, option: string) => Promise<string>;
   setWindowOption: (target: string, option: string, value: string) => Promise<void>;
   /** Popup surface for hook-path popup tasks; bound to the session's tmux socket. */
-  displayPopup?: (opts: DisplayPopupOptions) => Promise<void>;
+  displayPopup: (opts: DisplayPopupOptions) => Promise<void>;
   exec: (cmd: string, args: string[], cwd?: string) => Promise<void>;
   /** Pre-flight expected host ports; returns a conflict message or null (B2). */
   preflightPorts: (serviceConfig: ServiceConfig, projectDir: string) => Promise<string | null>;

--- a/src/lib/service/manager.ts
+++ b/src/lib/service/manager.ts
@@ -16,6 +16,7 @@ import { openInBrowser } from "#src/lib/open.js";
 import { probePort } from "#src/lib/probe.js";
 import { newRunId } from "#src/lib/task/run-id.js";
 import { runTaskWithDeps } from "#src/lib/task/runner.js";
+import type { DisplayPopupOptions } from "#src/lib/tmux.js";
 
 import { DetachedRunner } from "./detached.js";
 import type { SpawnFn } from "./detached.js";
@@ -330,6 +331,7 @@ export class ServiceManager extends EventEmitter {
             statuses: this.statuses,
             projectDir: config.projectDir,
             services: config.project.services,
+            ...(this.deps.displayPopup ? { tmux: { displayPopup: this.deps.displayPopup } } : {}),
             onLine: (_taskKey, line) => {
               this.emit("taskLine", runId, line);
             },
@@ -1586,6 +1588,8 @@ export interface ServiceManagerDeps {
   getWindowName: (target: string) => Promise<string>;
   getWindowOption: (target: string, option: string) => Promise<string>;
   setWindowOption: (target: string, option: string, value: string) => Promise<void>;
+  /** Popup surface for hook-path popup tasks; bound to the session's tmux socket. */
+  displayPopup?: (opts: DisplayPopupOptions) => Promise<void>;
   exec: (cmd: string, args: string[], cwd?: string) => Promise<void>;
   /** Pre-flight expected host ports; returns a conflict message or null (B2). */
   preflightPorts: (serviceConfig: ServiceConfig, projectDir: string) => Promise<string | null>;

--- a/src/lib/task/output-popup.ts
+++ b/src/lib/task/output-popup.ts
@@ -3,11 +3,15 @@ import os from "node:os";
 import path from "node:path";
 
 import { shellEscape } from "#src/lib/service/env.js";
-import { displayPopup, tmuxSupportsPopup } from "#src/lib/tmux.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
+import type { TmuxHandle } from "#src/lib/tmux.js";
+
+/** The tmux commands an output popup issues. */
+type PopupTmux = Pick<TmuxHandle, "displayPopup" | "tmuxSupportsPopup">;
 
 /** True when tmux supports `display-popup` (>= 3.2) — the escalation target (Q3). */
-export async function outputPopupAvailable(): Promise<boolean> {
-  return tmuxSupportsPopup();
+export async function outputPopupAvailable(tmux: PopupTmux = defaultTmux): Promise<boolean> {
+  return tmux.tmuxSupportsPopup();
 }
 
 /**
@@ -18,7 +22,11 @@ export async function outputPopupAvailable(): Promise<boolean> {
  * `less`. Everything runs under `sh -c` (fish-safe). The temp dir is always
  * cleaned up. Callers should gate on {@link outputPopupAvailable} first.
  */
-export async function showOutputPopup(title: string, lines: string[]): Promise<void> {
+export async function showOutputPopup(
+  title: string,
+  lines: string[],
+  tmux: PopupTmux = defaultTmux,
+): Promise<void> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "zaps-task-output-"));
   const file = path.join(dir, "output");
   try {
@@ -26,7 +34,7 @@ export async function showOutputPopup(title: string, lines: string[]): Promise<v
     const esc = shellEscape(file);
     // `less` for scrollback; if absent, print + pause so -EE doesn't close instantly.
     const viewer = `less -R ${esc} 2>/dev/null || { cat ${esc}; printf '\\n[press enter to close]'; read _; }`;
-    await displayPopup({
+    await tmux.displayPopup({
       command: `sh -c ${shellEscape(viewer)}`,
       title,
       width: "80%",

--- a/src/lib/task/popup-picker.ts
+++ b/src/lib/task/popup-picker.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 
 import { shellEscape } from "#src/lib/service/env.js";
-import { displayPopup, tmuxSupportsPopup } from "#src/lib/tmux.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
+import type { TmuxHandle } from "#src/lib/tmux.js";
+
+/** The tmux commands the picker popup issues. */
+type PopupTmux = Pick<TmuxHandle, "displayPopup" | "tmuxSupportsPopup">;
 
 /** Resolve true if `cmd --version` runs (a cheap presence probe). */
 async function binaryAvailable(cmd: string): Promise<boolean> {
@@ -26,6 +30,8 @@ export type PickerScriptBuilder = (inFile: string, outFile: string) => string;
 export interface PopupPickerOptions {
   /** Override the in-popup picker command — tests inject a non-interactive stub. */
   buildScript?: PickerScriptBuilder;
+  /** Tmux surface for the popup; defaults to the env-based handle. */
+  tmux?: PopupTmux;
 }
 
 /**
@@ -50,8 +56,8 @@ export function parseSelection(raw: string): string | null {
 }
 
 /** True when both tmux (>= 3.2, for `display-popup`) and `fzf` are available. */
-export async function popupPickerAvailable(): Promise<boolean> {
-  const [tmuxOk, fzfOk] = await Promise.all([tmuxSupportsPopup(), binaryAvailable("fzf")]);
+export async function popupPickerAvailable(tmux: PopupTmux = defaultTmux): Promise<boolean> {
+  const [tmuxOk, fzfOk] = await Promise.all([tmux.tmuxSupportsPopup(), binaryAvailable("fzf")]);
   return tmuxOk && fzfOk;
 }
 
@@ -66,13 +72,14 @@ export async function runPopupPicker(
   opts?: PopupPickerOptions,
 ): Promise<string | null> {
   const build = opts?.buildScript ?? buildFzfScript;
+  const tmux = opts?.tmux ?? defaultTmux;
   const dir = await mkdtemp(path.join(os.tmpdir(), "zaps-task-pick-"));
   const inFile = path.join(dir, "tasks");
   const outFile = path.join(dir, "selection");
   try {
     const lines = tasks.map((t) => `${t.key}\t${t.name}`).join("\n");
     await writeFile(inFile, `${lines}\n`, "utf8");
-    await displayPopup({
+    await tmux.displayPopup({
       command: `sh -c ${shellEscape(build(inFile, outFile))}`,
       title: "Run a task",
       width: "60%",

--- a/src/lib/task/runner.ts
+++ b/src/lib/task/runner.ts
@@ -2,7 +2,11 @@ import type { TaskConfig } from "#src/config/types.js";
 import { execCommand, execCommandWithResult } from "#src/lib/exec.js";
 import { buildServiceContext, resolveEnv } from "#src/lib/service/env.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
-import { displayPopup } from "#src/lib/tmux.js";
+import { defaultTmux } from "#src/lib/tmux-default.js";
+import type { TmuxHandle } from "#src/lib/tmux.js";
+
+/** The tmux command a popup task issues. */
+type RunnerTmux = Pick<TmuxHandle, "displayPopup">;
 
 interface TaskRunnerDeps {
   tasks: Record<string, TaskConfig>;
@@ -11,6 +15,8 @@ interface TaskRunnerDeps {
   services?: Record<string, { cwd?: string }>;
   onProgress?: (key: string, result: "success" | "error") => void;
   onLine?: (key: string, line: string) => void;
+  /** Tmux surface for popup tasks; defaults to the env-based handle. */
+  tmux?: RunnerTmux;
 }
 
 interface ExecuteContext {
@@ -20,6 +26,7 @@ interface ExecuteContext {
   emitLine: (line: string) => void;
   serviceCtx: ReturnType<typeof buildServiceContext>;
   projectDir: string;
+  tmux: RunnerTmux;
 }
 
 async function executeTask(t: TaskConfig, ctx: ExecuteContext): Promise<void> {
@@ -54,7 +61,7 @@ async function executeTask(t: TaskConfig, ctx: ExecuteContext): Promise<void> {
       const popupCfg = typeof t.popup === "object" ? t.popup : {};
       const joined = resolvedCommands.join(" && ");
       const wrapped = `${joined}; echo; echo 'Press Enter to close...'; read`;
-      await displayPopup({
+      await ctx.tmux.displayPopup({
         cwd: ctx.taskCwd,
         command: wrapped,
         title: t.name,
@@ -120,6 +127,7 @@ export async function runTaskWithDeps(
       emitLine,
       serviceCtx,
       projectDir: deps.projectDir,
+      tmux: deps.tmux ?? defaultTmux,
     });
   } catch {
     results.set(key, "error");

--- a/src/lib/tmux-default.ts
+++ b/src/lib/tmux-default.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line import/no-namespace -- the module surface IS the env-based handle; a namespace binding keeps lookups lazy
+import * as tmux from "./tmux.js";
+import type { TmuxHandle } from "./tmux.js";
+
+/**
+ * Handle bound to the socket in `ZAPS_TMUX_SOCKET` (default server when unset),
+ * i.e. the module-level exports. Used wherever no socket-bound handle is passed
+ * in, so consumers never read the env themselves.
+ */
+export const defaultTmux: TmuxHandle = tmux;

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -1,7 +1,6 @@
 import type { LayoutLeaf, LayoutNode, LayoutSplit, ServiceConfig } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
-import { defaultTmux } from "./tmux-default.js";
 import type { TmuxHandle } from "./tmux.js";
 
 type PaneMap = Record<string, string>;
@@ -512,12 +511,12 @@ export async function createLayout(
   startPaneId: string,
   layout: LayoutNode | undefined,
   services: Record<string, ServiceConfig>,
-  groups?: Map<string, string[]>,
-  options?: { reserveTuiPane?: boolean; skip?: Set<string>; tmux?: LayoutTmux },
+  groups: Map<string, string[]> | undefined,
+  options: { reserveTuiPane?: boolean; skip?: Set<string>; tmux: LayoutTmux },
 ): Promise<{ paneMap: PaneMap; focusPane: string }> {
-  const reserveTuiPane = options?.reserveTuiPane ?? false;
-  const tmux = options?.tmux ?? defaultTmux;
-  const skip = options?.skip;
+  const reserveTuiPane = options.reserveTuiPane ?? false;
+  const { tmux } = options;
+  const { skip } = options;
   const hasSkip = skip !== undefined && skip.size > 0;
   const paneMap: PaneMap = {};
   // Pane-less lazy services don't get a leftover-pane split. `skip` is pre-

--- a/src/lib/tmux-layout.ts
+++ b/src/lib/tmux-layout.ts
@@ -1,9 +1,13 @@
 import type { LayoutLeaf, LayoutNode, LayoutSplit, ServiceConfig } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
-import { killPane, splitPane } from "./tmux.js";
+import { defaultTmux } from "./tmux-default.js";
+import type { TmuxHandle } from "./tmux.js";
 
 type PaneMap = Record<string, string>;
+
+/** The tmux commands a layout build issues. */
+type LayoutTmux = Pick<TmuxHandle, "killPane" | "splitPane">;
 
 function collectPaneNames(node: LayoutNode): string[] {
   if (isLayoutLeaf(node)) {
@@ -54,6 +58,7 @@ async function walkLayout(
   currentPaneId: string,
   paneMap: PaneMap,
   createdPanes: string[],
+  tmux: LayoutTmux,
 ): Promise<string> {
   if (isLayoutLeaf(node)) {
     paneMap[node.pane] = currentPaneId;
@@ -92,7 +97,7 @@ async function walkLayout(
       const tmuxPercent =
         parentRemaining > 0 ? Math.round((childRemaining / parentRemaining) * 100) : 0;
 
-      const newPaneId = await splitPane(splitTarget, dir, { percent: tmuxPercent });
+      const newPaneId = await tmux.splitPane(splitTarget, dir, { percent: tmuxPercent });
       createdPanes.push(newPaneId);
       paneIds.push(newPaneId);
       splitTarget = newPaneId;
@@ -102,7 +107,7 @@ async function walkLayout(
     // Recurse into each child (must be sequential for tmux ordering)
     let focusPane = "";
     for (let i = 0; i < children.length; i += 1) {
-      const result = await walkLayout(children[i], paneIds[i], paneMap, createdPanes);
+      const result = await walkLayout(children[i], paneIds[i], paneMap, createdPanes, tmux);
       if (result) {
         focusPane = result;
       }
@@ -143,8 +148,12 @@ function expandGroupPanes(paneMap: PaneMap, groups: Map<string, string[]>): void
 }
 
 /** Split a vertical pane off `startPaneId`, recording it for rollback. */
-async function splitTracked(startPaneId: string, createdPanes: string[]): Promise<string> {
-  const paneId = await splitPane(startPaneId, "v");
+async function splitTracked(
+  startPaneId: string,
+  createdPanes: string[],
+  tmux: LayoutTmux,
+): Promise<string> {
+  const paneId = await tmux.splitPane(startPaneId, "v");
   createdPanes.push(paneId);
   return paneId;
 }
@@ -168,12 +177,13 @@ async function mapUnreferencedGroups(
   groups: Map<string, string[]>,
   paneMap: PaneMap,
   createdPanes: string[],
+  tmux: LayoutTmux,
 ): Promise<void> {
   for (const [groupName, children] of groups) {
     if (groupName in paneMap) {
       continue;
     }
-    const paneId = await splitTracked(startPaneId, createdPanes);
+    const paneId = await splitTracked(startPaneId, createdPanes, tmux);
     paneMap[groupName] = paneId;
     for (const child of children) {
       paneMap[child] = paneId;
@@ -189,10 +199,11 @@ async function mapLeftoverServices(
   groupChildNames: Set<string>,
   paneMap: PaneMap,
   createdPanes: string[],
+  tmux: LayoutTmux,
 ): Promise<void> {
   for (const name of serviceNames) {
     if (!services[name].detached && !groupChildNames.has(name) && !(name in paneMap)) {
-      paneMap[name] = await splitTracked(startPaneId, createdPanes);
+      paneMap[name] = await splitTracked(startPaneId, createdPanes, tmux);
     }
   }
 }
@@ -502,9 +513,10 @@ export async function createLayout(
   layout: LayoutNode | undefined,
   services: Record<string, ServiceConfig>,
   groups?: Map<string, string[]>,
-  options?: { reserveTuiPane?: boolean; skip?: Set<string> },
+  options?: { reserveTuiPane?: boolean; skip?: Set<string>; tmux?: LayoutTmux },
 ): Promise<{ paneMap: PaneMap; focusPane: string }> {
   const reserveTuiPane = options?.reserveTuiPane ?? false;
+  const tmux = options?.tmux ?? defaultTmux;
   const skip = options?.skip;
   const hasSkip = skip !== undefined && skip.size > 0;
   const paneMap: PaneMap = {};
@@ -523,7 +535,7 @@ export async function createLayout(
       // Case 1: No layout — @tui gets the start pane, each service/group a split.
       paneMap["@tui"] = startPaneId;
       if (groups) {
-        await mapUnreferencedGroups(startPaneId, groups, paneMap, createdPanes);
+        await mapUnreferencedGroups(startPaneId, groups, paneMap, createdPanes, tmux);
       }
       await mapLeftoverServices(
         startPaneId,
@@ -532,6 +544,7 @@ export async function createLayout(
         groupChildNames,
         paneMap,
         createdPanes,
+        tmux,
       );
       return { paneMap, focusPane: paneMap["@tui"] };
     }
@@ -558,7 +571,7 @@ export async function createLayout(
       );
     }
 
-    const focusName = await walkLayout(bootLayout, startPaneId, paneMap, createdPanes);
+    const focusName = await walkLayout(bootLayout, startPaneId, paneMap, createdPanes, tmux);
 
     if (reserveTuiPane) {
       reserveStartPaneForTui(bootLayout, startPaneId, paneMap);
@@ -568,7 +581,7 @@ export async function createLayout(
       // Referenced groups: map members to the group's pane; unreferenced: one
       // Shared pane each (E10).
       expandGroupPanes(paneMap, groups);
-      await mapUnreferencedGroups(startPaneId, groups, paneMap, createdPanes);
+      await mapUnreferencedGroups(startPaneId, groups, paneMap, createdPanes, tmux);
     }
 
     await mapLeftoverServices(
@@ -578,6 +591,7 @@ export async function createLayout(
       groupChildNames,
       paneMap,
       createdPanes,
+      tmux,
     );
 
     return { paneMap, focusPane: (focusName && paneMap[focusName]) || paneMap["@tui"] };
@@ -585,7 +599,7 @@ export async function createLayout(
     // Best-effort: tear down every pane this call created so a failed
     // Create/reload never leaves a half-built layout behind (E15).
     for (const paneId of createdPanes) {
-      await killPane(paneId).catch(() => {
+      await tmux.killPane(paneId).catch(() => {
         /* Swallow — cleanup is best-effort */
       });
     }

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -1,7 +1,6 @@
 import type { LayoutLeaf, LayoutNode } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
-import { defaultTmux } from "./tmux-default.js";
 import {
   PaneTooSmallError,
   computeRects,
@@ -62,7 +61,7 @@ type PaneMap = Record<string, string>;
  */
 interface LayoutReflowDeps {
   /** Socket-bound tmux surface; per-command overrides below still win. */
-  tmux?: ReflowTmux;
+  tmux: ReflowTmux;
   /** The declared layout tree (may be undefined when the project has no layout). */
   getLayout: () => LayoutNode | undefined;
   /** Live name → pane-id map; mutated by insert/remove, replaced by reload. */
@@ -244,8 +243,8 @@ class LayoutReflow {
 
   public constructor(deps: LayoutReflowDeps) {
     this.deps = deps;
-    // Socket-bound handle (env-based default); tests override any subset via deps.
-    const tmux = deps.tmux ?? defaultTmux;
+    // Socket-bound handle; tests override any subset via the per-command deps.
+    const { tmux } = deps;
     this.tmux = {
       getWindowSize: deps.getWindowSize ?? tmux.getWindowSize,
       paneIndexOrder: deps.paneIndexOrder ?? tmux.paneIndexOrder,

--- a/src/lib/tmux-reflow.ts
+++ b/src/lib/tmux-reflow.ts
@@ -1,6 +1,7 @@
 import type { LayoutLeaf, LayoutNode } from "#src/config/types.js";
 import { isLayoutLeaf, isLayoutSplit } from "#src/config/types.js";
 
+import { defaultTmux } from "./tmux-default.js";
 import {
   PaneTooSmallError,
   computeRects,
@@ -10,18 +11,21 @@ import {
   splitAnchor,
 } from "./tmux-layout.js";
 import type { Rect } from "./tmux-layout.js";
-import {
-  getWindowSize as defaultGetWindowSize,
-  killPane as defaultKillPane,
-  paneIndexOrder as defaultPaneIndexOrder,
-  resyncPaneSizes as defaultResyncPaneSizes,
-  selectLayout as defaultSelectLayout,
-  selectPane as defaultSelectPane,
-  splitPane as defaultSplitPane,
-  swapPanes as defaultSwapPanes,
-  windowLayout as defaultWindowLayout,
-} from "./tmux.js";
-import type { SplitPaneOptions } from "./tmux.js";
+import type { SplitPaneOptions, TmuxHandle } from "./tmux.js";
+
+/** The tmux commands a reflow issues. */
+type ReflowTmux = Pick<
+  TmuxHandle,
+  | "getWindowSize"
+  | "killPane"
+  | "paneIndexOrder"
+  | "resyncPaneSizes"
+  | "selectLayout"
+  | "selectPane"
+  | "splitPane"
+  | "swapPanes"
+  | "windowLayout"
+>;
 
 /**
  * A tmux command failed during a reflow operation. Wraps the original cause and
@@ -57,6 +61,8 @@ type PaneMap = Record<string, string>;
  * injected too so unit tests can pin behavior without spawning tmux.
  */
 interface LayoutReflowDeps {
+  /** Socket-bound tmux surface; per-command overrides below still win. */
+  tmux?: ReflowTmux;
   /** The declared layout tree (may be undefined when the project has no layout). */
   getLayout: () => LayoutNode | undefined;
   /** Live name → pane-id map; mutated by insert/remove, replaced by reload. */
@@ -234,35 +240,22 @@ interface ApplyGeometryOptions {
  */
 class LayoutReflow {
   private readonly deps: LayoutReflowDeps;
-  private readonly tmux: {
-    getWindowSize: (target: string) => Promise<{ width: number; height: number }>;
-    paneIndexOrder: (target: string) => Promise<{ index: number; id: string }[]>;
-    swapPanes: (src: string, dst: string) => Promise<void>;
-    selectLayout: (target: string, layout: string) => Promise<void>;
-    resyncPaneSizes: (target: string) => Promise<void>;
-    splitPane: (
-      target: string,
-      direction: "h" | "v",
-      options?: SplitPaneOptions,
-    ) => Promise<string>;
-    selectPane: (target: string) => Promise<void>;
-    killPane: (target: string) => Promise<void>;
-    windowLayout: (target: string) => Promise<string>;
-  };
+  private readonly tmux: ReflowTmux;
 
   public constructor(deps: LayoutReflowDeps) {
     this.deps = deps;
-    // Fill in real tmux wrappers; tests can override any subset via deps.
+    // Socket-bound handle (env-based default); tests override any subset via deps.
+    const tmux = deps.tmux ?? defaultTmux;
     this.tmux = {
-      getWindowSize: deps.getWindowSize ?? defaultGetWindowSize,
-      paneIndexOrder: deps.paneIndexOrder ?? defaultPaneIndexOrder,
-      swapPanes: deps.swapPanes ?? defaultSwapPanes,
-      selectLayout: deps.selectLayout ?? defaultSelectLayout,
-      resyncPaneSizes: deps.resyncPaneSizes ?? defaultResyncPaneSizes,
-      splitPane: deps.splitPane ?? defaultSplitPane,
-      selectPane: deps.selectPane ?? defaultSelectPane,
-      killPane: deps.killPane ?? defaultKillPane,
-      windowLayout: deps.windowLayout ?? defaultWindowLayout,
+      getWindowSize: deps.getWindowSize ?? tmux.getWindowSize,
+      paneIndexOrder: deps.paneIndexOrder ?? tmux.paneIndexOrder,
+      swapPanes: deps.swapPanes ?? tmux.swapPanes,
+      selectLayout: deps.selectLayout ?? tmux.selectLayout,
+      resyncPaneSizes: deps.resyncPaneSizes ?? tmux.resyncPaneSizes,
+      splitPane: deps.splitPane ?? tmux.splitPane,
+      selectPane: deps.selectPane ?? tmux.selectPane,
+      killPane: deps.killPane ?? tmux.killPane,
+      windowLayout: deps.windowLayout ?? tmux.windowLayout,
     };
   }
 

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -30,6 +30,19 @@ interface SplitPaneOptions {
   before?: boolean;
 }
 
+/**
+ * Force EXACT session-name matching (`-t =name`).
+ *
+ * tmux resolves a target-session as exact → prefix → fnmatch, so `kill-session
+ * -t zaps-app-a1` happily kills `zaps-app-a1-notes` when the exact name is gone
+ * — and `has-session` reports the short name as existing. Every session-name
+ * target zaps sends goes through here; pane targets (`%N`) are unambiguous and
+ * are left alone.
+ */
+function exact(sessionName: string): string {
+  return `=${sessionName}`;
+}
+
 interface DisplayPopupOptions {
   cwd?: string;
   command: string;
@@ -90,7 +103,7 @@ function createTmux(resolveSocket: () => string | null) {
 
   async function showEnv(session: string, key: string): Promise<string | null> {
     try {
-      const out = await run(["show-environment", "-t", session, key]);
+      const out = await run(["show-environment", "-t", exact(session), key]);
       return out.replace(`${key}=`, "");
     } catch {
       return null;
@@ -104,7 +117,7 @@ function createTmux(resolveSocket: () => string | null) {
     }
     args.push(
       "-t",
-      session,
+      exact(session),
       "-F",
       "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}:#{pane_dead}",
     );
@@ -126,7 +139,7 @@ function createTmux(resolveSocket: () => string | null) {
 
   async function hasSession(name: string): Promise<boolean> {
     try {
-      await run(["has-session", "-t", name]);
+      await run(["has-session", "-t", exact(name)]);
       return true;
     } catch {
       return false;
@@ -151,11 +164,11 @@ function createTmux(resolveSocket: () => string | null) {
   }
 
   async function newWindow(session: string): Promise<string> {
-    return run(["new-window", "-t", session, "-d", "-P", "-F", "#{pane_id}"]);
+    return run(["new-window", "-t", exact(session), "-d", "-P", "-F", "#{pane_id}"]);
   }
 
   async function killSession(name: string): Promise<void> {
-    await run(["kill-session", "-t", name]);
+    await run(["kill-session", "-t", exact(name)]);
   }
 
   async function splitPane(
@@ -261,11 +274,11 @@ function createTmux(resolveSocket: () => string | null) {
   }
 
   async function setEnv(session: string, key: string, value: string): Promise<void> {
-    await run(["set-environment", "-t", session, key, value]);
+    await run(["set-environment", "-t", exact(session), key, value]);
   }
 
   async function removeEnv(session: string, key: string): Promise<void> {
-    await run(["set-environment", "-u", "-t", session, key]);
+    await run(["set-environment", "-u", "-t", exact(session), key]);
   }
 
   async function selectPane(target: string): Promise<void> {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -221,14 +221,16 @@ function createTmux(resolveSocket: () => string | null) {
   }
 
   /**
-   * Detach the client attached to this pane's session (`detach-client -t <pane>`).
-   * Targeting the PANE (not the session) detaches only the client this process
-   * belongs to, so a second terminal attached to the same managed session keeps
-   * its view. Used by the TUI's managed-mode quit: the user lands back in the
-   * plain shell they started from while the session (and services) live on.
+   * Detach the client this process is running under. No `-t`: that flag takes a
+   * target-CLIENT (a tty name, e.g. `/dev/pts/3`) — passing a pane id fails with
+   * `can't find client: %N`. Without it tmux resolves the current client from
+   * the caller's `$TMUX`, which is exactly the client to drop.
+   *
+   * Used by the TUI's managed-mode quit: the user lands back in the plain shell
+   * they started from while the session (and its services) live on.
    */
-  async function detachClient(paneTarget: string): Promise<void> {
-    await run(["detach-client", "-t", paneTarget]);
+  async function detachClient(): Promise<void> {
+    await run(["detach-client"]);
   }
 
   async function panePid(target: string): Promise<number> {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -4,11 +4,6 @@ import path from "node:path";
 
 import { getEnv } from "./env.js";
 
-function socketArgs(): string[] {
-  const socket = getEnv("ZAPS_TMUX_SOCKET");
-  return socket ? ["-L", socket] : [];
-}
-
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -17,103 +12,14 @@ async function sleep(ms: number): Promise<void> {
  *  pty winsize before the next command. Measured threshold ~100ms; 150 for margin. */
 const RESYNC_SETTLE_MS = 150;
 
-async function run(args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (d: Buffer) => (stdout += d));
-    proc.stderr.on("data", (d: Buffer) => (stderr += d));
-    proc.on("close", (code: number | null) => {
-      if (code === 0) {
-        resolve(stdout.trim());
-      } else {
-        reject(new Error(`tmux ${args.join(" ")} failed: ${stderr.trim()}`));
-      }
-    });
-  });
-}
-
-export async function currentPaneId(): Promise<string> {
-  return run(["display-message", "-p", "#{pane_id}"]);
-}
-
-export async function currentSession(): Promise<string> {
-  return run(["display-message", "-p", "#{session_name}"]);
-}
-
-export async function showEnv(session: string, key: string): Promise<string | null> {
-  try {
-    const out = await run(["show-environment", "-t", session, key]);
-    return out.replace(`${key}=`, "");
-  } catch {
-    return null;
-  }
-}
-
-export interface PaneInfo {
+interface PaneInfo {
   id: string;
   pid: number;
   width: number;
   height: number;
 }
 
-export async function listPanes(session: string, allWindows = false): Promise<PaneInfo[]> {
-  const args = ["list-panes"];
-  if (allWindows) {
-    args.push("-s");
-  }
-  args.push("-t", session, "-F", "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}");
-  const out = await run(args);
-  if (!out) {
-    return [];
-  }
-  return out.split("\n").map((line) => {
-    const [id, pid, width, height] = line.split(":");
-    return {
-      id,
-      pid: Number.parseInt(pid, 10),
-      width: Number.parseInt(width, 10),
-      height: Number.parseInt(height, 10),
-    };
-  });
-}
-
-export async function hasSession(name: string): Promise<boolean> {
-  try {
-    await run(["has-session", "-t", name]);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export async function sendKeys(target: string, keys: string): Promise<void> {
-  await run(["send-keys", "-t", target, "-l", keys]);
-  await run(["send-keys", "-t", target, "Enter"]);
-}
-
-export async function newSession(name: string, opts?: { x?: number; y?: number }): Promise<string> {
-  const args = ["new-session", "-d", "-s", name];
-  if (opts?.x) {
-    args.push("-x", String(opts.x));
-  }
-  if (opts?.y) {
-    args.push("-y", String(opts.y));
-  }
-  args.push("-P", "-F", "#{pane_id}");
-  return run(args);
-}
-
-export async function newWindow(session: string): Promise<string> {
-  return run(["new-window", "-t", session, "-d", "-P", "-F", "#{pane_id}"]);
-}
-
-export async function killSession(name: string): Promise<void> {
-  await run(["kill-session", "-t", name]);
-}
-
-export interface SplitPaneOptions {
+interface SplitPaneOptions {
   /** Percentage of the parent pane the new pane should occupy. */
   percent?: number;
   /** When true, pass `-d` so the new pane does NOT steal focus from the active pane. */
@@ -122,210 +28,7 @@ export interface SplitPaneOptions {
   before?: boolean;
 }
 
-export async function splitPane(
-  target: string,
-  direction: "h" | "v",
-  options?: SplitPaneOptions,
-): Promise<string> {
-  const args = ["split-window", `-${direction}`];
-  if (options?.before) {
-    args.push("-b");
-  }
-  if (options?.detached) {
-    args.push("-d");
-  }
-  args.push("-t", target);
-  if (typeof options?.percent === "number") {
-    args.push("-l", `${options.percent}%`);
-  }
-  args.push("-P", "-F", "#{pane_id}");
-  return run(args);
-}
-
-/** Swap two panes' positions (`swap-pane -s <src> -t <dst>`). Processes stay attached. */
-export async function swapPanes(src: string, dst: string): Promise<void> {
-  await run(["swap-pane", "-s", src, "-t", dst]);
-}
-
-/**
- * Apply an absolute layout string to `target`'s window via `select-layout -t <target> <layout>`.
- * `layout` is passed as a single argv element so the `{` / `[` characters never hit a shell —
- * `run` already spawns tmux directly without one.
- */
-export async function selectLayout(target: string, layout: string): Promise<void> {
-  await run(["select-layout", "-t", target, layout]);
-}
-
-/** Read the live `#{window_layout}` string for `target`'s window (for tests/rollback). */
-export async function windowLayout(target: string): Promise<string> {
-  return run(["display-message", "-p", "-t", target, "#{window_layout}"]);
-}
-
-/**
- * The current spatial order of panes in `target`'s window, sorted by `pane_index`.
- * tmux assigns `pane_index` in spatial DFS order, so this is exactly the order
- * `select-layout` binds panes to layout cells.
- */
-export async function paneIndexOrder(target: string): Promise<{ index: number; id: string }[]> {
-  const out = await run(["list-panes", "-t", target, "-F", "#{pane_index} #{pane_id}"]);
-  if (!out) {
-    return [];
-  }
-  return out
-    .split("\n")
-    .map((line) => {
-      const [indexStr, id] = line.split(" ");
-      return { index: Number.parseInt(indexStr, 10), id };
-    })
-    .toSorted((a, b) => a.index - b.index);
-}
-
-export async function killPane(target: string): Promise<void> {
-  await run(["kill-pane", "-t", target]);
-}
-
-export async function panePid(target: string): Promise<number> {
-  const out = await run(["display-message", "-p", "-t", target, "#{pane_pid}"]);
-  return Number.parseInt(out, 10);
-}
-
-/** True if `target` is still a live tmux pane (false if it was killed/closed). */
-export async function paneExists(target: string): Promise<boolean> {
-  try {
-    // A `display-message -t <id>` probe is NOT reliable: tmux exits 0 and echoes
-    // The requested id back even for a dead pane whose session is gone, so it
-    // Reports every pane as alive (the A4 staleness regression). Enumerate the
-    // Live panes across the server instead and check real membership.
-    const out = await run(["list-panes", "-a", "-F", "#{pane_id}"]);
-    return out.split("\n").includes(target);
-  } catch {
-    return false;
-  }
-}
-
-export async function capturePane(target: string, lines = 100): Promise<string> {
-  return run(["capture-pane", "-t", target, "-p", "-S", `-${lines}`]);
-}
-
-export async function sendCtrlC(target: string): Promise<void> {
-  await run(["send-keys", "-t", target, "C-c"]);
-}
-
-export async function setEnv(session: string, key: string, value: string): Promise<void> {
-  await run(["set-environment", "-t", session, key, value]);
-}
-
-export async function removeEnv(session: string, key: string): Promise<void> {
-  await run(["set-environment", "-u", "-t", session, key]);
-}
-
-export async function selectPane(target: string): Promise<void> {
-  await run(["select-pane", "-t", target]);
-}
-
-export async function zoomPane(target: string): Promise<void> {
-  await run(["select-pane", "-t", target]);
-  await run(["resize-pane", "-Z", "-t", target]);
-}
-
-export async function getWindowName(target: string): Promise<string> {
-  return run(["display-message", "-p", "-t", target, "#{window_name}"]);
-}
-
-export async function renameWindow(target: string, name: string): Promise<void> {
-  await run(["rename-window", "-t", target, name]);
-}
-
-export async function getWindowOption(target: string, option: string): Promise<string> {
-  return run(["show-window-option", "-v", "-t", target, option]);
-}
-
-export async function setWindowOption(
-  target: string,
-  option: string,
-  value: string,
-): Promise<void> {
-  await run(["set-window-option", "-t", target, option, value]);
-}
-
-export async function getWindowSize(target: string): Promise<{ width: number; height: number }> {
-  const out = await run([
-    "display-message",
-    "-p",
-    "-t",
-    target,
-    "#{window_width} #{window_height}",
-  ]);
-  const [width, height] = out.split(" ").map((n) => Number.parseInt(n, 10));
-  return { width, height };
-}
-
-export async function resizeWindow(target: string, x: number, y: number): Promise<void> {
-  await run(["resize-window", "-t", target, "-x", String(x), "-y", String(y)]);
-}
-
-/**
- * Force tmux to re-push every pane's kernel pty winsize in `target`'s window.
- *
- * Building the layout splits panes repeatedly off the @tui pane; tmux can leave
- * a *split-from* pane's pty winsize stale at its larger pre-split size (verified
- * live: a 152-col pane whose pty still reported 255 cols). The in-process TUI
- * then paints to the stale width and wraps into garbage until a manual resize.
- * tmux only re-pushes a winsize when a pane's size genuinely changes AND once
- * its event loop has processed that change — so nudge the whole window smaller,
- * let it settle, restore it, settle again. `window-size manual` makes the resize
- * stick despite the attached client; the prior option is restored afterwards.
- * Best-effort: any failure is swallowed so it can never block session startup.
- */
-export async function resyncPaneSizes(target: string, settleMs = RESYNC_SETTLE_MS): Promise<void> {
-  try {
-    const { width, height } = await getWindowSize(target);
-    if (!Number.isFinite(width) || !Number.isFinite(height)) {
-      return;
-    }
-    const prevOption = await getWindowOption(target, "window-size");
-    await setWindowOption(target, "window-size", "manual");
-    await resizeWindow(target, Math.max(width - 10, 20), Math.max(height - 2, 5));
-    await sleep(settleMs);
-    await resizeWindow(target, width, height);
-    await sleep(settleMs);
-    await setWindowOption(target, "window-size", prevOption || "latest");
-  } catch {
-    // Resync is best-effort; never let it block startup.
-  }
-}
-
-/**
- * Parsed tmux version (major.minor), or null if tmux is absent or its version
- * string is unrecognised. `display-popup` (used by the popup task picker) was
- * added in tmux 3.2, so callers gate popups on this.
- */
-export async function tmuxVersion(): Promise<{ major: number; minor: number } | null> {
-  try {
-    const out = await run(["-V"]);
-    const match = /(?<major>\d+)\.(?<minor>\d+)/u.exec(out);
-    if (!match?.groups) {
-      return null;
-    }
-    return {
-      major: Number.parseInt(match.groups.major, 10),
-      minor: Number.parseInt(match.groups.minor, 10),
-    };
-  } catch {
-    return null;
-  }
-}
-
-/** True if this tmux supports `display-popup` (>= 3.2). */
-export async function tmuxSupportsPopup(): Promise<boolean> {
-  const version = await tmuxVersion();
-  if (!version) {
-    return false;
-  }
-  return version.major > 3 || (version.major === 3 && version.minor >= 2);
-}
-
-export interface DisplayPopupOptions {
+interface DisplayPopupOptions {
   cwd?: string;
   command: string;
   title?: string;
@@ -334,46 +37,436 @@ export interface DisplayPopupOptions {
   env?: Record<string, string>;
 }
 
-export async function displayPopup(opts: DisplayPopupOptions): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const args = ["display-popup", "-EE"];
-    if (opts.cwd) {
-      args.push("-d", opts.cwd);
-    }
-    if (opts.width) {
-      args.push("-w", opts.width);
-    }
-    if (opts.height) {
-      args.push("-h", opts.height);
-    }
-    if (opts.title) {
-      args.push("-T", opts.title);
-    }
-    if (opts.env) {
-      for (const [k, v] of Object.entries(opts.env)) {
-        args.push("-e", `${k}=${v}`);
-      }
-    }
-    args.push("--", opts.command);
+/**
+ * Build the whole tmux command surface bound to one tmux server socket.
+ * `resolveSocket` is called per command so the env-based default handle picks up
+ * `ZAPS_TMUX_SOCKET` changes at call time (as the previous module-level
+ * `socketArgs()` did).
+ */
+function createTmux(resolveSocket: () => string | null) {
+  function socketArgs(): string[] {
+    const socket = resolveSocket();
+    return socket ? ["-L", socket] : [];
+  }
 
-    const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: "ignore" });
-    proc.on("close", (code: number | null) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Popup command failed with code ${code}`));
-      }
+  async function run(args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      proc.stdout.on("data", (d: Buffer) => (stdout += d));
+      proc.stderr.on("data", (d: Buffer) => (stderr += d));
+      proc.on("close", (code: number | null) => {
+        if (code === 0) {
+          resolve(stdout.trim());
+        } else {
+          reject(new Error(`tmux ${args.join(" ")} failed: ${stderr.trim()}`));
+        }
+      });
     });
-  });
+  }
+
+  async function currentPaneId(): Promise<string> {
+    return run(["display-message", "-p", "#{pane_id}"]);
+  }
+
+  async function currentSession(): Promise<string> {
+    return run(["display-message", "-p", "#{session_name}"]);
+  }
+
+  async function showEnv(session: string, key: string): Promise<string | null> {
+    try {
+      const out = await run(["show-environment", "-t", session, key]);
+      return out.replace(`${key}=`, "");
+    } catch {
+      return null;
+    }
+  }
+
+  async function listPanes(session: string, allWindows = false): Promise<PaneInfo[]> {
+    const args = ["list-panes"];
+    if (allWindows) {
+      args.push("-s");
+    }
+    args.push("-t", session, "-F", "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}");
+    const out = await run(args);
+    if (!out) {
+      return [];
+    }
+    return out.split("\n").map((line) => {
+      const [id, pid, width, height] = line.split(":");
+      return {
+        id,
+        pid: Number.parseInt(pid, 10),
+        width: Number.parseInt(width, 10),
+        height: Number.parseInt(height, 10),
+      };
+    });
+  }
+
+  async function hasSession(name: string): Promise<boolean> {
+    try {
+      await run(["has-session", "-t", name]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function sendKeys(target: string, keys: string): Promise<void> {
+    await run(["send-keys", "-t", target, "-l", keys]);
+    await run(["send-keys", "-t", target, "Enter"]);
+  }
+
+  async function newSession(name: string, opts?: { x?: number; y?: number }): Promise<string> {
+    const args = ["new-session", "-d", "-s", name];
+    if (opts?.x) {
+      args.push("-x", String(opts.x));
+    }
+    if (opts?.y) {
+      args.push("-y", String(opts.y));
+    }
+    args.push("-P", "-F", "#{pane_id}");
+    return run(args);
+  }
+
+  async function newWindow(session: string): Promise<string> {
+    return run(["new-window", "-t", session, "-d", "-P", "-F", "#{pane_id}"]);
+  }
+
+  async function killSession(name: string): Promise<void> {
+    await run(["kill-session", "-t", name]);
+  }
+
+  async function splitPane(
+    target: string,
+    direction: "h" | "v",
+    options?: SplitPaneOptions,
+  ): Promise<string> {
+    const args = ["split-window", `-${direction}`];
+    if (options?.before) {
+      args.push("-b");
+    }
+    if (options?.detached) {
+      args.push("-d");
+    }
+    args.push("-t", target);
+    if (typeof options?.percent === "number") {
+      args.push("-l", `${options.percent}%`);
+    }
+    args.push("-P", "-F", "#{pane_id}");
+    return run(args);
+  }
+
+  /** Swap two panes' positions (`swap-pane -s <src> -t <dst>`). Processes stay attached. */
+  async function swapPanes(src: string, dst: string): Promise<void> {
+    await run(["swap-pane", "-s", src, "-t", dst]);
+  }
+
+  /**
+   * Apply an absolute layout string to `target`'s window via `select-layout -t <target> <layout>`.
+   * `layout` is passed as a single argv element so the `{` / `[` characters never hit a shell —
+   * `run` already spawns tmux directly without one.
+   */
+  async function selectLayout(target: string, layout: string): Promise<void> {
+    await run(["select-layout", "-t", target, layout]);
+  }
+
+  /** Read the live `#{window_layout}` string for `target`'s window (for tests/rollback). */
+  async function windowLayout(target: string): Promise<string> {
+    return run(["display-message", "-p", "-t", target, "#{window_layout}"]);
+  }
+
+  /**
+   * The current spatial order of panes in `target`'s window, sorted by `pane_index`.
+   * tmux assigns `pane_index` in spatial DFS order, so this is exactly the order
+   * `select-layout` binds panes to layout cells.
+   */
+  async function paneIndexOrder(target: string): Promise<{ index: number; id: string }[]> {
+    const out = await run(["list-panes", "-t", target, "-F", "#{pane_index} #{pane_id}"]);
+    if (!out) {
+      return [];
+    }
+    return out
+      .split("\n")
+      .map((line) => {
+        const [indexStr, id] = line.split(" ");
+        return { index: Number.parseInt(indexStr, 10), id };
+      })
+      .toSorted((a, b) => a.index - b.index);
+  }
+
+  async function killPane(target: string): Promise<void> {
+    await run(["kill-pane", "-t", target]);
+  }
+
+  async function panePid(target: string): Promise<number> {
+    const out = await run(["display-message", "-p", "-t", target, "#{pane_pid}"]);
+    return Number.parseInt(out, 10);
+  }
+
+  /** True if `target` is still a live tmux pane (false if it was killed/closed). */
+  async function paneExists(target: string): Promise<boolean> {
+    try {
+      // A `display-message -t <id>` probe is NOT reliable: tmux exits 0 and echoes
+      // The requested id back even for a dead pane whose session is gone, so it
+      // Reports every pane as alive (the A4 staleness regression). Enumerate the
+      // Live panes across the server instead and check real membership.
+      const out = await run(["list-panes", "-a", "-F", "#{pane_id}"]);
+      return out.split("\n").includes(target);
+    } catch {
+      return false;
+    }
+  }
+
+  async function capturePane(target: string, lines = 100): Promise<string> {
+    return run(["capture-pane", "-t", target, "-p", "-S", `-${lines}`]);
+  }
+
+  async function sendCtrlC(target: string): Promise<void> {
+    await run(["send-keys", "-t", target, "C-c"]);
+  }
+
+  async function setEnv(session: string, key: string, value: string): Promise<void> {
+    await run(["set-environment", "-t", session, key, value]);
+  }
+
+  async function removeEnv(session: string, key: string): Promise<void> {
+    await run(["set-environment", "-u", "-t", session, key]);
+  }
+
+  async function selectPane(target: string): Promise<void> {
+    await run(["select-pane", "-t", target]);
+  }
+
+  async function zoomPane(target: string): Promise<void> {
+    await run(["select-pane", "-t", target]);
+    await run(["resize-pane", "-Z", "-t", target]);
+  }
+
+  async function getWindowName(target: string): Promise<string> {
+    return run(["display-message", "-p", "-t", target, "#{window_name}"]);
+  }
+
+  async function renameWindow(target: string, name: string): Promise<void> {
+    await run(["rename-window", "-t", target, name]);
+  }
+
+  async function getWindowOption(target: string, option: string): Promise<string> {
+    return run(["show-window-option", "-v", "-t", target, option]);
+  }
+
+  async function setWindowOption(target: string, option: string, value: string): Promise<void> {
+    await run(["set-window-option", "-t", target, option, value]);
+  }
+
+  async function getWindowSize(target: string): Promise<{ width: number; height: number }> {
+    const out = await run([
+      "display-message",
+      "-p",
+      "-t",
+      target,
+      "#{window_width} #{window_height}",
+    ]);
+    const [width, height] = out.split(" ").map((n) => Number.parseInt(n, 10));
+    return { width, height };
+  }
+
+  async function resizeWindow(target: string, x: number, y: number): Promise<void> {
+    await run(["resize-window", "-t", target, "-x", String(x), "-y", String(y)]);
+  }
+
+  /**
+   * Force tmux to re-push every pane's kernel pty winsize in `target`'s window.
+   *
+   * Building the layout splits panes repeatedly off the @tui pane; tmux can leave
+   * a *split-from* pane's pty winsize stale at its larger pre-split size (verified
+   * live: a 152-col pane whose pty still reported 255 cols). The in-process TUI
+   * then paints to the stale width and wraps into garbage until a manual resize.
+   * tmux only re-pushes a winsize when a pane's size genuinely changes AND once
+   * its event loop has processed that change — so nudge the whole window smaller,
+   * let it settle, restore it, settle again. `window-size manual` makes the resize
+   * stick despite the attached client; the prior option is restored afterwards.
+   * Best-effort: any failure is swallowed so it can never block session startup.
+   */
+  async function resyncPaneSizes(target: string, settleMs = RESYNC_SETTLE_MS): Promise<void> {
+    try {
+      const { width, height } = await getWindowSize(target);
+      if (!Number.isFinite(width) || !Number.isFinite(height)) {
+        return;
+      }
+      const prevOption = await getWindowOption(target, "window-size");
+      await setWindowOption(target, "window-size", "manual");
+      await resizeWindow(target, Math.max(width - 10, 20), Math.max(height - 2, 5));
+      await sleep(settleMs);
+      await resizeWindow(target, width, height);
+      await sleep(settleMs);
+      await setWindowOption(target, "window-size", prevOption || "latest");
+    } catch {
+      // Resync is best-effort; never let it block startup.
+    }
+  }
+
+  /**
+   * Parsed tmux version (major.minor), or null if tmux is absent or its version
+   * string is unrecognised. `display-popup` (used by the popup task picker) was
+   * added in tmux 3.2, so callers gate popups on this.
+   */
+  async function tmuxVersion(): Promise<{ major: number; minor: number } | null> {
+    try {
+      const out = await run(["-V"]);
+      const match = /(?<major>\d+)\.(?<minor>\d+)/u.exec(out);
+      if (!match?.groups) {
+        return null;
+      }
+      return {
+        major: Number.parseInt(match.groups.major, 10),
+        minor: Number.parseInt(match.groups.minor, 10),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /** True if this tmux supports `display-popup` (>= 3.2). */
+  async function tmuxSupportsPopup(): Promise<boolean> {
+    const version = await tmuxVersion();
+    if (!version) {
+      return false;
+    }
+    return version.major > 3 || (version.major === 3 && version.minor >= 2);
+  }
+
+  async function displayPopup(opts: DisplayPopupOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const args = ["display-popup", "-EE"];
+      if (opts.cwd) {
+        args.push("-d", opts.cwd);
+      }
+      if (opts.width) {
+        args.push("-w", opts.width);
+      }
+      if (opts.height) {
+        args.push("-h", opts.height);
+      }
+      if (opts.title) {
+        args.push("-T", opts.title);
+      }
+      if (opts.env) {
+        for (const [k, v] of Object.entries(opts.env)) {
+          args.push("-e", `${k}=${v}`);
+        }
+      }
+      args.push("--", opts.command);
+
+      const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: "ignore" });
+      proc.on("close", (code: number | null) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Popup command failed with code ${code}`));
+        }
+      });
+    });
+  }
+
+  async function editPaneCapture(target: string, title: string): Promise<void> {
+    const editor = getEnv("EDITOR") || "vim";
+    const template = path.join(os.tmpdir(), "zaps-capture-XXXXXX");
+    await displayPopup({
+      command: `sh -c 'f=$(mktemp ${template}) && tmux capture-pane -t ${target} -p -S - > "$f" && ${editor} "$f"; rm -f "$f"'`,
+      title,
+      width: "90%",
+      height: "90%",
+    });
+  }
+
+  return {
+    capturePane,
+    currentPaneId,
+    currentSession,
+    displayPopup,
+    editPaneCapture,
+    getWindowName,
+    getWindowOption,
+    getWindowSize,
+    hasSession,
+    killPane,
+    killSession,
+    listPanes,
+    newSession,
+    newWindow,
+    paneExists,
+    paneIndexOrder,
+    panePid,
+    removeEnv,
+    renameWindow,
+    resizeWindow,
+    resyncPaneSizes,
+    selectLayout,
+    selectPane,
+    sendCtrlC,
+    sendKeys,
+    setEnv,
+    setWindowOption,
+    showEnv,
+    splitPane,
+    swapPanes,
+    tmuxSupportsPopup,
+    tmuxVersion,
+    windowLayout,
+    zoomPane,
+  };
 }
 
-export async function editPaneCapture(target: string, title: string): Promise<void> {
-  const editor = getEnv("EDITOR") || "vim";
-  const template = path.join(os.tmpdir(), "zaps-capture-XXXXXX");
-  await displayPopup({
-    command: `sh -c 'f=$(mktemp ${template}) && tmux capture-pane -t ${target} -p -S - > "$f" && ${editor} "$f"; rm -f "$f"'`,
-    title,
-    width: "90%",
-    height: "90%",
-  });
+/**
+ * A tmux command surface bound to one server socket: `tmuxFor("zaps")` runs
+ * `tmux -L zaps …`, `tmuxFor(null)` targets the default server (no `-L`).
+ */
+function tmuxFor(socket: string | null) {
+  return createTmux(() => socket);
 }
+
+type TmuxHandle = ReturnType<typeof tmuxFor>;
+
+/** Default handle: socket from `ZAPS_TMUX_SOCKET`, re-read on every command. */
+const defaultTmux = createTmux(() => getEnv("ZAPS_TMUX_SOCKET") ?? null);
+
+export type { DisplayPopupOptions, PaneInfo, SplitPaneOptions, TmuxHandle };
+export { tmuxFor };
+export const {
+  capturePane,
+  currentPaneId,
+  currentSession,
+  displayPopup,
+  editPaneCapture,
+  getWindowName,
+  getWindowOption,
+  getWindowSize,
+  hasSession,
+  killPane,
+  killSession,
+  listPanes,
+  newSession,
+  newWindow,
+  paneExists,
+  paneIndexOrder,
+  panePid,
+  removeEnv,
+  renameWindow,
+  resizeWindow,
+  resyncPaneSizes,
+  selectLayout,
+  selectPane,
+  sendCtrlC,
+  sendKeys,
+  setEnv,
+  setWindowOption,
+  showEnv,
+  splitPane,
+  swapPanes,
+  tmuxSupportsPopup,
+  tmuxVersion,
+  windowLayout,
+  zoomPane,
+} = defaultTmux;

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -17,6 +17,8 @@ interface PaneInfo {
   pid: number;
   width: number;
   height: number;
+  /** `#{pane_dead}` — true for a pane held open by `remain-on-exit`. */
+  dead: boolean;
 }
 
 interface SplitPaneOptions {
@@ -100,18 +102,24 @@ function createTmux(resolveSocket: () => string | null) {
     if (allWindows) {
       args.push("-s");
     }
-    args.push("-t", session, "-F", "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}");
+    args.push(
+      "-t",
+      session,
+      "-F",
+      "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}:#{pane_dead}",
+    );
     const out = await run(args);
     if (!out) {
       return [];
     }
     return out.split("\n").map((line) => {
-      const [id, pid, width, height] = line.split(":");
+      const [id, pid, width, height, dead] = line.split(":");
       return {
         id,
         pid: Number.parseInt(pid, 10),
         width: Number.parseInt(width, 10),
         height: Number.parseInt(height, 10),
+        dead: dead === "1",
       };
     });
   }
@@ -210,6 +218,17 @@ function createTmux(resolveSocket: () => string | null) {
 
   async function killPane(target: string): Promise<void> {
     await run(["kill-pane", "-t", target]);
+  }
+
+  /**
+   * Detach the client attached to this pane's session (`detach-client -t <pane>`).
+   * Targeting the PANE (not the session) detaches only the client this process
+   * belongs to, so a second terminal attached to the same managed session keeps
+   * its view. Used by the TUI's managed-mode quit: the user lands back in the
+   * plain shell they started from while the session (and services) live on.
+   */
+  async function detachClient(paneTarget: string): Promise<void> {
+    await run(["detach-client", "-t", paneTarget]);
   }
 
   async function panePid(target: string): Promise<number> {
@@ -400,6 +419,7 @@ function createTmux(resolveSocket: () => string | null) {
     capturePane,
     currentPaneId,
     currentSession,
+    detachClient,
     displayMessage,
     displayPopup,
     editPaneCapture,
@@ -454,6 +474,7 @@ export const {
   capturePane,
   currentPaneId,
   currentSession,
+  detachClient,
   displayMessage,
   displayPopup,
   editPaneCapture,

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -70,6 +70,14 @@ function createTmux(resolveSocket: () => string | null) {
     return run(["display-message", "-p", "#{pane_id}"]);
   }
 
+  /**
+   * Raw `display-message -p -t <target> <format>` for format strings the typed
+   * helpers don't cover (e.g. `#{pane_dead}`/`#{pane_dead_status}`).
+   */
+  async function displayMessage(target: string, format: string): Promise<string> {
+    return run(["display-message", "-p", "-t", target, format]);
+  }
+
   async function currentSession(): Promise<string> {
     return run(["display-message", "-p", "#{session_name}"]);
   }
@@ -385,6 +393,7 @@ function createTmux(resolveSocket: () => string | null) {
     capturePane,
     currentPaneId,
     currentSession,
+    displayMessage,
     displayPopup,
     editPaneCapture,
     getWindowName,
@@ -438,6 +447,7 @@ export const {
   capturePane,
   currentPaneId,
   currentSession,
+  displayMessage,
   displayPopup,
   editPaneCapture,
   getWindowName,

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -43,6 +43,19 @@ function exact(sessionName: string): string {
   return `=${sessionName}`;
 }
 
+/**
+ * Exact target for the session's CURRENT WINDOW (`=name:`).
+ *
+ * Window-scoped commands (`display-message`, `select-layout`, `resize-window`,
+ * `set-option`) need the trailing colon: verified live, a bare `=name` makes
+ * `display-message` return an empty string and `select-layout` fail outright,
+ * while a bare `name` prefix-matches a longer-named session exactly like the
+ * session-target commands do.
+ */
+function exactWindowTarget(sessionName: string): string {
+  return `=${sessionName}:`;
+}
+
 interface DisplayPopupOptions {
   cwd?: string;
   command: string;
@@ -484,7 +497,7 @@ type TmuxHandle = ReturnType<typeof tmuxFor>;
 const defaultTmux = createTmux(() => getEnv("ZAPS_TMUX_SOCKET") ?? null);
 
 export type { DisplayPopupOptions, PaneInfo, SplitPaneOptions, TmuxHandle };
-export { tmuxFor };
+export { exactWindowTarget, tmuxFor };
 export const {
   capturePane,
   currentPaneId,

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -56,6 +56,10 @@ function createTmux(resolveSocket: () => string | null) {
       let stderr = "";
       proc.stdout.on("data", (d: Buffer) => (stdout += d));
       proc.stderr.on("data", (d: Buffer) => (stderr += d));
+      // Without this the spawn failure (no tmux on PATH → ENOENT) surfaces as an
+      // Unhandled 'error' event and takes the whole process down, so callers'
+      // Try/catch — including the tmux-presence gate — never runs.
+      proc.on("error", reject);
       proc.on("close", (code: number | null) => {
         if (code === 0) {
           resolve(stdout.trim());
@@ -368,6 +372,9 @@ function createTmux(resolveSocket: () => string | null) {
       args.push("--", opts.command);
 
       const proc = spawn("tmux", [...socketArgs(), ...args], { stdio: "ignore" });
+      // Same reason as in `run()`: an unhandled 'error' event would crash the
+      // Process instead of rejecting this promise.
+      proc.on("error", reject);
       proc.on("close", (code: number | null) => {
         if (code === 0) {
           resolve();

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -21,6 +21,9 @@ vi.mock("../src/lib/tmux.js", () => ({
   setWindowOption: vi.fn().mockResolvedValue(undefined),
   currentSession: vi.fn().mockResolvedValue(""),
   showEnv: vi.fn().mockResolvedValue(""),
+  // Quitting detaches the tmux client in managed mode; without this export the
+  // Detach throws inside its own catch and the tests below pass vacuously.
+  detachClient: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../src/lib/open.js", () => ({
@@ -237,6 +240,49 @@ describe("Keyboard routing — Dashboard", () => {
       /* Flush */
     });
 
+    expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
+  });
+
+  it("q hands the terminal back by detaching the managed tmux client", async () => {
+    const { detachClient } = await import("../src/lib/tmux.js");
+    vi.mocked(detachClient).mockClear();
+    vi.stubEnv("ZAPS_MANAGED_TMUX", "1");
+    vi.stubEnv("TMUX", "/tmp/tmux-1000/zaps,42,0");
+    const statuses: ServiceStatus[] = [
+      { name: "db", state: "ready", ports: [5432], retryCount: 0 },
+    ];
+
+    const { stdin, client } = renderApp({ statuses });
+
+    act(() => {
+      stdin.write("q");
+    });
+    await act(async () => {
+      /* Flush */
+    });
+
+    expect(vi.mocked(detachClient)).toHaveBeenCalled();
+    expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("q in a personal tmux leaves the client attached", async () => {
+    const { detachClient } = await import("../src/lib/tmux.js");
+    vi.mocked(detachClient).mockClear();
+    const statuses: ServiceStatus[] = [
+      { name: "db", state: "ready", ports: [5432], retryCount: 0 },
+    ];
+
+    const { stdin, client } = renderApp({ statuses });
+
+    act(() => {
+      stdin.write("q");
+    });
+    await act(async () => {
+      /* Flush */
+    });
+
+    expect(vi.mocked(detachClient)).not.toHaveBeenCalled();
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
 

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 
 import { render } from "ink-testing-library";
 import { act } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock tmux functions to prevent real tmux commands
 vi.mock("../src/lib/tmux.js", () => ({
@@ -155,6 +155,11 @@ describe("App", () => {
 });
 
 describe("Keyboard routing — Dashboard", () => {
+  // Env stubs must come back even when a test throws mid-body.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("up/down changes selection index", async () => {
     const statuses: ServiceStatus[] = [
       { name: "db", state: "ready", ports: [5432], retryCount: 0 },
@@ -263,7 +268,6 @@ describe("Keyboard routing — Dashboard", () => {
 
     expect(vi.mocked(detachClient)).toHaveBeenCalled();
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
-    vi.unstubAllEnvs();
   });
 
   it("q in a personal tmux leaves the client attached", async () => {

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -290,15 +290,24 @@ describe("Keyboard routing — Dashboard", () => {
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
 
-  it("d destroys session (shut down)", async () => {
+  it("d destroys session (shut down) once confirmed", async () => {
     const statuses: ServiceStatus[] = [
       { name: "db", state: "ready", ports: [5432], retryCount: 0 },
     ];
 
-    const { stdin, client } = renderApp({ statuses });
+    const { stdin, client, lastFrame } = renderApp({ statuses });
 
     act(() => {
       stdin.write("d");
+    });
+    await act(async () => {
+      /* Flush */
+    });
+    expect(vi.mocked(client.destroySession)).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain("Shut down session?");
+
+    act(() => {
+      stdin.write("y");
     });
     await act(async () => {
       /* Flush */
@@ -498,7 +507,7 @@ describe("Keyboard routing — ctrl keys", () => {
     expect(vi.mocked(client.disconnect)).toHaveBeenCalled();
   });
 
-  it("ctrl+d destroys session from dashboard", async () => {
+  it("ctrl+d destroys session from dashboard once confirmed", async () => {
     const statuses: ServiceStatus[] = [
       { name: "db", state: "ready", ports: [5432], retryCount: 0 },
     ];
@@ -507,6 +516,16 @@ describe("Keyboard routing — ctrl keys", () => {
 
     act(() => {
       stdin.write("\x04"); // Ctrl+d
+    });
+    await act(async () => {
+      /* Flush */
+    });
+    // A lone 0x04 — which a tmux client attaching with stdin at EOF injects —
+    // Must not tear the session down.
+    expect(vi.mocked(client.destroySession)).not.toHaveBeenCalled();
+
+    act(() => {
+      stdin.write("y");
     });
     await act(async () => {
       /* Flush */

--- a/test/_helpers/mock-session.ts
+++ b/test/_helpers/mock-session.ts
@@ -5,6 +5,8 @@ import type { SessionStore } from "../../src/daemon/server.js";
 import type { Session } from "../../src/daemon/session.js";
 import { TaskOutputStore } from "../../src/daemon/task-output-store.js";
 import type { PaneRunInfo } from "../../src/lib/task/run-in-pane.js";
+import { defaultTmux } from "../../src/lib/tmux-default.js";
+import type { TmuxHandle } from "../../src/lib/tmux.js";
 
 export interface MockSession {
   id: string;
@@ -22,6 +24,7 @@ export interface MockSession {
     unavailableServices: Map<string, { name: string; reason: string }>;
   };
   paneMap: Record<string, string>;
+  tmux: TmuxHandle;
   tmuxSession: string;
   originPane: string;
   execInfo: Map<string, { command: string; cwd: string; env: Record<string, string> }>;
@@ -80,6 +83,7 @@ export function createMockSession(overrides: Partial<MockSession> = {}): MockSes
       unavailableServices: new Map(),
     },
     paneMap: { "@tui": "%0", api: "%1" },
+    tmux: defaultTmux,
     tmuxSession: "test-tmux",
     originPane: "%0",
     execInfo: overrides.execInfo ?? new Map(),

--- a/test/_helpers/mock-session.ts
+++ b/test/_helpers/mock-session.ts
@@ -5,7 +5,7 @@ import type { SessionStore } from "../../src/daemon/server.js";
 import type { Session } from "../../src/daemon/session.js";
 import { TaskOutputStore } from "../../src/daemon/task-output-store.js";
 import type { PaneRunInfo } from "../../src/lib/task/run-in-pane.js";
-import { defaultTmux } from "../../src/lib/tmux-default.js";
+import { tmuxFor } from "../../src/lib/tmux.js";
 import type { TmuxHandle } from "../../src/lib/tmux.js";
 
 export interface MockSession {
@@ -85,7 +85,7 @@ export function createMockSession(overrides: Partial<MockSession> = {}): MockSes
       unavailableServices: new Map(),
     },
     paneMap: { "@tui": "%0", api: "%1" },
-    tmux: defaultTmux,
+    tmux: tmuxFor(null),
     tmuxSocket: null,
     managedTmux: false,
     tmuxSession: "test-tmux",

--- a/test/_helpers/mock-session.ts
+++ b/test/_helpers/mock-session.ts
@@ -25,6 +25,8 @@ export interface MockSession {
   };
   paneMap: Record<string, string>;
   tmux: TmuxHandle;
+  tmuxSocket: string | null;
+  managedTmux: boolean;
   tmuxSession: string;
   originPane: string;
   execInfo: Map<string, { command: string; cwd: string; env: Record<string, string> }>;
@@ -84,6 +86,8 @@ export function createMockSession(overrides: Partial<MockSession> = {}): MockSes
     },
     paneMap: { "@tui": "%0", api: "%1" },
     tmux: defaultTmux,
+    tmuxSocket: null,
+    managedTmux: false,
     tmuxSession: "test-tmux",
     originPane: "%0",
     execInfo: overrides.execInfo ?? new Map(),

--- a/test/cli/bootstrap-tmux-defaults.test.ts
+++ b/test/cli/bootstrap-tmux-defaults.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ensureTmuxContext } from "../../src/cli/bootstrap-tmux.js";
+import type { BootstrapDeps } from "../../src/cli/bootstrap-tmux.js";
+
+vi.mock("../../src/daemon/lifecycle.js", () => ({
+  isDaemonRunning: vi.fn(),
+  socketPath: () => "/tmp/zaps-bootstrap-defaults.sock",
+}));
+vi.mock("../../src/lib/ipc/client.js", () => ({ ipcRequest: vi.fn() }));
+
+const { isDaemonRunning } = await import("../../src/daemon/lifecycle.js");
+const { ipcRequest } = await import("../../src/lib/ipc/client.js");
+const { sessionId } = await import("../../src/daemon/session.js");
+
+const CONFIG_PATH = "/tmp/zaps-defaults/.zaps.mts";
+const ID = sessionId(CONFIG_PATH);
+
+/** Only stdio is faked: the daemon lookup under test is the real default dep. */
+function io(): { deps: Partial<BootstrapDeps>; err: string[] } {
+  const err: string[] = [];
+  return {
+    err,
+    deps: {
+      io: {
+        stdout: () => undefined,
+        stderr: (text) => err.push(text),
+      },
+    },
+  };
+}
+
+async function run(deps: Partial<BootstrapDeps>): Promise<boolean> {
+  const result = await ensureTmuxContext({
+    configPath: CONFIG_PATH,
+    projectDir: "/tmp/zaps-defaults",
+    detach: false,
+    deps,
+  });
+  return result.proceed;
+}
+
+beforeEach(() => {
+  vi.mocked(isDaemonRunning).mockReturnValue(true);
+  vi.mocked(ipcRequest).mockReset();
+  // Inside tmux: the decision is made purely from the daemon's answer, so no
+  // Tmux subprocess ever runs from these tests.
+  vi.stubEnv("TMUX", "/tmp/tmux-1000/default,1,0");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("ensureTmuxContext — default daemon lookup", () => {
+  it("finds this project's session by id and refuses a managed one", async () => {
+    vi.mocked(ipcRequest).mockResolvedValue({
+      id: "1",
+      result: [
+        { id: "other", name: "other", projectDir: "/x", tmuxSession: "x", managed: true },
+        {
+          id: ID,
+          name: "app",
+          projectDir: "/tmp/zaps-defaults",
+          tmuxSession: "zaps-app",
+          managed: true,
+        },
+      ],
+    });
+    const { deps, err } = io();
+    await expect(run(deps)).resolves.toBe(false);
+    expect(err.join("")).toContain("zaps-managed tmux");
+  });
+
+  it("proceeds when the daemon knows no session for this project", async () => {
+    vi.mocked(ipcRequest).mockResolvedValue({ id: "1", result: [] });
+    await expect(run(io().deps)).resolves.toBe(true);
+  });
+
+  it("proceeds when the daemon is not running (no IPC attempted)", async () => {
+    vi.mocked(isDaemonRunning).mockReturnValue(false);
+    await expect(run(io().deps)).resolves.toBe(true);
+    expect(ipcRequest).not.toHaveBeenCalled();
+  });
+
+  it("treats an IPC error as 'no session' rather than failing the command", async () => {
+    vi.mocked(ipcRequest).mockResolvedValue({ id: "1", error: "boom" });
+    await expect(run(io().deps)).resolves.toBe(true);
+  });
+
+  it("treats an unreachable daemon socket the same way", async () => {
+    vi.mocked(ipcRequest).mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(run(io().deps)).resolves.toBe(true);
+  });
+});

--- a/test/cli/bootstrap-tmux.test.ts
+++ b/test/cli/bootstrap-tmux.test.ts
@@ -108,7 +108,7 @@ describe("ensureTmuxContext — refusals", () => {
     const h = harness();
     h.deps.tmux.tmuxVersion = vi.fn().mockResolvedValue(null);
     await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 1 });
-    expect(h.err.join("")).toContain("zaps requires tmux (>= 3.5a)");
+    expect(h.err.join("")).toContain("zaps requires tmux (>= 3.5)");
   });
 
   it("refuses a session running in the user's own tmux", async () => {

--- a/test/cli/bootstrap-tmux.test.ts
+++ b/test/cli/bootstrap-tmux.test.ts
@@ -33,7 +33,9 @@ function harness(overrides: Partial<BootstrapDeps> = {}): Harness {
       displayMessage: vi.fn().mockResolvedValue("1|0|"),
       hasSession: vi.fn().mockResolvedValue(false),
       killSession: vi.fn().mockResolvedValue(undefined),
-      listPanes: vi.fn().mockResolvedValue([{ id: "%3", pid: 42, width: 80, height: 24 }]),
+      listPanes: vi
+        .fn()
+        .mockResolvedValue([{ id: "%3", pid: 42, width: 80, height: 24, dead: false }]),
       tmuxVersion: vi.fn().mockResolvedValue({ major: 3, minor: 5 }),
     },
     runTmux: vi.fn(async (args: string[]) => {
@@ -41,6 +43,7 @@ function harness(overrides: Partial<BootstrapDeps> = {}): Harness {
       return 0;
     }),
     daemonSession: vi.fn().mockResolvedValue(undefined),
+    currentTmuxSession: vi.fn().mockResolvedValue(undefined),
     zapsArgv: () => ["/usr/bin/zaps"],
     size: () => ({ width: 200, height: 50 }),
     settleTimeoutMs: 200,
@@ -109,7 +112,12 @@ describe("ensureTmuxContext — refusals", () => {
   });
 
   it("refuses a session running in the user's own tmux", async () => {
-    const personal: DaemonSessionView = { name: "app", tmuxSession: "work", managed: false };
+    const personal: DaemonSessionView = {
+      name: "app",
+      tmuxSession: "work",
+      managed: false,
+      tuiPane: "%3",
+    };
     const h = harness({ daemonSession: vi.fn().mockResolvedValue(personal) });
     await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 1 });
     expect(h.err.join("")).toContain("running inside tmux session 'work'");
@@ -122,10 +130,19 @@ describe("ensureTmuxContext — re-attach", () => {
     name: "app",
     tmuxSession: "zaps-app-abc",
     managed: true,
+    tuiPane: "%3",
   };
+
+  /** Dead-but-held TUI pane: what `remain-on-exit` leaves behind after a detach. */
+  function deadTuiPane(h: Harness): void {
+    h.deps.tmux.listPanes = vi
+      .fn()
+      .mockResolvedValue([{ id: "%3", pid: 42, width: 80, height: 24, dead: true }]);
+  }
 
   it("attaches with the TTY handed to tmux and mirrors its exit code", async () => {
     const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    // Pane still alive (nothing to revive) — just attach.
     h.deps.runTmux = vi.fn(async (args: string[]) => {
       h.tmuxCalls.push(args);
       return 130;
@@ -133,6 +150,70 @@ describe("ensureTmuxContext — re-attach", () => {
     await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 130 });
     expect(h.tmuxCalls).toEqual([["-L", "zaps", "attach-session", "-t", "zaps-app-abc"]]);
     expect(vi.mocked(h.deps.runTmux).mock.calls[0][1]).toBe(true);
+  });
+
+  it("revives a dead TUI pane in place before attaching (F3)", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    deadTuiPane(h);
+    await run(h);
+    expect(h.tmuxCalls).toEqual([
+      // No `-k`: the pane is dead-but-held, respawning it must not need a kill.
+      ["-L", "zaps", "respawn-pane", "-t", "%3", "--", "/usr/bin/zaps", "attach"],
+      ["-L", "zaps", "attach-session", "-t", "zaps-app-abc"],
+    ]);
+  });
+
+  it("opens a window instead of failing when the TUI pane is gone", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    // The pane is not in the session's pane list at all.
+    h.deps.tmux.listPanes = vi
+      .fn()
+      .mockResolvedValue([{ id: "%9", pid: 1, width: 8, height: 2, dead: false }]);
+    await run(h);
+    expect(h.tmuxCalls[0]).toEqual([
+      "-L",
+      "zaps",
+      "new-window",
+      "-t",
+      "zaps-app-abc",
+      "--",
+      "/usr/bin/zaps",
+      "attach",
+    ]);
+    expect(h.err.join("")).toContain("opening a new window instead");
+  });
+
+  it("falls back to a new window when the respawn itself fails", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    deadTuiPane(h);
+    h.deps.runTmux = vi.fn(async (args: string[]) => {
+      h.tmuxCalls.push(args);
+      return args[2] === "respawn-pane" ? 1 : 0;
+    });
+    await run(h);
+    expect(h.tmuxCalls.map((args) => args[2])).toEqual([
+      "respawn-pane",
+      "new-window",
+      "attach-session",
+    ]);
+  });
+
+  it("prints the detach hint when the session outlives the client (F2)", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    deadTuiPane(h);
+    h.deps.tmux.hasSession = vi.fn().mockResolvedValue(true);
+    await run(h);
+    expect(h.out.join("")).toContain(
+      "detached — services still running. zaps to re-attach, zaps down to stop.",
+    );
+  });
+
+  it("stays silent when the session is gone (teardown prints its own summary)", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    deadTuiPane(h);
+    h.deps.tmux.hasSession = vi.fn().mockResolvedValue(false);
+    await run(h);
+    expect(h.out.join("")).toBe("");
   });
 
   it("reports instead of re-creating when `up -d` finds it running", async () => {
@@ -185,6 +266,13 @@ describe("ensureTmuxContext — attached create (F1)", () => {
       "remain-on-exit",
       "on",
     ]);
+  });
+
+  it("prints the detach hint after the foreground client exits (F2)", async () => {
+    const h = harness();
+    sessionAppearsAfterCreate(h);
+    await run(h);
+    expect(h.out.join("")).toContain("detached — services still running");
   });
 
   it("still exits with tmux's code when the session never appears", async () => {
@@ -304,11 +392,18 @@ describe("ensureTmuxContext — stale session (F9)", () => {
     expect(h.tmuxCalls[0][2]).toBe("new-session");
   });
 
-  it("never probes staleness while the daemon still owns the session", async () => {
-    const managed: DaemonSessionView = { name: "app", tmuxSession: "zaps-app", managed: true };
+  it("never reaps a session the daemon still owns", async () => {
+    const managed: DaemonSessionView = {
+      name: "app",
+      tmuxSession: "zaps-app",
+      managed: true,
+      tuiPane: "%3",
+    };
     const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
     await run(h);
-    expect(h.deps.tmux.hasSession).not.toHaveBeenCalled();
     expect(h.deps.tmux.killSession).not.toHaveBeenCalled();
+    // The only `has-session` here is the post-detach probe, which runs AFTER the
+    // Client exits — never as a staleness check that could reap a live session.
+    expect(h.tmuxCalls.at(-1)?.[2]).toBe("attach-session");
   });
 });

--- a/test/cli/bootstrap-tmux.test.ts
+++ b/test/cli/bootstrap-tmux.test.ts
@@ -148,7 +148,7 @@ describe("ensureTmuxContext — re-attach", () => {
       return 130;
     });
     await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 130 });
-    expect(h.tmuxCalls).toEqual([["-L", "zaps", "attach-session", "-t", "zaps-app-abc"]]);
+    expect(h.tmuxCalls).toEqual([["-L", "zaps", "attach-session", "-t", "=zaps-app-abc"]]);
     expect(vi.mocked(h.deps.runTmux).mock.calls[0][1]).toBe(true);
   });
 
@@ -159,7 +159,7 @@ describe("ensureTmuxContext — re-attach", () => {
     expect(h.tmuxCalls).toEqual([
       // No `-k`: the pane is dead-but-held, respawning it must not need a kill.
       ["-L", "zaps", "respawn-pane", "-t", "%3", "--", "/usr/bin/zaps", "attach"],
-      ["-L", "zaps", "attach-session", "-t", "zaps-app-abc"],
+      ["-L", "zaps", "attach-session", "-t", "=zaps-app-abc"],
     ]);
   });
 
@@ -175,7 +175,7 @@ describe("ensureTmuxContext — re-attach", () => {
       "zaps",
       "new-window",
       "-t",
-      "zaps-app-abc",
+      "=zaps-app-abc",
       "--",
       "/usr/bin/zaps",
       "attach",
@@ -252,7 +252,7 @@ describe("ensureTmuxContext — attached create (F1)", () => {
       "zaps",
       "set-option",
       "-t",
-      expect.stringContaining("zaps-zaps-bootstrap-test-") as unknown as string,
+      expect.stringMatching(/^=zaps-zaps-bootstrap-test-.*:$/u) as unknown as string,
       "destroy-unattached",
       "off",
     ]);

--- a/test/cli/bootstrap-tmux.test.ts
+++ b/test/cli/bootstrap-tmux.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ensureTmuxContext } from "../../src/cli/bootstrap-tmux.js";
+import type { BootstrapDeps } from "../../src/cli/bootstrap-tmux.js";
+import type { DaemonSessionView } from "../../src/cli/tmux-context.js";
+
+const CONFIG_PATH = "/tmp/zaps-bootstrap-test/.zaps.mts";
+const PROJECT_DIR = "/tmp/zaps-bootstrap-test";
+
+interface Harness {
+  deps: BootstrapDeps;
+  out: string[];
+  err: string[];
+  tmuxCalls: string[][];
+}
+
+/**
+ * Bootstrap wired to fakes: tmux never runs, so every path (create, respawn,
+ * settle, kill) is observable as an argv list.
+ */
+function harness(overrides: Partial<BootstrapDeps> = {}): Harness {
+  const out: string[] = [];
+  const err: string[] = [];
+  const tmuxCalls: string[][] = [];
+  const deps: BootstrapDeps = {
+    io: {
+      stdout: (text) => out.push(text),
+      stderr: (text) => err.push(text),
+    },
+    tmux: {
+      capturePane: vi.fn().mockResolvedValue(""),
+      // Dead pane, exit 0 — the happy `up -d` settlement.
+      displayMessage: vi.fn().mockResolvedValue("1|0|"),
+      hasSession: vi.fn().mockResolvedValue(false),
+      killSession: vi.fn().mockResolvedValue(undefined),
+      listPanes: vi.fn().mockResolvedValue([{ id: "%3", pid: 42, width: 80, height: 24 }]),
+      tmuxVersion: vi.fn().mockResolvedValue({ major: 3, minor: 5 }),
+    },
+    runTmux: vi.fn(async (args: string[]) => {
+      tmuxCalls.push(args);
+      return 0;
+    }),
+    daemonSession: vi.fn().mockResolvedValue(undefined),
+    zapsArgv: () => ["/usr/bin/zaps"],
+    size: () => ({ width: 200, height: 50 }),
+    settleTimeoutMs: 200,
+    sessionVisibleTimeoutMs: 100,
+    ...overrides,
+  };
+  return { deps, out, err, tmuxCalls };
+}
+
+/** `hasSession`: false for the staleness probe, true once the session exists. */
+function sessionAppearsAfterCreate(h: Harness): void {
+  h.deps.tmux.hasSession = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+}
+
+async function run(h: Harness, detach = false): Promise<{ exitCode?: number; proceed: boolean }> {
+  const result = await ensureTmuxContext({
+    configPath: CONFIG_PATH,
+    projectDir: PROJECT_DIR,
+    detach,
+    deps: h.deps,
+  });
+  return result.proceed ? { proceed: true } : { proceed: false, exitCode: result.exitCode };
+}
+
+/** Argv of the first tmux call whose verb matches. */
+function callFor(h: Harness, verb: string): string[] | undefined {
+  return h.tmuxCalls.find((args) => args[2] === verb);
+}
+
+beforeEach(() => {
+  vi.stubEnv("TMUX", undefined);
+  vi.stubEnv("ZAPS_AUTO_TMUX", undefined);
+  vi.stubEnv("ZAPS_SOCKET_PATH", undefined);
+  vi.stubEnv("XDG_RUNTIME_DIR", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("ensureTmuxContext — inside tmux", () => {
+  it("proceeds without running a single tmux command", async () => {
+    vi.stubEnv("TMUX", "/tmp/tmux-1000/default,1,0");
+    const h = harness();
+    await expect(run(h)).resolves.toEqual({ proceed: true });
+    expect(h.tmuxCalls).toEqual([]);
+    expect(h.deps.tmux.tmuxVersion).not.toHaveBeenCalled();
+    expect(h.deps.tmux.hasSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureTmuxContext — refusals", () => {
+  it("prints the legacy error for ZAPS_AUTO_TMUX=0 and exits 1", async () => {
+    vi.stubEnv("ZAPS_AUTO_TMUX", "0");
+    const h = harness();
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("zaps must be run from inside a tmux session.");
+    expect(h.tmuxCalls).toEqual([]);
+  });
+
+  it("prints the tmux requirement when tmux is missing", async () => {
+    const h = harness();
+    h.deps.tmux.tmuxVersion = vi.fn().mockResolvedValue(null);
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("zaps requires tmux (>= 3.5a)");
+  });
+
+  it("refuses a session running in the user's own tmux", async () => {
+    const personal: DaemonSessionView = { name: "app", tmuxSession: "work", managed: false };
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(personal) });
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("running inside tmux session 'work'");
+    expect(h.tmuxCalls).toEqual([]);
+  });
+});
+
+describe("ensureTmuxContext — re-attach", () => {
+  const managed: DaemonSessionView = {
+    name: "app",
+    tmuxSession: "zaps-app-abc",
+    managed: true,
+  };
+
+  it("attaches with the TTY handed to tmux and mirrors its exit code", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    h.deps.runTmux = vi.fn(async (args: string[]) => {
+      h.tmuxCalls.push(args);
+      return 130;
+    });
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 130 });
+    expect(h.tmuxCalls).toEqual([["-L", "zaps", "attach-session", "-t", "zaps-app-abc"]]);
+    expect(vi.mocked(h.deps.runTmux).mock.calls[0][1]).toBe(true);
+  });
+
+  it("reports instead of re-creating when `up -d` finds it running", async () => {
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 0 });
+    expect(h.out.join("")).toContain("already running");
+    expect(h.tmuxCalls).toEqual([]);
+  });
+});
+
+describe("ensureTmuxContext — attached create (F1)", () => {
+  it("creates the session in the foreground and mirrors tmux's exit code", async () => {
+    const h = harness();
+    sessionAppearsAfterCreate(h);
+    h.deps.runTmux = vi.fn(async (args: string[]) => {
+      h.tmuxCalls.push(args);
+      return args[2] === "new-session" ? 7 : 0;
+    });
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 7 });
+
+    const create = callFor(h, "new-session");
+    expect(create).toBeDefined();
+    expect(create?.slice(-3)).toEqual(["--", "/usr/bin/zaps", "up"]);
+    expect(create).toContain("ZAPS_MANAGED_TMUX=1");
+    expect(create).toContain("ZAPS_TMUX_SOCKET=zaps");
+    // Foreground: the child owns the terminal.
+    expect(vi.mocked(h.deps.runTmux).mock.calls[0][1]).toBe(true);
+  });
+
+  it("applies the managed options once the session shows up", async () => {
+    const h = harness();
+    sessionAppearsAfterCreate(h);
+    await run(h);
+    expect(h.tmuxCalls).toContainEqual([
+      "-L",
+      "zaps",
+      "set-option",
+      "-t",
+      expect.stringContaining("zaps-zaps-bootstrap-test-") as unknown as string,
+      "destroy-unattached",
+      "off",
+    ]);
+    expect(h.tmuxCalls).toContainEqual([
+      "-L",
+      "zaps",
+      "set-option",
+      "-p",
+      "-t",
+      "%3",
+      "remain-on-exit",
+      "on",
+    ]);
+  });
+
+  it("still exits with tmux's code when the session never appears", async () => {
+    // HasSession stays false: options are skipped, the result is unaffected.
+    const h = harness();
+    await expect(run(h)).resolves.toEqual({ proceed: false, exitCode: 0 });
+  });
+});
+
+describe("ensureTmuxContext — detached create (F4)", () => {
+  it("creates bare, sets options, then respawns the pane with zaps", async () => {
+    const h = harness();
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 0 });
+
+    const verbs = h.tmuxCalls.map((args) => args.slice(2, 3).join(""));
+    expect(verbs).toEqual(["new-session", "set-option", "set-option", "respawn-pane"]);
+
+    const create = callFor(h, "new-session");
+    // No command: the pane options must land before zaps can exit.
+    expect(create).not.toContain("--");
+    expect(create).toContain("-d");
+    expect(create?.slice(4, 8)).toEqual(["-x", "200", "-y", "50"]);
+
+    const respawn = callFor(h, "respawn-pane");
+    expect(respawn).toEqual([
+      "-L",
+      "zaps",
+      "respawn-pane",
+      "-k",
+      "-t",
+      "%3",
+      "--",
+      "/usr/bin/zaps",
+      "up",
+      "-d",
+    ]);
+    expect(h.out.join("")).toContain("started (detached, managed tmux)");
+  });
+
+  it("forwards the daemon-locating env into the session", async () => {
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
+    vi.stubEnv("ZAPS_SOCKET_PATH", "/tmp/custom.sock");
+    const h = harness();
+    await run(h, true);
+    const create = callFor(h, "new-session");
+    expect(create).toContain("XDG_RUNTIME_DIR=/run/user/1000");
+    expect(create).toContain("ZAPS_SOCKET_PATH=/tmp/custom.sock");
+  });
+
+  it("replays the inner output and propagates the exit code on failure", async () => {
+    const h = harness();
+    h.deps.tmux.displayMessage = vi.fn().mockResolvedValue("1|3|");
+    h.deps.tmux.capturePane = vi.fn().mockResolvedValue("Error: bad config\n\n");
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 3 });
+    expect(h.err.join("")).toContain("Error: bad config");
+    // No orphan session left behind.
+    expect(h.deps.tmux.killSession).toHaveBeenCalledWith(
+      expect.stringContaining("zaps-zaps-bootstrap-test-"),
+    );
+  });
+
+  it("kills the session and exits 1 when the inner run never settles", async () => {
+    // Pane still alive at the deadline: no exit code to propagate.
+    const h = harness();
+    h.deps.tmux.displayMessage = vi.fn().mockResolvedValue("0||");
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("Timed out waiting for");
+    expect(h.deps.tmux.killSession).toHaveBeenCalled();
+  });
+
+  it("reports a pane that died without a readable status", async () => {
+    const h = harness({ settleTimeoutMs: 5000 });
+    h.deps.tmux.displayMessage = vi.fn().mockRejectedValue(new Error("can't find pane"));
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("died before reporting a result");
+  });
+
+  it("gives up when tmux cannot create the session", async () => {
+    const h = harness();
+    h.deps.runTmux = vi.fn(async (args: string[]) => {
+      h.tmuxCalls.push(args);
+      return args[2] === "new-session" ? 1 : 0;
+    });
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("Failed to create managed tmux session");
+    expect(h.tmuxCalls).toHaveLength(1);
+  });
+
+  it("cleans up when the session disappears before the pane can be read", async () => {
+    const h = harness();
+    h.deps.tmux.listPanes = vi.fn().mockResolvedValue([]);
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("vanished before it could start");
+    expect(h.deps.tmux.killSession).toHaveBeenCalled();
+  });
+
+  it("cleans up when the pane cannot be respawned with zaps", async () => {
+    const h = harness();
+    h.deps.runTmux = vi.fn(async (args: string[]) => {
+      h.tmuxCalls.push(args);
+      return args[2] === "respawn-pane" ? 1 : 0;
+    });
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("Failed to start zaps in managed tmux session");
+    expect(h.deps.tmux.killSession).toHaveBeenCalled();
+  });
+});
+
+describe("ensureTmuxContext — stale session (F9)", () => {
+  it("kills the leftover session before creating a fresh one", async () => {
+    const h = harness();
+    h.deps.tmux.hasSession = vi.fn().mockResolvedValue(true);
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 0 });
+    expect(h.deps.tmux.killSession).toHaveBeenCalledWith(
+      expect.stringContaining("zaps-zaps-bootstrap-test-"),
+    );
+    expect(h.tmuxCalls[0][2]).toBe("new-session");
+  });
+
+  it("never probes staleness while the daemon still owns the session", async () => {
+    const managed: DaemonSessionView = { name: "app", tmuxSession: "zaps-app", managed: true };
+    const h = harness({ daemonSession: vi.fn().mockResolvedValue(managed) });
+    await run(h);
+    expect(h.deps.tmux.hasSession).not.toHaveBeenCalled();
+    expect(h.deps.tmux.killSession).not.toHaveBeenCalled();
+  });
+});

--- a/test/cli/bootstrap-tmux.test.ts
+++ b/test/cli/bootstrap-tmux.test.ts
@@ -350,6 +350,34 @@ describe("ensureTmuxContext — detached create (F4)", () => {
     expect(h.err.join("")).toContain("died before reporting a result");
   });
 
+  it("falls back to the daemon when the dead pane's status never lands", async () => {
+    // Reap-lag zombie: pane dead, status unreadable forever — but the daemon
+    // Registered the session, which only happens when the inner run succeeded.
+    const h = harness({
+      settleTimeoutMs: 5000,
+      daemonSession: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValue({
+        name: "app",
+        tmuxSession: "zaps-app-x",
+        managed: true,
+        tuiPane: "%3",
+      }),
+    });
+    h.deps.tmux.displayMessage = vi.fn().mockResolvedValue("1||");
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 0 });
+    expect(h.out.join("")).toContain("started (detached, managed tmux)");
+    expect(h.deps.tmux.killSession).not.toHaveBeenCalled();
+  });
+
+  it("still fails on an unreadable status when the daemon knows nothing", async () => {
+    // Pre-session failures never register a daemon session, so the fallback
+    // Cannot mask them.
+    const h = harness({ settleTimeoutMs: 5000 });
+    h.deps.tmux.displayMessage = vi.fn().mockResolvedValue("1||");
+    await expect(run(h, true)).resolves.toEqual({ proceed: false, exitCode: 1 });
+    expect(h.err.join("")).toContain("died before reporting a result");
+    expect(h.deps.tmux.killSession).toHaveBeenCalled();
+  });
+
   it("gives up when tmux cannot create the session", async () => {
     const h = harness();
     h.deps.runTmux = vi.fn(async (args: string[]) => {

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -130,9 +130,27 @@ describe("resolveRuntime", () => {
 
 describe("resolveTargetSession", () => {
   const sessions: SessionInfo[] = [
-    { id: "abc123", name: "project-a", projectDir: "/a" },
-    { id: "def456", name: "project-b", projectDir: "/b" },
-    { id: "ghi789", name: "project-c", projectDir: "/c" },
+    {
+      id: "abc123",
+      name: "project-a",
+      projectDir: "/a",
+      tmuxSession: "tmux-abc123",
+      managed: false,
+    },
+    {
+      id: "def456",
+      name: "project-b",
+      projectDir: "/b",
+      tmuxSession: "tmux-def456",
+      managed: false,
+    },
+    {
+      id: "ghi789",
+      name: "project-c",
+      projectDir: "/c",
+      tmuxSession: "tmux-ghi789",
+      managed: false,
+    },
   ];
 
   it("returns exact id match", () => {
@@ -181,8 +199,8 @@ describe("resolveTargetSession", () => {
 
   it("prefers exact id over exact name", () => {
     const dupes: SessionInfo[] = [
-      { id: "abc", name: "xyz", projectDir: "/1" },
-      { id: "xyz", name: "abc", projectDir: "/2" },
+      { id: "abc", name: "xyz", projectDir: "/1", tmuxSession: "tmux-abc", managed: false },
+      { id: "xyz", name: "abc", projectDir: "/2", tmuxSession: "tmux-xyz", managed: false },
     ];
     // "abc" should match first by exact id
     expect(resolveTargetSession(dupes, "abc")).toBe(dupes[0]);
@@ -273,7 +291,15 @@ describe("withDaemon", () => {
     const { ipcRequest } = await import("../../src/lib/ipc/client.js");
     vi.mocked(ipcRequest).mockResolvedValue({
       id: "r1",
-      result: [{ id: "abc123", name: "project-a", projectDir: "/a" }],
+      result: [
+        {
+          id: "abc123",
+          name: "project-a",
+          projectDir: "/a",
+          tmuxSession: "tmux-abc123",
+          managed: false,
+        },
+      ],
     });
 
     const result = await withDaemon(async (ipc) => {
@@ -303,7 +329,15 @@ describe("withDaemon", () => {
     const { ipcRequest } = await import("../../src/lib/ipc/client.js");
     vi.mocked(ipcRequest).mockResolvedValue({
       id: "r1",
-      result: [{ id: "session-/my/.zaps.mts", name: "my-project", projectDir: "/my" }],
+      result: [
+        {
+          id: "session-/my/.zaps.mts",
+          name: "my-project",
+          projectDir: "/my",
+          tmuxSession: "tmux-session-/my/.zaps.mts",
+          managed: false,
+        },
+      ],
     });
 
     const result = await withDaemon(async (ipc) => {
@@ -323,7 +357,15 @@ describe("withDaemon", () => {
     const { ipcRequest } = await import("../../src/lib/ipc/client.js");
     vi.mocked(ipcRequest).mockResolvedValue({
       id: "r1",
-      result: [{ id: "other-session", name: "other", projectDir: "/other" }],
+      result: [
+        {
+          id: "other-session",
+          name: "other",
+          projectDir: "/other",
+          tmuxSession: "tmux-other-session",
+          managed: false,
+        },
+      ],
     });
 
     await expect(withDaemon(async () => "result")).rejects.toThrow(
@@ -346,7 +388,9 @@ describe("withDaemon", () => {
 });
 
 describe("runDown", () => {
-  const sessions = [{ id: "abc", name: "proj", projectDir: "/proj" }];
+  const sessions = [
+    { id: "abc", name: "proj", projectDir: "/proj", tmuxSession: "tmux-abc", managed: false },
+  ];
 
   function makeDeps(over: Partial<DownDeps> = {}): {
     deps: DownDeps;
@@ -440,8 +484,14 @@ describe("parsePositiveInt", () => {
 
 describe("resolveTargetSession — subdirectory resolution (E12)", () => {
   const sessions: SessionInfo[] = [
-    { id: "a1", name: "app", projectDir: "/home/u/app" },
-    { id: "b1", name: "other", projectDir: "/home/u/other" },
+    { id: "a1", name: "app", projectDir: "/home/u/app", tmuxSession: "tmux-a1", managed: false },
+    {
+      id: "b1",
+      name: "other",
+      projectDir: "/home/u/other",
+      tmuxSession: "tmux-b1",
+      managed: false,
+    },
   ];
 
   function withCwd(cwd: string, fn: () => void) {
@@ -461,8 +511,14 @@ describe("resolveTargetSession — subdirectory resolution (E12)", () => {
 
   it("does not match a sibling dir sharing a name prefix (/app vs /app2)", () => {
     const siblings: SessionInfo[] = [
-      { id: "a1", name: "app", projectDir: "/home/u/app" },
-      { id: "c1", name: "other", projectDir: "/home/u/zzz" },
+      { id: "a1", name: "app", projectDir: "/home/u/app", tmuxSession: "tmux-a1", managed: false },
+      {
+        id: "c1",
+        name: "other",
+        projectDir: "/home/u/zzz",
+        tmuxSession: "tmux-c1",
+        managed: false,
+      },
     ];
     withCwd("/home/u/app2", () => {
       expect(() => resolveTargetSession(siblings)).toThrow(/Multiple sessions/);
@@ -471,8 +527,20 @@ describe("resolveTargetSession — subdirectory resolution (E12)", () => {
 
   it("prefers the deepest (longest) projectDir for nested projects", () => {
     const nested: SessionInfo[] = [
-      { id: "root", name: "monorepo", projectDir: "/home/u/app" },
-      { id: "pkg", name: "api", projectDir: "/home/u/app/packages/api" },
+      {
+        id: "root",
+        name: "monorepo",
+        projectDir: "/home/u/app",
+        tmuxSession: "tmux-root",
+        managed: false,
+      },
+      {
+        id: "pkg",
+        name: "api",
+        projectDir: "/home/u/app/packages/api",
+        tmuxSession: "tmux-pkg",
+        managed: false,
+      },
     ];
     withCwd("/home/u/app/packages/api/src", () => {
       expect(resolveTargetSession(nested).id).toBe("pkg");
@@ -495,7 +563,13 @@ describe("resolveListedSessionId (E8 events validation)", () => {
     const { discoverConfig } = await import("../../src/config/discovery.js");
     vi.mocked(discoverConfig).mockReturnValue("/my/.zaps.mts");
     const sessions: SessionInfo[] = [
-      { id: "session-/my/.zaps.mts", name: "my", projectDir: "/my" },
+      {
+        id: "session-/my/.zaps.mts",
+        name: "my",
+        projectDir: "/my",
+        tmuxSession: "tmux-session-/my/.zaps.mts",
+        managed: false,
+      },
     ];
     expect(resolveListedSessionId(sessions)).toBe("session-/my/.zaps.mts");
   });
@@ -507,12 +581,16 @@ describe("resolveListedSessionId (E8 events validation)", () => {
   });
 
   it("defers to resolveTargetSession for an explicit arg", () => {
-    const sessions: SessionInfo[] = [{ id: "abc", name: "proj", projectDir: "/p" }];
+    const sessions: SessionInfo[] = [
+      { id: "abc", name: "proj", projectDir: "/p", tmuxSession: "tmux-abc", managed: false },
+    ];
     expect(resolveListedSessionId(sessions, "proj")).toBe("abc");
   });
 
   it("throws for an explicit arg that matches nothing", () => {
-    const sessions: SessionInfo[] = [{ id: "abc", name: "proj", projectDir: "/p" }];
+    const sessions: SessionInfo[] = [
+      { id: "abc", name: "proj", projectDir: "/p", tmuxSession: "tmux-abc", managed: false },
+    ];
     expect(() => resolveListedSessionId(sessions, "ghost")).toThrow(/Session not found/);
   });
 });

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -136,6 +136,7 @@ describe("resolveTargetSession", () => {
       projectDir: "/a",
       tmuxSession: "tmux-abc123",
       managed: false,
+      tuiPane: null,
     },
     {
       id: "def456",
@@ -143,6 +144,7 @@ describe("resolveTargetSession", () => {
       projectDir: "/b",
       tmuxSession: "tmux-def456",
       managed: false,
+      tuiPane: null,
     },
     {
       id: "ghi789",
@@ -150,6 +152,7 @@ describe("resolveTargetSession", () => {
       projectDir: "/c",
       tmuxSession: "tmux-ghi789",
       managed: false,
+      tuiPane: null,
     },
   ];
 
@@ -199,8 +202,22 @@ describe("resolveTargetSession", () => {
 
   it("prefers exact id over exact name", () => {
     const dupes: SessionInfo[] = [
-      { id: "abc", name: "xyz", projectDir: "/1", tmuxSession: "tmux-abc", managed: false },
-      { id: "xyz", name: "abc", projectDir: "/2", tmuxSession: "tmux-xyz", managed: false },
+      {
+        id: "abc",
+        name: "xyz",
+        projectDir: "/1",
+        tmuxSession: "tmux-abc",
+        managed: false,
+        tuiPane: null,
+      },
+      {
+        id: "xyz",
+        name: "abc",
+        projectDir: "/2",
+        tmuxSession: "tmux-xyz",
+        managed: false,
+        tuiPane: null,
+      },
     ];
     // "abc" should match first by exact id
     expect(resolveTargetSession(dupes, "abc")).toBe(dupes[0]);
@@ -298,6 +315,7 @@ describe("withDaemon", () => {
           projectDir: "/a",
           tmuxSession: "tmux-abc123",
           managed: false,
+          tuiPane: null,
         },
       ],
     });
@@ -336,6 +354,7 @@ describe("withDaemon", () => {
           projectDir: "/my",
           tmuxSession: "tmux-session-/my/.zaps.mts",
           managed: false,
+          tuiPane: null,
         },
       ],
     });
@@ -364,6 +383,7 @@ describe("withDaemon", () => {
           projectDir: "/other",
           tmuxSession: "tmux-other-session",
           managed: false,
+          tuiPane: null,
         },
       ],
     });
@@ -389,7 +409,14 @@ describe("withDaemon", () => {
 
 describe("runDown", () => {
   const sessions = [
-    { id: "abc", name: "proj", projectDir: "/proj", tmuxSession: "tmux-abc", managed: false },
+    {
+      id: "abc",
+      name: "proj",
+      projectDir: "/proj",
+      tmuxSession: "tmux-abc",
+      managed: false,
+      tuiPane: null,
+    },
   ];
 
   function makeDeps(over: Partial<DownDeps> = {}): {
@@ -484,13 +511,21 @@ describe("parsePositiveInt", () => {
 
 describe("resolveTargetSession — subdirectory resolution (E12)", () => {
   const sessions: SessionInfo[] = [
-    { id: "a1", name: "app", projectDir: "/home/u/app", tmuxSession: "tmux-a1", managed: false },
+    {
+      id: "a1",
+      name: "app",
+      projectDir: "/home/u/app",
+      tmuxSession: "tmux-a1",
+      managed: false,
+      tuiPane: null,
+    },
     {
       id: "b1",
       name: "other",
       projectDir: "/home/u/other",
       tmuxSession: "tmux-b1",
       managed: false,
+      tuiPane: null,
     },
   ];
 
@@ -511,13 +546,21 @@ describe("resolveTargetSession — subdirectory resolution (E12)", () => {
 
   it("does not match a sibling dir sharing a name prefix (/app vs /app2)", () => {
     const siblings: SessionInfo[] = [
-      { id: "a1", name: "app", projectDir: "/home/u/app", tmuxSession: "tmux-a1", managed: false },
+      {
+        id: "a1",
+        name: "app",
+        projectDir: "/home/u/app",
+        tmuxSession: "tmux-a1",
+        managed: false,
+        tuiPane: null,
+      },
       {
         id: "c1",
         name: "other",
         projectDir: "/home/u/zzz",
         tmuxSession: "tmux-c1",
         managed: false,
+        tuiPane: null,
       },
     ];
     withCwd("/home/u/app2", () => {
@@ -533,6 +576,7 @@ describe("resolveTargetSession — subdirectory resolution (E12)", () => {
         projectDir: "/home/u/app",
         tmuxSession: "tmux-root",
         managed: false,
+        tuiPane: null,
       },
       {
         id: "pkg",
@@ -540,6 +584,7 @@ describe("resolveTargetSession — subdirectory resolution (E12)", () => {
         projectDir: "/home/u/app/packages/api",
         tmuxSession: "tmux-pkg",
         managed: false,
+        tuiPane: null,
       },
     ];
     withCwd("/home/u/app/packages/api/src", () => {
@@ -569,6 +614,7 @@ describe("resolveListedSessionId (E8 events validation)", () => {
         projectDir: "/my",
         tmuxSession: "tmux-session-/my/.zaps.mts",
         managed: false,
+        tuiPane: null,
       },
     ];
     expect(resolveListedSessionId(sessions)).toBe("session-/my/.zaps.mts");
@@ -582,14 +628,28 @@ describe("resolveListedSessionId (E8 events validation)", () => {
 
   it("defers to resolveTargetSession for an explicit arg", () => {
     const sessions: SessionInfo[] = [
-      { id: "abc", name: "proj", projectDir: "/p", tmuxSession: "tmux-abc", managed: false },
+      {
+        id: "abc",
+        name: "proj",
+        projectDir: "/p",
+        tmuxSession: "tmux-abc",
+        managed: false,
+        tuiPane: null,
+      },
     ];
     expect(resolveListedSessionId(sessions, "proj")).toBe("abc");
   });
 
   it("throws for an explicit arg that matches nothing", () => {
     const sessions: SessionInfo[] = [
-      { id: "abc", name: "proj", projectDir: "/p", tmuxSession: "tmux-abc", managed: false },
+      {
+        id: "abc",
+        name: "proj",
+        projectDir: "/p",
+        tmuxSession: "tmux-abc",
+        managed: false,
+        tuiPane: null,
+      },
     ];
     expect(() => resolveListedSessionId(sessions, "ghost")).toThrow(/Session not found/);
   });

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -467,6 +467,31 @@ describe("runDown", () => {
     expect(destroy).not.toHaveBeenCalled();
   });
 
+  it("reports the managed tmux kill that came with the destroy (F5)", async () => {
+    const managedSessions = [
+      {
+        id: "abc",
+        name: "proj",
+        projectDir: "/proj",
+        tmuxSession: "zaps-proj-abc123abc123",
+        managed: true,
+        tuiPane: "%0",
+      },
+    ];
+    const { deps, out } = makeDeps({
+      listSessions: async () => ({ id: "l1", result: managedSessions }),
+    });
+    expect(await runDown(deps)).toBe(0);
+    expect(out.join("")).toContain("Session destroyed.");
+    expect(out.join("")).toContain("Killed managed tmux session zaps-proj-abc123abc123.");
+  });
+
+  it("says nothing about tmux for a session in the user's own tmux", async () => {
+    const { deps, out } = makeDeps();
+    expect(await runDown(deps)).toBe(0);
+    expect(out.join("")).not.toContain("Killed managed tmux session");
+  });
+
   it("returns 1 when destroy fails", async () => {
     const { deps, err } = makeDeps({ destroy: async () => ({ id: "d1", error: "no" }) });
     expect(await runDown(deps)).toBe(1);

--- a/test/cli/output.test.ts
+++ b/test/cli/output.test.ts
@@ -1,7 +1,13 @@
 import { encode } from "@toon-format/toon";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isCodingAgent, resolveFormat, writeData } from "../../src/cli/output.js";
+import {
+  isCodingAgent,
+  resolveFormat,
+  sessionLocation,
+  sessionRows,
+  writeData,
+} from "../../src/cli/output.js";
 
 const AGENT_VARS = ["CLAUDECODE", "CURSOR_TRACE_DIR"];
 
@@ -157,5 +163,43 @@ describe("writeData", () => {
   it("handles arrays", () => {
     writeData([], "json");
     expect(written).toBe("[]\n");
+  });
+});
+
+describe("sessionLocation", () => {
+  it("marks a tmux session zaps owns", () => {
+    expect(
+      sessionLocation({
+        id: "a",
+        name: "app",
+        projectDir: "/app",
+        tmuxSession: "zaps-app-abc123abc123",
+        managed: true,
+      }),
+    ).toBe("zaps-app-abc123abc123 (managed)");
+  });
+
+  it("names a personal tmux session without the marker", () => {
+    expect(sessionLocation({ id: "a", name: "app", projectDir: "/app", tmuxSession: "work" })).toBe(
+      "work",
+    );
+  });
+
+  it("stays blank when an older daemon reports no tmux session", () => {
+    expect(sessionLocation({ id: "a", name: "app", projectDir: "/app" })).toBe("");
+  });
+});
+
+describe("sessionRows", () => {
+  it("puts the location last, after id/name/dir", () => {
+    expect(
+      sessionRows([
+        { id: "a1", name: "app", projectDir: "/app", tmuxSession: "zaps-app-a1", managed: true },
+        { id: "b2", name: "api", projectDir: "/api", tmuxSession: "work" },
+      ]),
+    ).toEqual([
+      ["a1", "app", "/app", "zaps-app-a1 (managed)"],
+      ["b2", "api", "/api", "work"],
+    ]);
   });
 });

--- a/test/cli/tmux-context.test.ts
+++ b/test/cli/tmux-context.test.ts
@@ -85,9 +85,14 @@ describe("decideTmuxContext — inside tmux", () => {
       }),
     );
     expect(decision.kind).toBe("refuse-managed");
-    expect(decision).toMatchObject({
-      message: expect.stringContaining("zaps-managed tmux") as unknown as string,
-    });
+    const { message } = decision as { message: string };
+    // Exact spec wording, plus the copy-pasteable escape hatch (Q5).
+    expect(message).toBe(
+      [
+        `Session "app" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`,
+        `  tmux -L zaps attach -t ${MANAGED_NAME}`,
+      ].join("\n"),
+    );
   });
 });
 
@@ -162,12 +167,13 @@ describe("decideTmuxContext — running sessions", () => {
     });
   });
 
-  it("refuses a session living in the user's own tmux (F6)", () => {
+  it("refuses a session living in the user's own tmux with the spec message (F6)", () => {
     const decision = decideTmuxContext(input({ daemonSession: personalSession }));
     expect(decision.kind).toBe("refuse-personal");
     const { message } = decision as { message: string };
-    expect(message).toContain(`Session "app" is running inside tmux session 'work'`);
-    expect(message).toContain("zaps down");
+    expect(message).toBe(
+      `Session "app" is running inside tmux session 'work'. Attach from within tmux, or run zaps down first.`,
+    );
   });
 
   it("refuses the personal session even with -d (never spawns a second one)", () => {

--- a/test/cli/tmux-context.test.ts
+++ b/test/cli/tmux-context.test.ts
@@ -17,6 +17,7 @@ function input(overrides: Partial<TmuxContextInput> = {}): TmuxContextInput {
     detach: false,
     tmuxAvailability: { ok: true, version: "3.5" },
     daemonSession: undefined,
+    currentTmuxSession: undefined,
     managedName: MANAGED_NAME,
     managedSessionExists: false,
     ...overrides,
@@ -27,12 +28,14 @@ const managedSession: DaemonSessionView = {
   name: "app",
   tmuxSession: MANAGED_NAME,
   managed: true,
+  tuiPane: "%3",
 };
 
 const personalSession: DaemonSessionView = {
   name: "app",
   tmuxSession: "work",
   managed: false,
+  tuiPane: "%1",
 };
 
 describe("decideTmuxContext — inside tmux", () => {
@@ -60,9 +63,26 @@ describe("decideTmuxContext — inside tmux", () => {
     expect(decision).toEqual({ kind: "proceed-inside" });
   });
 
-  it("refuses when this project's session is managed (F7)", () => {
+  it("carries on inside the project's OWN managed session (post-detach shell)", () => {
+    // The tmux-naive user quit the TUI and typed `zaps` at the pane's shell:
+    // Refusing here would be a dead end — the TUI just attaches in this pane.
     const decision = decideTmuxContext(
-      input({ tmuxEnv: "/tmp/tmux-1000/default,123,0", daemonSession: managedSession }),
+      input({
+        tmuxEnv: "/tmp/tmux-1000/zaps,123,0",
+        daemonSession: managedSession,
+        currentTmuxSession: MANAGED_NAME,
+      }),
+    );
+    expect(decision).toEqual({ kind: "proceed-inside" });
+  });
+
+  it("refuses when the session is managed by a tmux we are NOT in (F7)", () => {
+    const decision = decideTmuxContext(
+      input({
+        tmuxEnv: "/tmp/tmux-1000/default,123,0",
+        daemonSession: managedSession,
+        currentTmuxSession: "work",
+      }),
     );
     expect(decision.kind).toBe("refuse-managed");
     expect(decision).toMatchObject({
@@ -126,10 +146,11 @@ describe("decideTmuxContext — escape hatch and tmux gate", () => {
 });
 
 describe("decideTmuxContext — running sessions", () => {
-  it("re-attaches to this project's managed session (F3)", () => {
+  it("re-attaches to this project's managed session, carrying its TUI pane (F3)", () => {
     expect(decideTmuxContext(input({ daemonSession: managedSession }))).toEqual({
       kind: "reattach",
       name: MANAGED_NAME,
+      tuiPane: "%3",
     });
   });
 

--- a/test/cli/tmux-context.test.ts
+++ b/test/cli/tmux-context.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LEGACY_TMUX_ERROR,
+  TMUX_INSTALL_URL,
+  decideTmuxContext,
+} from "../../src/cli/tmux-context.js";
+import type { DaemonSessionView, TmuxContextInput } from "../../src/cli/tmux-context.js";
+
+const MANAGED_NAME = "zaps-app-a1b2c3d4e5f6";
+
+/** Plain terminal, tmux fine, nothing running — the F1 baseline. */
+function input(overrides: Partial<TmuxContextInput> = {}): TmuxContextInput {
+  return {
+    tmuxEnv: undefined,
+    autoTmuxEnv: undefined,
+    detach: false,
+    tmuxAvailability: { ok: true, version: "3.5" },
+    daemonSession: undefined,
+    managedName: MANAGED_NAME,
+    managedSessionExists: false,
+    ...overrides,
+  };
+}
+
+const managedSession: DaemonSessionView = {
+  name: "app",
+  tmuxSession: MANAGED_NAME,
+  managed: true,
+};
+
+const personalSession: DaemonSessionView = {
+  name: "app",
+  tmuxSession: "work",
+  managed: false,
+};
+
+describe("decideTmuxContext — inside tmux", () => {
+  it("proceeds with today's flow, unchanged", () => {
+    expect(decideTmuxContext(input({ tmuxEnv: "/tmp/tmux-1000/default,123,0" }))).toEqual({
+      kind: "proceed-inside",
+    });
+  });
+
+  it("proceeds even when a personal session is already running", () => {
+    const decision = decideTmuxContext(
+      input({ tmuxEnv: "/tmp/tmux-1000/default,123,0", daemonSession: personalSession }),
+    );
+    expect(decision).toEqual({ kind: "proceed-inside" });
+  });
+
+  it("wins over the escape hatch and a broken tmux binary (both are irrelevant inside)", () => {
+    const decision = decideTmuxContext(
+      input({
+        tmuxEnv: "/tmp/tmux-1000/default,123,0",
+        autoTmuxEnv: "0",
+        tmuxAvailability: { ok: false, reason: "missing" },
+      }),
+    );
+    expect(decision).toEqual({ kind: "proceed-inside" });
+  });
+
+  it("refuses when this project's session is managed (F7)", () => {
+    const decision = decideTmuxContext(
+      input({ tmuxEnv: "/tmp/tmux-1000/default,123,0", daemonSession: managedSession }),
+    );
+    expect(decision.kind).toBe("refuse-managed");
+    expect(decision).toMatchObject({
+      message: expect.stringContaining("zaps-managed tmux") as unknown as string,
+    });
+  });
+});
+
+describe("decideTmuxContext — escape hatch and tmux gate", () => {
+  it("restores the legacy error for ZAPS_AUTO_TMUX=0", () => {
+    expect(decideTmuxContext(input({ autoTmuxEnv: "0" }))).toEqual({
+      kind: "error-legacy",
+      message: LEGACY_TMUX_ERROR,
+    });
+  });
+
+  it("only honors an exact '0' opt-out", () => {
+    expect(decideTmuxContext(input({ autoTmuxEnv: "1" })).kind).toBe("spawn");
+    expect(decideTmuxContext(input({ autoTmuxEnv: "" })).kind).toBe("spawn");
+  });
+
+  it("takes the escape hatch before probing tmux", () => {
+    const decision = decideTmuxContext(
+      input({ autoTmuxEnv: "0", tmuxAvailability: { ok: false, reason: "missing" } }),
+    );
+    expect(decision.kind).toBe("error-legacy");
+  });
+
+  it("reports missing tmux with the install link (F8)", () => {
+    const decision = decideTmuxContext(
+      input({ tmuxAvailability: { ok: false, reason: "missing" } }),
+    );
+    expect(decision.kind).toBe("error-no-tmux");
+    const { message } = decision as { message: string };
+    expect(message).toContain("zaps requires tmux (>= 3.5a)");
+    expect(message).toContain(TMUX_INSTALL_URL);
+    expect(message).not.toContain("Found tmux");
+  });
+
+  it("names the version it found when tmux is too old (F8)", () => {
+    const decision = decideTmuxContext(
+      input({ tmuxAvailability: { ok: false, reason: "too-old", version: "3.2" } }),
+    );
+    expect(decision.kind).toBe("error-no-tmux");
+    const { message } = decision as { message: string };
+    // The requirement is quoted verbatim from the spec, never the parsed label.
+    expect(message).toContain(">= 3.5a");
+    expect(message).toContain("Found tmux 3.2.");
+  });
+
+  it("gates on tmux before touching any session state", () => {
+    const decision = decideTmuxContext(
+      input({
+        tmuxAvailability: { ok: false, reason: "missing" },
+        daemonSession: managedSession,
+        managedSessionExists: true,
+      }),
+    );
+    expect(decision.kind).toBe("error-no-tmux");
+  });
+});
+
+describe("decideTmuxContext — running sessions", () => {
+  it("re-attaches to this project's managed session (F3)", () => {
+    expect(decideTmuxContext(input({ daemonSession: managedSession }))).toEqual({
+      kind: "reattach",
+      name: MANAGED_NAME,
+    });
+  });
+
+  it("reports instead of re-creating when `up -d` finds it already running", () => {
+    const decision = decideTmuxContext(input({ daemonSession: managedSession, detach: true }));
+    expect(decision.kind).toBe("already-running");
+    expect(decision).toMatchObject({
+      message: expect.stringContaining("already running") as unknown as string,
+    });
+  });
+
+  it("refuses a session living in the user's own tmux (F6)", () => {
+    const decision = decideTmuxContext(input({ daemonSession: personalSession }));
+    expect(decision.kind).toBe("refuse-personal");
+    const { message } = decision as { message: string };
+    expect(message).toContain(`Session "app" is running inside tmux session 'work'`);
+    expect(message).toContain("zaps down");
+  });
+
+  it("refuses the personal session even with -d (never spawns a second one)", () => {
+    expect(decideTmuxContext(input({ daemonSession: personalSession, detach: true })).kind).toBe(
+      "refuse-personal",
+    );
+  });
+
+  it("prefers the daemon's answer over a same-named tmux session", () => {
+    // Not stale: the daemon still owns it, so the name must not be reaped.
+    const decision = decideTmuxContext(
+      input({ daemonSession: managedSession, managedSessionExists: true }),
+    );
+    expect(decision.kind).toBe("reattach");
+  });
+});
+
+describe("decideTmuxContext — stale sessions (F9)", () => {
+  it("reaps a managed session the daemon knows nothing about, then creates", () => {
+    expect(decideTmuxContext(input({ managedSessionExists: true }))).toEqual({
+      kind: "kill-stale-then-spawn",
+      name: MANAGED_NAME,
+      detach: false,
+    });
+  });
+
+  it("carries the detach flag through the stale path", () => {
+    expect(decideTmuxContext(input({ managedSessionExists: true, detach: true }))).toEqual({
+      kind: "kill-stale-then-spawn",
+      name: MANAGED_NAME,
+      detach: true,
+    });
+  });
+});
+
+describe("decideTmuxContext — create paths", () => {
+  it("spawns and attaches for plain `zaps` / `zaps up` (F1)", () => {
+    expect(decideTmuxContext(input())).toEqual({ kind: "spawn", name: MANAGED_NAME });
+  });
+
+  it("spawns detached for `zaps up -d` (F4)", () => {
+    expect(decideTmuxContext(input({ detach: true }))).toEqual({
+      kind: "spawn-detached",
+      name: MANAGED_NAME,
+    });
+  });
+});

--- a/test/cli/tmux-context.test.ts
+++ b/test/cli/tmux-context.test.ts
@@ -122,7 +122,7 @@ describe("decideTmuxContext — escape hatch and tmux gate", () => {
     );
     expect(decision.kind).toBe("error-no-tmux");
     const { message } = decision as { message: string };
-    expect(message).toContain("zaps requires tmux (>= 3.5a)");
+    expect(message).toContain("zaps requires tmux (>= 3.5)");
     expect(message).toContain(TMUX_INSTALL_URL);
     expect(message).not.toContain("Found tmux");
   });
@@ -134,7 +134,7 @@ describe("decideTmuxContext — escape hatch and tmux gate", () => {
     expect(decision.kind).toBe("error-no-tmux");
     const { message } = decision as { message: string };
     // The requirement is quoted verbatim from the spec, never the parsed label.
-    expect(message).toContain(">= 3.5a");
+    expect(message).toContain(">= 3.5");
     expect(message).toContain("Found tmux 3.2.");
   });
 

--- a/test/cli/tmux-context.test.ts
+++ b/test/cli/tmux-context.test.ts
@@ -90,7 +90,7 @@ describe("decideTmuxContext — inside tmux", () => {
     expect(message).toBe(
       [
         `Session "app" is running in a zaps-managed tmux. Re-attach from a plain terminal (zaps attach), or run zaps down first.`,
-        `  tmux -L zaps attach -t ${MANAGED_NAME}`,
+        `  tmux -L zaps attach -t =${MANAGED_NAME}`,
       ].join("\n"),
     );
   });

--- a/test/components/Router.failed-output.test.tsx
+++ b/test/components/Router.failed-output.test.tsx
@@ -18,6 +18,9 @@ import type { ServiceStatus } from "../../src/lib/service/types.js";
 
 vi.mock("../../src/lib/open.js", () => ({ openInBrowser: vi.fn() }));
 vi.mock("../../src/lib/tmux.js", () => ({
+  // `q` detaches the tmux client in managed mode; keep the mock complete so a
+  // Future test pressing `q` fails loudly instead of silently skipping it.
+  detachClient: vi.fn().mockResolvedValue(undefined),
   zoomPane: vi.fn(),
   editPaneCapture: vi.fn().mockResolvedValue(undefined),
 }));

--- a/test/components/Router.overlay.test.tsx
+++ b/test/components/Router.overlay.test.tsx
@@ -14,6 +14,9 @@ import type { ServiceStatus } from "../../src/lib/service/types.js";
 
 vi.mock("../../src/lib/open.js", () => ({ openInBrowser: vi.fn() }));
 vi.mock("../../src/lib/tmux.js", () => ({
+  // `q` detaches the tmux client in managed mode; keep the mock complete so a
+  // Future test pressing `q` fails loudly instead of silently skipping it.
+  detachClient: vi.fn().mockResolvedValue(undefined),
   zoomPane: vi.fn(),
   editPaneCapture: vi.fn().mockResolvedValue(undefined),
 }));

--- a/test/components/Router.overlay.test.tsx
+++ b/test/components/Router.overlay.test.tsx
@@ -179,3 +179,57 @@ describe("Router help overlay", () => {
     expect(overlay?.top?.id).toBe("help");
   });
 });
+
+// The shutdown gate lives here (not in Router.test.tsx) because it needs a real
+// `OverlayHost` mounted: the overlay owns its own `useInput`.
+describe("Router shutdown confirmation", () => {
+  afterEach(() => {
+    overlay = undefined;
+  });
+
+  it("tears the session down only after `y`", async () => {
+    const client = createMockClient();
+    const { stdin } = renderWithOverlay(client, [STATUS]);
+
+    stdin.write("\x04"); // Ctrl-D
+    await flush();
+    expect(overlay?.top?.id).toBe("shutdown-confirm");
+    expect(client.destroySession).not.toHaveBeenCalled();
+
+    stdin.write("y");
+    await flush();
+    expect(client.destroySession).toHaveBeenCalledTimes(1);
+    expect(overlay?.isOpen).toBe(false);
+  });
+
+  // A tmux client attaching with its own stdin at EOF makes the pty emit VEOF
+  // (0x04), which tmux hands to the pane as a plain Ctrl-D. Repeats of that byte
+  // Must stay harmless — only a distinct key confirms.
+  it("survives a stream of stray Ctrl-D bytes", async () => {
+    const client = createMockClient();
+    const { stdin } = renderWithOverlay(client, [STATUS]);
+
+    stdin.write("\x04");
+    await flush();
+    stdin.write("\x04");
+    await flush();
+    stdin.write("\x04");
+    await flush();
+
+    expect(client.destroySession).not.toHaveBeenCalled();
+  });
+
+  it("cancels on any other key", async () => {
+    const client = createMockClient();
+    const { stdin } = renderWithOverlay(client, [STATUS]);
+
+    stdin.write("d");
+    await flush();
+    expect(overlay?.top?.id).toBe("shutdown-confirm");
+
+    stdin.write("n");
+    await flush();
+    expect(client.destroySession).not.toHaveBeenCalled();
+    expect(overlay?.isOpen).toBe(false);
+  });
+});

--- a/test/components/Router.test.tsx
+++ b/test/components/Router.test.tsx
@@ -473,14 +473,14 @@ describe("Router", () => {
 
   it("detaches the tmux client on q in a managed session (F2)", async () => {
     vi.stubEnv("ZAPS_MANAGED_TMUX", "1");
-    vi.stubEnv("TMUX_PANE", "%4");
+    vi.stubEnv("TMUX", "/tmp/tmux-1000/zaps,42,0");
     const client = createMockClient();
     const { stdin } = renderRouter({ client });
     stdin.write("q");
     await act(async () => {
       /* Flush */
     });
-    expect(detachClient).toHaveBeenCalledWith("%4");
+    expect(detachClient).toHaveBeenCalledWith();
     expect(client.disconnect).toHaveBeenCalled();
     vi.unstubAllEnvs();
   });

--- a/test/components/Router.test.tsx
+++ b/test/components/Router.test.tsx
@@ -395,11 +395,16 @@ describe("Router", () => {
 
   // ── dashboard input: destroy session (d) ─────────────────────
 
-  it("destroys session with d key", () => {
+  it("asks before destroying the session on `d`", async () => {
     const client = createMockClient();
     const { stdin } = renderRouter({ client });
     stdin.write("d");
-    expect(client.destroySession).toHaveBeenCalled();
+    await act(async () => {
+      /* Flush */
+    });
+    // Nothing torn down yet — `d` only opens the confirmation overlay.
+    expect(client.destroySession).not.toHaveBeenCalled();
+    expect(overlay?.top?.id).toBe("shutdown-confirm");
   });
 
   // ── single sort, shared by render + input handler (F8) ───────
@@ -784,11 +789,22 @@ describe("Router", () => {
 
   // ── ctrl+d: destroy from any view ────────────────────────────
 
-  it("destroys session on ctrl+d", () => {
+  // A tmux client attaching with its own stdin at EOF makes the pty emit VEOF
+  // (0x04), which tmux hands to the pane as a plain Ctrl-D. A single stray byte
+  // Must never stop every service — the end-to-end case lives in the managed
+  // Re-attach integration suite.
+  it("asks before destroying the session on ctrl+d, and never on the byte alone", async () => {
     const client = createMockClient();
     const { stdin } = renderRouter({ client });
     stdin.write("\x04");
-    expect(client.destroySession).toHaveBeenCalled();
+    await act(async () => {
+      /* Flush */
+    });
+    expect(client.destroySession).not.toHaveBeenCalled();
+    expect(overlay?.top?.id).toBe("shutdown-confirm");
+    // A repeat of the same byte cannot confirm it either.
+    stdin.write("\x04");
+    expect(client.destroySession).not.toHaveBeenCalled();
   });
 
   // ── q still works during per-service busy ───────────────────
@@ -811,7 +827,7 @@ describe("Router", () => {
 
   // ── ctrl+d still works during per-service busy ────────────
 
-  it("allows ctrl+d even when a service is busy", () => {
+  it("still offers shutdown when a service is busy", async () => {
     const client = createMockClient();
     client.restartService = vi.fn().mockReturnValue(
       new Promise(() => {
@@ -821,6 +837,9 @@ describe("Router", () => {
     const { stdin } = renderRouter({ client });
     stdin.write("r"); // Makes service busy
     stdin.write("\x04");
-    expect(client.destroySession).toHaveBeenCalled();
+    await act(async () => {
+      /* Flush */
+    });
+    expect(overlay?.top?.id).toBe("shutdown-confirm");
   });
 });

--- a/test/components/Router.test.tsx
+++ b/test/components/Router.test.tsx
@@ -26,6 +26,8 @@ vi.mock("../../src/lib/open.js", () => ({
 vi.mock("../../src/lib/tmux.js", () => ({
   zoomPane: vi.fn(),
   editPaneCapture: vi.fn().mockResolvedValue(undefined),
+  // Quitting asks tmux to detach the client (managed mode only).
+  detachClient: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../src/lib/task/popup-picker.js", () => ({
@@ -34,7 +36,7 @@ vi.mock("../../src/lib/task/popup-picker.js", () => ({
 }));
 
 const { openInBrowser } = await import("../../src/lib/open.js");
-const { zoomPane, editPaneCapture } = await import("../../src/lib/tmux.js");
+const { zoomPane, editPaneCapture, detachClient } = await import("../../src/lib/tmux.js");
 const { popupPickerAvailable, runPopupPicker } = await import("../../src/lib/task/popup-picker.js");
 
 // ── helpers ────────────────────────────────────────────────────────────
@@ -457,11 +459,39 @@ describe("Router", () => {
 
   // ── global input: quit (q) ───────────────────────────────────
 
-  it("disconnects client on q", () => {
+  it("disconnects client on q", async () => {
     const client = createMockClient();
     const { stdin } = renderRouter({ client });
     stdin.write("q");
+    // Quitting first asks tmux to detach the client (a no-op outside a managed
+    // Session), so the disconnect lands one microtask later.
+    await act(async () => {
+      /* Flush */
+    });
     expect(client.disconnect).toHaveBeenCalled();
+  });
+
+  it("detaches the tmux client on q in a managed session (F2)", async () => {
+    vi.stubEnv("ZAPS_MANAGED_TMUX", "1");
+    vi.stubEnv("TMUX_PANE", "%4");
+    const client = createMockClient();
+    const { stdin } = renderRouter({ client });
+    stdin.write("q");
+    await act(async () => {
+      /* Flush */
+    });
+    expect(detachClient).toHaveBeenCalledWith("%4");
+    expect(client.disconnect).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not touch tmux on q in a personal session", async () => {
+    const { stdin } = renderRouter();
+    stdin.write("q");
+    await act(async () => {
+      /* Flush */
+    });
+    expect(detachClient).not.toHaveBeenCalled();
   });
 
   // ── logs view input ──────────────────────────────────────────
@@ -763,7 +793,7 @@ describe("Router", () => {
 
   // ── q still works during per-service busy ───────────────────
 
-  it("allows q even when a service is busy", () => {
+  it("allows q even when a service is busy", async () => {
     const client = createMockClient();
     client.restartService = vi.fn().mockReturnValue(
       new Promise(() => {
@@ -773,6 +803,9 @@ describe("Router", () => {
     const { stdin } = renderRouter({ client });
     stdin.write("r"); // Makes service busy (per-service, not global)
     stdin.write("q");
+    await act(async () => {
+      /* Flush */
+    });
     expect(client.disconnect).toHaveBeenCalled();
   });
 

--- a/test/components/logo.test.ts
+++ b/test/components/logo.test.ts
@@ -1,7 +1,13 @@
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { LOGO, LOGO_ASCII, renderSplash } from "../../src/components/logo.js";
+import {
+  LOGO,
+  LOGO_ASCII,
+  MANAGED_TMUX_HINT,
+  managedSplashHint,
+  renderSplash,
+} from "../../src/components/logo.js";
 
 describe("LOGO", () => {
   it("is a non-empty string", () => {
@@ -76,5 +82,33 @@ describe("renderSplash", () => {
     renderSplash({ cols: 20, rows: 5 });
     expect(writeSpy).toHaveBeenCalled();
     // Should not throw even with tiny terminal
+  });
+
+  it("renders the managed hint below the subtitle when given one", () => {
+    renderSplash({ cols: 100, rows: 30 }, undefined, MANAGED_TMUX_HINT);
+    const output = writeSpy.mock.calls[0][0] as string;
+    const lines = output.split("\n");
+    const subtitleRow = lines.findIndex((l) => l.includes("Starting services..."));
+    expect(lines[subtitleRow + 1]).toContain(MANAGED_TMUX_HINT);
+  });
+
+  it("omits the hint line when there is none", () => {
+    renderSplash({ cols: 100, rows: 30 });
+    const output = writeSpy.mock.calls[0][0] as string;
+    expect(output).not.toContain("auto-tmux");
+  });
+
+  it("drops the hint rather than overwriting the size label on a short pane", () => {
+    renderSplash({ cols: 100, rows: 9 }, undefined, MANAGED_TMUX_HINT);
+    const output = writeSpy.mock.calls[0][0] as string;
+    expect(output).toContain("100x9");
+  });
+});
+
+describe("managedSplashHint", () => {
+  it("shows the hint only in managed mode", () => {
+    expect(managedSplashHint("1")).toBe(MANAGED_TMUX_HINT);
+    expect(managedSplashHint("0")).toBeUndefined();
+    expect(managedSplashHint(undefined)).toBeUndefined();
   });
 });

--- a/test/daemon/handlers/daemon.test.ts
+++ b/test/daemon/handlers/daemon.test.ts
@@ -94,6 +94,24 @@ describe("daemon handlers", () => {
         name: "proj",
         configPath: "/a/.zaps.mts",
         projectDir: "/a",
+        tmuxSession: "test-tmux",
+        managed: false,
+      });
+    });
+
+    it("reports the hosting tmux session + managed flag (F6/F7 hints)", async () => {
+      const session = createMockSession({
+        id: "s2",
+        tmuxSession: "zaps-proj-abc123",
+        tmuxSocket: "zaps",
+        managedTmux: true,
+      });
+      const store = createMockStore([session]);
+      const req: IpcRequest = { id: "r5a", method: "session.list" };
+      const res = await daemonHandlers["session.list"](req, store);
+      expect((res.result as unknown[])[0]).toMatchObject({
+        tmuxSession: "zaps-proj-abc123",
+        managed: true,
       });
     });
   });
@@ -129,6 +147,82 @@ describe("daemon handlers", () => {
       };
       const res = await daemonHandlers["session.create"](req, store);
       expect(res.error).toBe("configPath required");
+    });
+
+    it("forwards tmuxSocket + managedTmux to the store", async () => {
+      const session = createMockSession();
+      const store = createMockStore([session]);
+      const req: IpcRequest = {
+        id: "r6a",
+        method: "session.create",
+        params: {
+          configPath: "/fake/.zaps.mts",
+          projectDir: "/fake",
+          tmuxSession: "zaps-fake-abc123",
+          originPane: "%0",
+          tmuxSocket: "zaps",
+          managedTmux: true,
+        },
+      };
+      await daemonHandlers["session.create"](req, store);
+      expect(store.create).toHaveBeenCalledWith(
+        expect.objectContaining({ tmuxSocket: "zaps", managedTmux: true }),
+      );
+    });
+
+    it("defaults to the user's default server when no socket is sent", async () => {
+      const session = createMockSession();
+      const store = createMockStore([session]);
+      const req: IpcRequest = {
+        id: "r6b",
+        method: "session.create",
+        params: {
+          configPath: "/fake/.zaps.mts",
+          projectDir: "/fake",
+          tmuxSession: "main",
+          originPane: "%0",
+        },
+      };
+      await daemonHandlers["session.create"](req, store);
+      expect(store.create).toHaveBeenCalledWith(
+        expect.objectContaining({ tmuxSocket: null, managedTmux: false }),
+      );
+    });
+
+    it.each(["", "   "])("rejects a blank tmuxSocket (%j)", async (socket) => {
+      const store = createMockStore();
+      const req: IpcRequest = {
+        id: "r6c",
+        method: "session.create",
+        params: {
+          configPath: "/fake/.zaps.mts",
+          projectDir: "/fake",
+          tmuxSession: "main",
+          originPane: "%0",
+          tmuxSocket: socket,
+        },
+      };
+      const res = await daemonHandlers["session.create"](req, store);
+      expect(res.error).toBe("tmuxSocket must be a non-empty string or null");
+      expect(store.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects managedTmux without a socket — never kill-session on the default server", async () => {
+      const store = createMockStore();
+      const req: IpcRequest = {
+        id: "r6d",
+        method: "session.create",
+        params: {
+          configPath: "/fake/.zaps.mts",
+          projectDir: "/fake",
+          tmuxSession: "main",
+          originPane: "%0",
+          managedTmux: true,
+        },
+      };
+      const res = await daemonHandlers["session.create"](req, store);
+      expect(res.error).toBe("managed session requires tmuxSocket");
+      expect(store.create).not.toHaveBeenCalled();
     });
 
     it("returns error when store.create throws", async () => {

--- a/test/daemon/handlers/session.test.ts
+++ b/test/daemon/handlers/session.test.ts
@@ -19,11 +19,17 @@ vi.mock("../../../src/lib/task/runner.js", () => ({
   runTaskWithDeps: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock("../../../src/lib/tmux.js", () => ({
-  newWindow: vi.fn().mockResolvedValue("%win"),
-  splitPane: vi.fn().mockResolvedValue("%split"),
-  sendKeys: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("../../../src/lib/tmux.js", () => {
+  // Handlers reach tmux through `session.tmux`, so the factory returns the SAME
+  // Stub surface for the module exports and for `tmuxFor()` — assertions on the
+  // Named exports still observe every call.
+  const api = {
+    newWindow: vi.fn().mockResolvedValue("%win"),
+    splitPane: vi.fn().mockResolvedValue("%split"),
+    sendKeys: vi.fn().mockResolvedValue(undefined),
+  };
+  return { ...api, tmuxFor: vi.fn(() => api) };
+});
 
 // `run-in-pane.js` is now pure (joinTaskCommands/buildWrapperCommand) — used real.
 

--- a/test/daemon/index.test.ts
+++ b/test/daemon/index.test.ts
@@ -18,6 +18,7 @@ vi.mock("node:fs", () => ({
     writeSync: vi.fn(),
     closeSync: vi.fn(),
     statSync: vi.fn(() => ({ mtimeMs: Date.now() })),
+    existsSync: vi.fn(() => true),
   },
 }));
 
@@ -25,6 +26,7 @@ vi.mock("node:os", () => ({
   default: {
     tmpdir: () => "/tmp",
     userInfo: () => ({ uid: 1000 }),
+    homedir: () => "/home/test",
   },
 }));
 
@@ -196,6 +198,20 @@ describe("ensureDaemon", () => {
     expect(opts.env.ZAPS_TMUX_SOCKET).toBeUndefined();
     expect(opts.env.TMUX).toBeUndefined();
     expect(opts.env.ZAPS_COMMAND).toBe("zaps");
+  });
+
+  it("spawns the daemon in a stable cwd so a deleted project dir can't poison it", async () => {
+    const fsModule = await import("node:fs");
+    const fs = fsModule.default;
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    await ensureDaemon({ file: "zaps", args: [] });
+
+    const { spawn } = await import("node:child_process");
+    const opts = vi.mocked(spawn).mock.calls.at(-1)?.[2] as { cwd?: string };
+    expect(opts.cwd).toBe("/home/test");
   });
 
   it("throws a clear error when the daemon spawn fails (E1)", async () => {

--- a/test/daemon/index.test.ts
+++ b/test/daemon/index.test.ts
@@ -184,12 +184,14 @@ describe("ensureDaemon", () => {
     });
     process.env.ZAPS_TMUX_SOCKET = "zaps";
     process.env.TMUX = "/tmp/tmux-1000/zaps,123,0";
+    process.env.TMUX_PANE = "%3";
 
     try {
       await ensureDaemon({ file: "zaps", args: [] });
     } finally {
       delete process.env.ZAPS_TMUX_SOCKET;
       delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
     }
 
     const { spawn } = await import("node:child_process");
@@ -197,6 +199,7 @@ describe("ensureDaemon", () => {
     const opts = call?.[2] as { env: Record<string, string | undefined> };
     expect(opts.env.ZAPS_TMUX_SOCKET).toBeUndefined();
     expect(opts.env.TMUX).toBeUndefined();
+    expect(opts.env.TMUX_PANE).toBeUndefined();
     expect(opts.env.ZAPS_COMMAND).toBe("zaps");
   });
 
@@ -326,11 +329,13 @@ describe("runDaemon", () => {
   it("deletes inherited tmux env at startup (socket selection is per-session)", async () => {
     process.env.ZAPS_TMUX_SOCKET = "zaps";
     process.env.TMUX = "/tmp/tmux-1000/zaps,123,0";
+    process.env.TMUX_PANE = "%3";
 
     await runDaemon();
 
     expect(process.env.ZAPS_TMUX_SOCKET).toBeUndefined();
     expect(process.env.TMUX).toBeUndefined();
+    expect(process.env.TMUX_PANE).toBeUndefined();
   });
 
   it("shuts down on idle timeout with no sessions", async () => {

--- a/test/daemon/index.test.ts
+++ b/test/daemon/index.test.ts
@@ -261,6 +261,8 @@ describe("runDaemon", () => {
     vi.useFakeTimers();
     process.exit = vi.fn() as unknown as typeof process.exit;
     processOnSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+    // Never move the test worker's cwd; runDaemon chdirs to a stable dir.
+    vi.spyOn(process, "chdir").mockImplementation(() => undefined);
     delete process.env.XDG_RUNTIME_DIR;
 
     // Re-establish DaemonServer mock (vi.restoreAllMocks in other suites may clear it)
@@ -313,6 +315,12 @@ describe("runDaemon", () => {
     expect(fs.writeFileSync).toHaveBeenCalled();
     expect(fs.openSync).toHaveBeenCalled();
     expect(serverInstance().start).toHaveBeenCalledWith(expect.stringMatching(/daemon\.sock$/));
+  });
+
+  it("chdirs to a stable dir so a deleted project dir can't poison spawns", async () => {
+    await runDaemon();
+
+    expect(process.chdir).toHaveBeenCalledWith("/home/test");
   });
 
   it("deletes inherited tmux env at startup (socket selection is per-session)", async () => {

--- a/test/daemon/index.test.ts
+++ b/test/daemon/index.test.ts
@@ -174,6 +174,30 @@ describe("ensureDaemon", () => {
     expect(opts.env.ZAPS_COMMAND).toBe("node /path/cli.mjs");
   });
 
+  it("strips ZAPS_TMUX_SOCKET + TMUX from the daemon child env (sanitization rule)", async () => {
+    const fsModule = await import("node:fs");
+    const fs = fsModule.default;
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    process.env.ZAPS_TMUX_SOCKET = "zaps";
+    process.env.TMUX = "/tmp/tmux-1000/zaps,123,0";
+
+    try {
+      await ensureDaemon({ file: "zaps", args: [] });
+    } finally {
+      delete process.env.ZAPS_TMUX_SOCKET;
+      delete process.env.TMUX;
+    }
+
+    const { spawn } = await import("node:child_process");
+    const call = vi.mocked(spawn).mock.calls.at(-1);
+    const opts = call?.[2] as { env: Record<string, string | undefined> };
+    expect(opts.env.ZAPS_TMUX_SOCKET).toBeUndefined();
+    expect(opts.env.TMUX).toBeUndefined();
+    expect(opts.env.ZAPS_COMMAND).toBe("zaps");
+  });
+
   it("throws a clear error when the daemon spawn fails (E1)", async () => {
     vi.useFakeTimers();
     const fsModule = await import("node:fs");
@@ -273,6 +297,16 @@ describe("runDaemon", () => {
     expect(fs.writeFileSync).toHaveBeenCalled();
     expect(fs.openSync).toHaveBeenCalled();
     expect(serverInstance().start).toHaveBeenCalledWith(expect.stringMatching(/daemon\.sock$/));
+  });
+
+  it("deletes inherited tmux env at startup (socket selection is per-session)", async () => {
+    process.env.ZAPS_TMUX_SOCKET = "zaps";
+    process.env.TMUX = "/tmp/tmux-1000/zaps,123,0";
+
+    await runDaemon();
+
+    expect(process.env.ZAPS_TMUX_SOCKET).toBeUndefined();
+    expect(process.env.TMUX).toBeUndefined();
   });
 
   it("shuts down on idle timeout with no sessions", async () => {

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -196,6 +196,42 @@ describe("DaemonServer", () => {
     expect(server.get(session.id)).toBe(session);
   });
 
+  it("binds the layout + session handle to the requested tmux socket", async () => {
+    const { tmuxFor } = await import("#src/lib/tmux.js");
+    vi.mocked(tmuxFor).mockClear();
+
+    const session = await server.create({
+      configPath: "/socket/.zaps.mts",
+      projectDir: "/socket",
+      tmuxSession: "zaps-socket-abc",
+      originPane: "%0",
+      tmuxSocket: "zaps",
+      managedTmux: true,
+    });
+
+    expect(tmuxFor).toHaveBeenCalledWith("zaps");
+    expect(session.tmuxSocket).toBe("zaps");
+    expect(session.managedTmux).toBe(true);
+    const layoutCall = mockCreateLayout.mock.calls.at(-1);
+    expect(layoutCall?.[4]).toMatchObject({ tmux: expect.any(Object) });
+  });
+
+  it("defaults an unmanaged session to the user's default server", async () => {
+    const { tmuxFor } = await import("#src/lib/tmux.js");
+    vi.mocked(tmuxFor).mockClear();
+
+    const session = await server.create({
+      configPath: "/default/.zaps.mts",
+      projectDir: "/default",
+      tmuxSession: "main",
+      originPane: "%0",
+    });
+
+    expect(tmuxFor).toHaveBeenCalledWith(null);
+    expect(session.tmuxSocket).toBeNull();
+    expect(session.managedTmux).toBe(false);
+  });
+
   it("returns existing session on duplicate create", async () => {
     const s1 = await server.create({
       configPath: "/test/.zaps.mts",

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -60,27 +60,34 @@ vi.mock("#src/lib/tmux-layout.js", () => ({
   createLayout: vi.fn(),
 }));
 
-vi.mock("#src/lib/tmux.js", () => ({
-  capturePane: vi.fn(),
-  selectPane: vi.fn(),
-  sendKeys: vi.fn(),
-  sendCtrlC: vi.fn(),
-  panePid: vi.fn(),
-  paneExists: vi.fn(),
-  killPane: vi.fn(),
-  renameWindow: vi.fn(),
-  getWindowName: vi.fn(),
-  getWindowOption: vi.fn(),
-  setWindowOption: vi.fn(),
-  resyncPaneSizes: vi.fn(),
-  // LayoutReflow (constructed by Session) imports these too.
-  getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
-  paneIndexOrder: vi.fn().mockResolvedValue([]),
-  selectLayout: vi.fn().mockResolvedValue(undefined),
-  splitPane: vi.fn().mockResolvedValue("%99"),
-  swapPanes: vi.fn().mockResolvedValue(undefined),
-  windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
-}));
+vi.mock("#src/lib/tmux.js", () => {
+  // Server + Session bind handles via `tmuxFor(tmuxSocket)`; the factory returns
+  // The SAME stub surface for both the module exports and the handle, so
+  // Assertions on the named exports still observe every call.
+  const api = {
+    capturePane: vi.fn(),
+    selectPane: vi.fn(),
+    sendKeys: vi.fn(),
+    sendCtrlC: vi.fn(),
+    panePid: vi.fn(),
+    paneExists: vi.fn(),
+    killPane: vi.fn(),
+    renameWindow: vi.fn(),
+    getWindowName: vi.fn(),
+    getWindowOption: vi.fn(),
+    setWindowOption: vi.fn(),
+    displayPopup: vi.fn(),
+    resyncPaneSizes: vi.fn(),
+    // LayoutReflow (constructed by Session) uses these too.
+    getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
+    paneIndexOrder: vi.fn().mockResolvedValue([]),
+    selectLayout: vi.fn().mockResolvedValue(undefined),
+    splitPane: vi.fn().mockResolvedValue("%99"),
+    swapPanes: vi.fn().mockResolvedValue(undefined),
+    windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
+  };
+  return { ...api, tmuxFor: vi.fn(() => api) };
+});
 
 vi.mock("#src/lib/port.js", () => ({
   detectPorts: vi.fn(),

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -314,6 +314,38 @@ describe("DaemonServer", () => {
     expect(mockCreateLayout).toHaveBeenCalledTimes(1);
   });
 
+  it("refuses a create whose tmux context disagrees with the live session", async () => {
+    const params = {
+      configPath: "/test/.zaps.mts",
+      projectDir: "/test",
+      tmuxSession: "main",
+      originPane: "%0",
+    };
+    await server.create(params);
+    tmux.paneExists.mockResolvedValue(true);
+
+    // Same project, but this caller runs in a managed tmux: handing back the
+    // Session on the default server would drive tmux at the wrong one.
+    await expect(
+      server.create({ ...params, tmuxSocket: "zaps", managedTmux: true }),
+    ).rejects.toThrow(/Session already running on the default tmux server/u);
+    expect(server.sessionCount).toBe(1);
+  });
+
+  it("still reuses the session for an identical tmux context", async () => {
+    const params = {
+      configPath: "/test/.zaps.mts",
+      projectDir: "/test",
+      tmuxSession: "zaps-test-abc",
+      originPane: "%0",
+      tmuxSocket: "zaps",
+      managedTmux: true,
+    };
+    const s1 = await server.create(params);
+    tmux.paneExists.mockResolvedValue(true);
+    await expect(server.create(params)).resolves.toBe(s1);
+  });
+
   it("destroys and rebuilds when the cached @tui pane is dead (A4)", async () => {
     const params = {
       configPath: "/test/.zaps.mts",

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -23,21 +23,26 @@ vi.mock("#src/lib/tmux-layout.js", () => ({
   createLayout: vi.fn(),
 }));
 
-vi.mock("#src/lib/tmux.js", () => ({
-  killPane: vi.fn().mockResolvedValue(undefined),
-  // LayoutReflow (constructed by Session) imports these as defaults. They are
-  // Stored as function refs at construction but only invoked when reflow code
-  // Runs; stub them so the import-time destructure succeeds in tests that
-  // Never exercise the reflow path.
-  getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
-  paneIndexOrder: vi.fn().mockResolvedValue([]),
-  resyncPaneSizes: vi.fn().mockResolvedValue(undefined),
-  selectLayout: vi.fn().mockResolvedValue(undefined),
-  selectPane: vi.fn().mockResolvedValue(undefined),
-  splitPane: vi.fn().mockResolvedValue("%99"),
-  swapPanes: vi.fn().mockResolvedValue(undefined),
-  windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
-}));
+vi.mock("#src/lib/tmux.js", () => {
+  // The Session binds its handle via `tmuxFor(tmuxSocket)`, so the factory
+  // Returns the SAME stub surface for both the module exports and the handle —
+  // Assertions on the named exports still observe every call.
+  const api = {
+    killPane: vi.fn().mockResolvedValue(undefined),
+    // LayoutReflow (constructed by Session) uses these as defaults. They are
+    // Stored as function refs at construction but only invoked when reflow code
+    // Runs; stub them so tests that never exercise the reflow path still work.
+    getWindowSize: vi.fn().mockResolvedValue({ width: 100, height: 30 }),
+    paneIndexOrder: vi.fn().mockResolvedValue([]),
+    resyncPaneSizes: vi.fn().mockResolvedValue(undefined),
+    selectLayout: vi.fn().mockResolvedValue(undefined),
+    selectPane: vi.fn().mockResolvedValue(undefined),
+    splitPane: vi.fn().mockResolvedValue("%99"),
+    swapPanes: vi.fn().mockResolvedValue(undefined),
+    windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
+  };
+  return { ...api, tmuxFor: vi.fn(() => api) };
+});
 
 function createMockManager(): ServiceManager {
   const emitter = new EventEmitter();
@@ -57,6 +62,8 @@ function createSessionParams(overrides?: Partial<SessionCreateParams>): SessionC
   return {
     configPath: "/test/.zaps.mts",
     projectDir: "/test",
+    tmuxSocket: null,
+    managedTmux: false,
     config: {
       project: {
         name: "test-project",
@@ -384,6 +391,25 @@ describe("Session", () => {
     });
   });
 
+  describe("managed tmux context", () => {
+    it("defaults to the user's default server", () => {
+      expect(session.tmuxSocket).toBeNull();
+      expect(session.managedTmux).toBe(false);
+    });
+
+    it("binds its tmux handle to the session socket", async () => {
+      const { tmuxFor } = await import("#src/lib/tmux.js");
+      vi.mocked(tmuxFor).mockClear();
+      const managed = new Session(
+        createSessionParams({ tmuxSocket: "zaps", managedTmux: true }),
+        createMockManager(),
+      );
+      expect(managed.tmuxSocket).toBe("zaps");
+      expect(managed.managedTmux).toBe(true);
+      expect(tmuxFor).toHaveBeenCalledWith("zaps");
+    });
+  });
+
   describe("attachSnapshot", () => {
     it("returns full snapshot", () => {
       const snap = session.attachSnapshot();
@@ -394,6 +420,16 @@ describe("Session", () => {
       expect(snap.logSnapshots).toHaveProperty("api");
       expect(snap.tasks).toBeDefined();
       expect(snap.servicesMeta).toBeDefined();
+      expect(snap.tmuxSession).toBe(session.tmuxSession);
+      expect(snap.managed).toBe(false);
+    });
+
+    it("reports managed sessions so the client can route attach/teardown", () => {
+      const managed = new Session(
+        createSessionParams({ tmuxSocket: "zaps", managedTmux: true }),
+        createMockManager(),
+      );
+      expect(managed.attachSnapshot().managed).toBe(true);
     });
 
     it("flags detached services in servicesMeta (E4)", () => {

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -29,6 +29,7 @@ vi.mock("#src/lib/tmux.js", () => {
   // Assertions on the named exports still observe every call.
   const api = {
     killPane: vi.fn().mockResolvedValue(undefined),
+    killSession: vi.fn().mockResolvedValue(undefined),
     // LayoutReflow (constructed by Session) uses these as defaults. They are
     // Stored as function refs at construction but only invoked when reflow code
     // Runs; stub them so tests that never exercise the reflow path still work.
@@ -346,6 +347,62 @@ describe("Session", () => {
       await session.destroy();
       await session.destroy();
       expect(vi.mocked(manager.stopAll)).toHaveBeenCalledTimes(1);
+    });
+
+    it("kills the tmux session zaps owns, by exact name (F5)", async () => {
+      const { killSession, tmuxFor } = await import("#src/lib/tmux.js");
+      vi.mocked(killSession).mockClear();
+      const managed = new Session(
+        createSessionParams({
+          tmuxSocket: "zaps",
+          managedTmux: true,
+          tmuxSession: "zaps-app-abc123abc123",
+        }),
+        createMockManager(),
+      );
+      await managed.destroy();
+      expect(killSession).toHaveBeenCalledWith("zaps-app-abc123abc123");
+      // On the session's own socket handle — never the default server.
+      expect(tmuxFor).toHaveBeenCalledWith("zaps");
+    });
+
+    it("never kills a tmux session zaps does not own", async () => {
+      const { killSession } = await import("#src/lib/tmux.js");
+      vi.mocked(killSession).mockClear();
+      await session.destroy();
+      expect(killSession).not.toHaveBeenCalled();
+    });
+
+    it("treats an already-gone tmux session as non-fatal", async () => {
+      const { killSession } = await import("#src/lib/tmux.js");
+      vi.mocked(killSession).mockRejectedValueOnce(new Error("can't find session"));
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const managed = new Session(
+        createSessionParams({ tmuxSocket: "zaps", managedTmux: true, tmuxSession: "zaps-gone" }),
+        createMockManager(),
+      );
+      await expect(managed.destroy()).resolves.toBeUndefined();
+      expect(managed.destroyed).toBe(true);
+      expect(stderr.mock.calls.join("")).toContain("zaps-gone");
+      stderr.mockRestore();
+    });
+
+    it("stops the services before killing the tmux session that hosts them", async () => {
+      const { killSession } = await import("#src/lib/tmux.js");
+      vi.mocked(killSession).mockClear();
+      const order: string[] = [];
+      const managed = createMockManager();
+      vi.mocked(managed.stopAll).mockImplementation(async () => {
+        order.push("stopAll");
+      });
+      vi.mocked(killSession).mockImplementation(async () => {
+        order.push("killSession");
+      });
+      await new Session(
+        createSessionParams({ tmuxSocket: "zaps", managedTmux: true }),
+        managed,
+      ).destroy();
+      expect(order).toEqual(["stopAll", "killSession"]);
     });
 
     it("serializes behind an in-flight reload via the shared op lock", async () => {

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -19,7 +19,10 @@ vi.mock("#src/config/loader.js", () => ({
   computeBootSkip: vi.fn(() => new Set<string>()),
 }));
 
-vi.mock("#src/lib/tmux-layout.js", () => ({
+// Only `createLayout` is stubbed: the pure tree helpers (`filterTree`, …) stay
+// Real so the reflow path can actually run.
+vi.mock("#src/lib/tmux-layout.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#src/lib/tmux-layout.js")>()),
   createLayout: vi.fn(),
 }));
 
@@ -42,7 +45,12 @@ vi.mock("#src/lib/tmux.js", () => {
     swapPanes: vi.fn().mockResolvedValue(undefined),
     windowLayout: vi.fn().mockResolvedValue("prior-layout-string"),
   };
-  return { ...api, tmuxFor: vi.fn(() => api) };
+  // Real implementation: the exact-target form is what these tests assert on.
+  return {
+    ...api,
+    exactWindowTarget: (name: string) => `=${name}:`,
+    tmuxFor: vi.fn(() => api),
+  };
 });
 
 function createMockManager(): ServiceManager {
@@ -836,6 +844,47 @@ describe("Session.reflow — wired with live-getter deps", () => {
     const beforeReflow = session.reflow;
     session.paneMap = { "@tui": "%9", api: "%10" };
     expect(session.reflow).toBe(beforeReflow);
+  });
+
+  // Every geometry command the reflow issues is WINDOW-scoped, and tmux matches
+  // Targets exact → prefix → fnmatch: a bare `main` would drive `main-notes`'s
+  // Window on the same server. `=main:` is the only form all four commands
+  // Accept — a bare `=main` makes `display-message` return empty and
+  // `select-layout` fail outright (verified against live tmux).
+  it("targets the session's own window exactly (`=name:`)", async () => {
+    const session = new Session(
+      createSessionParams({
+        tmuxSession: "zaps-app-a1",
+        paneMap: { "@tui": "%0", api: "%1" },
+        config: {
+          project: {
+            name: "test-project",
+            services: { api: { start: "npm dev" } },
+            layout: { direction: "columns", children: [{ pane: "@tui" }, { pane: "api" }] },
+          },
+          configPath: "/test/.zaps.mts",
+          projectDir: "/test",
+          groups: new Map(),
+          unavailableServices: new Map(),
+          lazyPaneByService: new Map(),
+        } as SessionCreateParams["config"],
+      }),
+      createMockManager(),
+    );
+
+    const tmux = await import("#src/lib/tmux.js");
+    vi.mocked(tmux.paneIndexOrder).mockResolvedValueOnce([
+      { index: 0, id: "%0" },
+      { index: 1, id: "%1" },
+    ]);
+
+    await session.reflow.applyGeometry(new Set(["@tui", "api"]));
+
+    // One getter feeds every window-scoped call site (incl. insert/remove's
+    // `windowLayout` snapshot), so pinning the geometry path pins them all.
+    expect(tmux.getWindowSize).toHaveBeenCalledWith("=zaps-app-a1:");
+    expect(tmux.paneIndexOrder).toHaveBeenCalledWith("=zaps-app-a1:");
+    expect(tmux.selectLayout).toHaveBeenCalledWith("=zaps-app-a1:", expect.any(String));
   });
 });
 

--- a/test/integration/daemon/cli-helpers.test.ts
+++ b/test/integration/daemon/cli-helpers.test.ts
@@ -10,6 +10,7 @@ const sessions: SessionInfo[] = [
     projectDir: "/projects/my-app",
     tmuxSession: "tmux-abc123def456",
     managed: false,
+    tuiPane: null,
   },
   {
     id: "xyz789ghi012",
@@ -17,6 +18,7 @@ const sessions: SessionInfo[] = [
     projectDir: "/projects/api-server",
     tmuxSession: "tmux-xyz789ghi012",
     managed: false,
+    tuiPane: null,
   },
   {
     id: "abc999zzz000",
@@ -24,6 +26,7 @@ const sessions: SessionInfo[] = [
     projectDir: "/projects/other",
     tmuxSession: "tmux-abc999zzz000",
     managed: false,
+    tuiPane: null,
   },
 ];
 

--- a/test/integration/daemon/cli-helpers.test.ts
+++ b/test/integration/daemon/cli-helpers.test.ts
@@ -4,9 +4,27 @@ import { CliError, formatTable, resolveTargetSession } from "#src/cli/helpers.js
 import type { SessionInfo } from "#src/cli/helpers.js";
 
 const sessions: SessionInfo[] = [
-  { id: "abc123def456", name: "my-app", projectDir: "/projects/my-app" },
-  { id: "xyz789ghi012", name: "api-server", projectDir: "/projects/api-server" },
-  { id: "abc999zzz000", name: "other", projectDir: "/projects/other" },
+  {
+    id: "abc123def456",
+    name: "my-app",
+    projectDir: "/projects/my-app",
+    tmuxSession: "tmux-abc123def456",
+    managed: false,
+  },
+  {
+    id: "xyz789ghi012",
+    name: "api-server",
+    projectDir: "/projects/api-server",
+    tmuxSession: "tmux-xyz789ghi012",
+    managed: false,
+  },
+  {
+    id: "abc999zzz000",
+    name: "other",
+    projectDir: "/projects/other",
+    tmuxSession: "tmux-abc999zzz000",
+    managed: false,
+  },
 ];
 
 describe("resolveTargetSession", () => {

--- a/test/integration/daemon/client.test.ts
+++ b/test/integration/daemon/client.test.ts
@@ -19,7 +19,7 @@ import {
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("DaemonClient integration", () => {
   let daemon: TestDaemon;
@@ -44,6 +44,7 @@ describe.skipIf(!hasTmux())("DaemonClient integration", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 

--- a/test/integration/daemon/create-staleness.test.ts
+++ b/test/integration/daemon/create-staleness.test.ts
@@ -14,7 +14,7 @@ import { createTestDaemon, waitForServiceState, writeTestConfig } from "../helpe
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("session.create dedupe / liveness / staleness", () => {
   let daemon: TestDaemon;
@@ -50,6 +50,7 @@ describe.skipIf(!hasTmux())("session.create dedupe / liveness / staleness", () =
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     };
 
     // Fire both creates in the same tick — they must share one in-flight build.
@@ -77,6 +78,7 @@ describe.skipIf(!hasTmux())("session.create dedupe / liveness / staleness", () =
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (firstRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
@@ -100,6 +102,7 @@ describe.skipIf(!hasTmux())("session.create dedupe / liveness / staleness", () =
         projectDir: tmpDir,
         tmuxSession: tmux2.name,
         originPane: tmux2.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sid = (secondRes.result as { id: string }).id;
       const secondPaneMap = (secondRes.result as { paneMap: Record<string, string> }).paneMap;
@@ -122,6 +125,7 @@ describe.skipIf(!hasTmux())("session.create dedupe / liveness / staleness", () =
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");

--- a/test/integration/daemon/detached-lifecycle.test.ts
+++ b/test/integration/daemon/detached-lifecycle.test.ts
@@ -13,7 +13,7 @@ import { createTestDaemon, waitForServiceState } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 /**
  * Write a config with a single DETACHED service: a pane-less HTTP server that
@@ -79,6 +79,7 @@ describe.skipIf(!hasTmux())("detached service lifecycle (E4)", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     expect(createRes.error).toBeUndefined();
     sid = (createRes.result as { id: string }).id;

--- a/test/integration/daemon/e2e.test.ts
+++ b/test/integration/daemon/e2e.test.ts
@@ -14,7 +14,7 @@ import { createTestDaemon, waitForServiceState, writeTestConfig } from "../helpe
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("daemon e2e", () => {
   // ── Daemon-level handlers ─────────────────────────────────────────────
@@ -105,6 +105,7 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
         projectDir: tmpDir,
         tmuxSession: tmux.name,
         originPane: tmux.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       expect(res.error).toBeUndefined();
 
@@ -131,6 +132,7 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
         projectDir: tmpDir,
         tmuxSession: tmux.name,
         originPane: tmux.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       const sid = (createRes.result as { id: string }).id;
 
@@ -174,6 +176,7 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
         projectDir: tmpDir,
         tmuxSession: tmux.name,
         originPane: tmux.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sid = (res.result as { id: string }).id;
 
@@ -390,6 +393,7 @@ describe.skipIf(!hasTmux())("daemon e2e", () => {
         projectDir: "/tmp",
         tmuxSession: tmux.name,
         originPane: tmux.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       expect(res.error).toBeDefined();
     });

--- a/test/integration/daemon/log-fanout.test.ts
+++ b/test/integration/daemon/log-fanout.test.ts
@@ -13,7 +13,7 @@ import { makeConfig } from "../helpers/config.js";
 import { tmuxDeps } from "../helpers/service-manager.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 /**
  * A combined group puts every member service on one shared tmux pane. This
@@ -78,6 +78,8 @@ describe.skipIf(!hasTmux())("combined-pane log fan-out (D2)", () => {
       paneMap,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
+      managedTmux: false,
       deps: tmuxDeps as unknown as SessionCreateParams["deps"],
     };
     session = new Session(params, fakeManager());

--- a/test/integration/daemon/multi-service.test.ts
+++ b/test/integration/daemon/multi-service.test.ts
@@ -18,7 +18,7 @@ import {
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("multi-service operations", () => {
   let daemon: TestDaemon;
@@ -42,6 +42,7 @@ describe.skipIf(!hasTmux())("multi-service operations", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 

--- a/test/integration/daemon/multi-session.test.ts
+++ b/test/integration/daemon/multi-session.test.ts
@@ -12,7 +12,7 @@ import { createTestDaemon, waitForServiceState, writeTestConfig } from "../helpe
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("daemon multi-session", () => {
   // ── Two sessions coexist on same daemon ──────────────────────────────
@@ -43,6 +43,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir1,
         tmuxSession: tmux1.name,
         originPane: tmux1.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidA = (resA.result as { id: string }).id;
 
@@ -51,6 +52,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir2,
         tmuxSession: tmux2.name,
         originPane: tmux2.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidB = (resB.result as { id: string }).id;
 
@@ -130,6 +132,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir1,
         tmuxSession: tmux1.name,
         originPane: tmux1.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidA = (resA.result as { id: string }).id;
 
@@ -138,6 +141,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir2,
         tmuxSession: tmux2.name,
         originPane: tmux2.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidB = (resB.result as { id: string }).id;
 
@@ -210,6 +214,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir1,
         tmuxSession: tmux1.name,
         originPane: tmux1.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidA = (resA.result as { id: string }).id;
 
@@ -218,6 +223,7 @@ describe.skipIf(!hasTmux())("daemon multi-session", () => {
         projectDir: tmpDir2,
         tmuxSession: tmux2.name,
         originPane: tmux2.initialPaneId,
+        tmuxSocket: testTmuxSocket(),
       });
       sidB = (resB.result as { id: string }).id;
 

--- a/test/integration/daemon/reload.test.ts
+++ b/test/integration/daemon/reload.test.ts
@@ -13,7 +13,7 @@ import { createTestDaemon, waitForServiceState } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 function writeConfig(
   dir: string,
@@ -75,6 +75,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
@@ -105,6 +106,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
@@ -147,6 +149,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
@@ -181,6 +184,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");
@@ -224,6 +228,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     const tuiPaneBefore = (createRes.result as { paneMap: Record<string, string> }).paneMap["@tui"];
@@ -252,6 +257,7 @@ describe.skipIf(!hasTmux())("config hot-reload", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (createRes.result as { id: string }).id;
     await waitForServiceState(daemon.socketPath, sid, "web", "ready");

--- a/test/integration/daemon/run-in-pane.test.ts
+++ b/test/integration/daemon/run-in-pane.test.ts
@@ -15,7 +15,7 @@ import { createTestDaemon } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const localZaps = path.join(projectRoot, "bin", "zaps");
@@ -81,6 +81,7 @@ describe.skipIf(!hasTmux())("daemon tasks.runInPane integration (exec-task wrapp
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
   });

--- a/test/integration/daemon/stop-cleanup.test.ts
+++ b/test/integration/daemon/stop-cleanup.test.ts
@@ -56,7 +56,7 @@ function listAllPanes(): string[] {
   try {
     const result = execFileSync(
       "tmux",
-      ["-L", "zaps-test", "list-panes", "-a", "-F", "#{pane_id}"],
+      ["-L", testTmuxSocket() ?? "zaps-test", "list-panes", "-a", "-F", "#{pane_id}"],
       { encoding: "utf8" },
     );
     return result.split("\n").filter((line) => line.trim() !== "");
@@ -92,7 +92,7 @@ describe.skipIf(!hasBinary() || !hasTmux())("zaps daemon stop cleanup", () => {
     const childEnv = {
       ...process.env,
       XDG_RUNTIME_DIR: runtimeDir,
-      ZAPS_TMUX_SOCKET: "zaps-test",
+      ZAPS_TMUX_SOCKET: testTmuxSocket() ?? "zaps-test",
     };
 
     // Fork a real background daemon (isolated runtime dir + tmux server).

--- a/test/integration/daemon/stop-cleanup.test.ts
+++ b/test/integration/daemon/stop-cleanup.test.ts
@@ -14,7 +14,7 @@ import { waitForServiceState, writeTestConfig } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasBinary, hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 const execFileAsync = promisify(execFile);
 const binaryPath = path.resolve("dist/zaps");
@@ -105,6 +105,7 @@ describe.skipIf(!hasBinary() || !hasTmux())("zaps daemon stop cleanup", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     const data = createRes.result as { paneMap: Record<string, string> };
     webPane = data.paneMap.web;

--- a/test/integration/global-setup.ts
+++ b/test/integration/global-setup.ts
@@ -1,10 +1,32 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-function killTestServer() {
+/**
+ * Every integration file runs on its own `zaps-test-*` socket (see
+ * `setup-tmux-socket.ts`), so reap all of them: tmux keeps one socket file per
+ * server under `/tmp/tmux-<uid>/`. A file's own `afterAll` normally kills its
+ * server; this catches whatever a crashed worker left behind.
+ */
+function killTestServers() {
+  const sockets = new Set(["zaps-test"]);
   try {
-    execFileSync("tmux", ["-L", "zaps-test", "kill-server"], { stdio: "ignore" });
+    const dir = path.join(os.tmpdir(), `tmux-${os.userInfo().uid}`);
+    for (const entry of fs.readdirSync(dir)) {
+      if (entry.startsWith("zaps-test")) {
+        sockets.add(entry);
+      }
+    }
   } catch {
-    /* Server may already be gone */
+    /* No tmux socket dir yet — nothing to reap */
+  }
+  for (const socket of sockets) {
+    try {
+      execFileSync("tmux", ["-L", socket, "kill-server"], { stdio: "ignore" });
+    } catch {
+      /* Server may already be gone */
+    }
   }
 }
 
@@ -14,8 +36,8 @@ export default function setup() {
   // Server exits unexpectedly). CI runs outside tmux, so this is a no-op there.
   delete process.env.TMUX;
   delete process.env.TMUX_PANE;
-  killTestServer();
+  killTestServers();
   return () => {
-    killTestServer();
+    killTestServers();
   };
 }

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -69,11 +69,17 @@ export async function runZaps(
     ...process.env,
     XDG_RUNTIME_DIR: runtimeDir,
     ZAPS_COMMAND: binaryPath,
-    ...extraEnv,
   };
+  // Plain terminal by default: strip the tmux context first, so a test that
+  // Wants to simulate one can put it back via `extraEnv`.
   delete env.TMUX;
   delete env.TMUX_PANE;
   delete env.ZAPS_TMUX_SOCKET;
+  // `zaps ls` picks toon when it thinks an agent is driving it; tests assert the
+  // Human table unless they ask for a machine format explicitly.
+  delete env.CLAUDECODE;
+  delete env.CURSOR_TRACE_DIR;
+  Object.assign(env, extraEnv);
   try {
     const { stdout, stderr } = await execFileAsync(binaryPath, args, { cwd, env });
     return { code: 0, stdout, stderr };

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -27,7 +27,9 @@ export async function managed(args: string[]): Promise<string> {
 
 export async function managedSessionExists(name: string): Promise<boolean> {
   try {
-    await managed(["has-session", "-t", name]);
+    // `=<name>`: tmux prefix-matches session targets, so a bare name would
+    // Report "exists" whenever a longer-named session is around.
+    await managed(["has-session", "-t", `=${name}`]);
     return true;
   } catch {
     return false;

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -138,6 +138,17 @@ export function serviceConfig(port: number): string {
 `;
 }
 
+/** TTYs of the clients attached to `session` (empty when nobody is attached). */
+export async function clients(session: string): Promise<string[]> {
+  try {
+    const out = await managed(["list-clients", "-t", session, "-F", "#{client_tty}"]);
+    return out ? out.split("\n") : [];
+  } catch {
+    // No server / session gone → nobody is attached.
+    return [];
+  }
+}
+
 /** True while the service still answers — i.e. the session survived. */
 export async function serviceAnswers(port: number): Promise<boolean> {
   try {

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -160,10 +160,17 @@ export async function clients(session: string): Promise<string[]> {
 
 /**
  * Print everything needed to diagnose a dead assertion from a CI log: what the
- * TUI pane shows, the pane table, and what the daemon believes.
+ * TUI pane shows, pane geometry/state, the daemon's view, and its log tail.
  */
-export async function dumpManagedState(session: string, runtimeDir: string): Promise<void> {
-  const frame = await managed(["capture-pane", "-t", `=${session}`, "-p", "-S", "-100"]).catch(
+export async function dumpManagedState(
+  session: string,
+  runtimeDir: string,
+  paneId?: string,
+): Promise<void> {
+  // Pane id when the caller has one; `=name:` (window form) otherwise — bare
+  // `=name` is not a valid capture-pane target on tmux 3.5a.
+  const target = paneId ?? `=${session}:`;
+  const frame = await managed(["capture-pane", "-t", target, "-p", "-S", "-100"]).catch(
     (error: unknown) => `capture failed: ${String(error)}`,
   );
   const paneTable = await managed([
@@ -171,16 +178,34 @@ export async function dumpManagedState(session: string, runtimeDir: string): Pro
     "-t",
     `=${session}`,
     "-F",
-    "#{pane_id}|#{pane_dead}|#{pane_current_command}",
+    "#{pane_id}|dead=#{pane_dead}|#{pane_width}x#{pane_height}|alt=#{alternate_on}|mode=#{pane_in_mode}|#{pane_current_command}",
   ]).catch((error: unknown) => `list-panes failed: ${String(error)}`);
   const ls = await runZaps(["ls", "--json"], process.cwd(), runtimeDir);
+  const logTails: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name === "daemon.log") {
+        const lines = fs.readFileSync(full, "utf8").split("\n");
+        logTails.push(`${full}:\n${lines.slice(-30).join("\n")}`);
+      }
+    }
+  };
+  try {
+    walk(runtimeDir);
+  } catch (error) {
+    logTails.push(`log walk failed: ${String(error)}`);
+  }
   // Uses process.stderr.write, NOT console.error: the lint autofix deletes
   // Console calls, which silently guts this dump (it happened).
   process.stderr.write(
     `--- managed state dump for ${session} ---\n` +
       `panes:\n${paneTable}\n` +
-      `tui frame:\n${frame}\n` +
+      `tui frame (${target}):\n${frame}\n` +
       `zaps ls (code ${ls.code}): ${ls.stdout || ls.stderr}\n` +
+      `daemon logs:\n${logTails.join("\n") || "(none found)"}\n` +
       `--- end dump ---\n`,
   );
 }

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -43,7 +43,7 @@ export async function panes(
   const out = await managed([
     "list-panes",
     "-t",
-    session,
+    `=${session}`,
     "-F",
     "#{pane_id}|#{pane_dead}|#{pane_pid}|#{pane_current_command}",
   ]);
@@ -149,7 +149,8 @@ export function serviceConfig(port: number): string {
 /** TTYs of the clients attached to `session` (empty when nobody is attached). */
 export async function clients(session: string): Promise<string[]> {
   try {
-    const out = await managed(["list-clients", "-t", session, "-F", "#{client_tty}"]);
+    // `=<name>`: without it tmux prefix-matches and lists a neighbour's clients.
+    const out = await managed(["list-clients", "-t", `=${session}`, "-F", "#{client_tty}"]);
     return out ? out.split("\n") : [];
   } catch {
     // No server / session gone → nobody is attached.

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -1,0 +1,151 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { sessionId } from "#src/daemon/session.js";
+import { MANAGED_SOCKET, managedSessionName } from "#src/lib/managed-tmux.js";
+
+const execFileAsync = promisify(execFile);
+
+/** The native binary — the only build that behaves exactly like a user's zaps. */
+export const binaryPath = path.resolve("dist/zaps");
+
+export interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** `tmux -L zaps …` — the real managed server, never the per-file test socket. */
+export async function managed(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("tmux", ["-L", MANAGED_SOCKET, ...args]);
+  return stdout.trim();
+}
+
+export async function managedSessionExists(name: string): Promise<boolean> {
+  try {
+    await managed(["has-session", "-t", name]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `#{pane_dead}`-style fields for every pane of `session`, in spatial order. */
+export async function panes(
+  session: string,
+): Promise<{ id: string; dead: boolean; pid: number; command: string }[]> {
+  const out = await managed([
+    "list-panes",
+    "-t",
+    session,
+    "-F",
+    "#{pane_id}|#{pane_dead}|#{pane_pid}|#{pane_current_command}",
+  ]);
+  if (!out) {
+    return [];
+  }
+  return out.split("\n").map((line) => {
+    const [id, dead, pid, command] = line.split("|");
+    return { id, dead: dead === "1", pid: Number.parseInt(pid, 10), command };
+  });
+}
+
+/**
+ * Run zaps the way a user would from a plain terminal: no `$TMUX`, no inherited
+ * tmux socket, and a private `XDG_RUNTIME_DIR` so the test drives its own daemon
+ * instead of the developer's. Never throws — the exit code is the assertion.
+ */
+export async function runZaps(
+  args: string[],
+  cwd: string,
+  runtimeDir: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    XDG_RUNTIME_DIR: runtimeDir,
+    ZAPS_COMMAND: binaryPath,
+    ...extraEnv,
+  };
+  delete env.TMUX;
+  delete env.TMUX_PANE;
+  delete env.ZAPS_TMUX_SOCKET;
+  try {
+    const { stdout, stderr } = await execFileAsync(binaryPath, args, { cwd, env });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: failure.code ?? 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
+  }
+}
+
+export async function pollUntil(
+  check: () => Promise<boolean>,
+  timeoutMs = 30_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  /* eslint-disable no-await-in-loop -- poll a real condition, never sleep-and-hope */
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  /* eslint-enable no-await-in-loop */
+  return false;
+}
+
+/** A project dir with a config, plus everything needed to address it later. */
+export interface Project {
+  dir: string;
+  runtimeDir: string;
+  sessionName: string;
+}
+
+export async function createProject(configBody: string): Promise<Project> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "zaps-managed-"));
+  // Real path: macOS tmpdir is a symlink, and zaps resolves cwd before hashing.
+  const realDir = fs.realpathSync(dir);
+  const configPath = path.join(realDir, ".zaps.mts");
+  await writeFile(configPath, configBody, "utf8");
+  const runtimeDir = path.join(realDir, "run");
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  return {
+    dir: realDir,
+    runtimeDir,
+    sessionName: managedSessionName(path.basename(realDir), sessionId(configPath)),
+  };
+}
+
+/** Config with one long-lived HTTP service, used to prove services survive. */
+export function serviceConfig(port: number): string {
+  const start = `node -e \\"require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port},()=>console.log('ready on port ${port}'))\\"`;
+  return `export function config({ define }) {
+  return define({
+    name: "managed-create",
+    services: {
+      web: {
+        start: "${start}",
+        ready: { port: ${port} },
+      },
+    },
+  });
+}
+`;
+}
+
+/** True while the service still answers — i.e. the session survived. */
+export async function serviceAnswers(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+}

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -174,7 +174,15 @@ export async function dumpManagedState(session: string, runtimeDir: string): Pro
     "#{pane_id}|#{pane_dead}|#{pane_current_command}",
   ]).catch((error: unknown) => `list-panes failed: ${String(error)}`);
   const ls = await runZaps(["ls", "--json"], process.cwd(), runtimeDir);
-  
+  // process.stderr.write, NOT console.error: the lint autofix deletes console
+  // calls, which silently guts this dump (it happened).
+  process.stderr.write(
+    `--- managed state dump for ${session} ---\n` +
+      `panes:\n${paneTable}\n` +
+      `tui frame:\n${frame}\n` +
+      `zaps ls (code ${ls.code}): ${ls.stdout || ls.stderr}\n` +
+      `--- end dump ---\n`,
+  );
 }
 
 /** True while the service still answers — i.e. the session survived. */

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -158,6 +158,25 @@ export async function clients(session: string): Promise<string[]> {
   }
 }
 
+/**
+ * Print everything needed to diagnose a dead assertion from a CI log: what the
+ * TUI pane shows, the pane table, and what the daemon believes.
+ */
+export async function dumpManagedState(session: string, runtimeDir: string): Promise<void> {
+  const frame = await managed(["capture-pane", "-t", `=${session}`, "-p", "-S", "-100"]).catch(
+    (error: unknown) => `capture failed: ${String(error)}`,
+  );
+  const paneTable = await managed([
+    "list-panes",
+    "-t",
+    `=${session}`,
+    "-F",
+    "#{pane_id}|#{pane_dead}|#{pane_current_command}",
+  ]).catch((error: unknown) => `list-panes failed: ${String(error)}`);
+  const ls = await runZaps(["ls", "--json"], process.cwd(), runtimeDir);
+  
+}
+
 /** True while the service still answers — i.e. the session survived. */
 export async function serviceAnswers(port: number): Promise<boolean> {
   try {

--- a/test/integration/helpers/managed.ts
+++ b/test/integration/helpers/managed.ts
@@ -174,8 +174,8 @@ export async function dumpManagedState(session: string, runtimeDir: string): Pro
     "#{pane_id}|#{pane_dead}|#{pane_current_command}",
   ]).catch((error: unknown) => `list-panes failed: ${String(error)}`);
   const ls = await runZaps(["ls", "--json"], process.cwd(), runtimeDir);
-  // process.stderr.write, NOT console.error: the lint autofix deletes console
-  // calls, which silently guts this dump (it happened).
+  // Uses process.stderr.write, NOT console.error: the lint autofix deletes
+  // Console calls, which silently guts this dump (it happened).
   process.stderr.write(
     `--- managed state dump for ${session} ---\n` +
       `panes:\n${paneTable}\n` +

--- a/test/integration/helpers/service-manager.ts
+++ b/test/integration/helpers/service-manager.ts
@@ -3,6 +3,7 @@ import type { ServiceManager } from "#src/lib/service/manager.js";
 import type { ServiceStatus } from "#src/lib/service/types.js";
 import {
   capturePane,
+  displayPopup,
   getWindowName,
   getWindowOption,
   panePid,
@@ -26,6 +27,7 @@ export const tmuxDeps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  displayPopup,
   exec: async () => {
     /* No-op */
   },

--- a/test/integration/helpers/service-manager.ts
+++ b/test/integration/helpers/service-manager.ts
@@ -10,13 +10,16 @@ import {
   sendCtrlC,
   sendKeys,
   setWindowOption,
+  tmuxFor,
 } from "#src/lib/tmux.js";
+
+import { testTmuxSocket } from "./tmux.js";
 
 export const tmuxDeps = {
   sendKeys,
   sendCtrlC,
   panePid,
-  detectPorts,
+  detectPorts: async (paneTarget: string) => detectPorts(paneTarget, tmuxFor(testTmuxSocket())),
   capturePane,
   getDescendantPids,
   renameWindow,

--- a/test/integration/helpers/tmux.ts
+++ b/test/integration/helpers/tmux.ts
@@ -85,3 +85,11 @@ export async function buildTestPaneMap(
   }
   return paneMap;
 }
+
+/**
+ * Socket the integration suite pins via its vitest env — passed explicitly to
+ * `session.create` / `Session`, since the daemon no longer reads the env.
+ */
+export function testTmuxSocket(): string | null {
+  return getEnv("ZAPS_TMUX_SOCKET") ?? null;
+}

--- a/test/integration/service-manager/raw-and-crash.test.ts
+++ b/test/integration/service-manager/raw-and-crash.test.ts
@@ -14,7 +14,7 @@ import { createTestDaemon, waitForServiceState } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const localZaps = path.join(projectRoot, "bin", "zaps");
@@ -76,6 +76,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 
@@ -119,6 +120,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 
@@ -167,6 +169,7 @@ describe.skipIf(!hasTmux())("raw mode and crash detection", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 

--- a/test/integration/service-manager/wrapper.test.ts
+++ b/test/integration/service-manager/wrapper.test.ts
@@ -14,7 +14,7 @@ import { createTestDaemon, waitForServiceState } from "../helpers/daemon.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const localZaps = path.join(projectRoot, "bin", "zaps");
@@ -83,6 +83,7 @@ describe.skipIf(!hasTmux())("wrapper lifecycle", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 
@@ -106,6 +107,7 @@ describe.skipIf(!hasTmux())("wrapper lifecycle", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 
@@ -127,6 +129,7 @@ describe.skipIf(!hasTmux())("wrapper lifecycle", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 
@@ -150,6 +153,7 @@ describe.skipIf(!hasTmux())("wrapper lifecycle", () => {
       projectDir: tmpDir,
       tmuxSession: tmux.name,
       originPane: tmux.initialPaneId,
+      tmuxSocket: testTmuxSocket(),
     });
     sid = (res.result as { id: string }).id;
 

--- a/test/integration/setup-tmux-socket.ts
+++ b/test/integration/setup-tmux-socket.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import { afterAll, expect } from "vitest";
+
+/**
+ * Give every integration FILE its own tmux server socket.
+ *
+ * With one shared server the suite raced against itself: the last `kill-session`
+ * of one file tears the server down while the next file is creating its session
+ * (`server exited unexpectedly`), and a client attached by one file resizes the
+ * windows another file measures. A socket per file removes both — servers are
+ * started on demand by the first command and exit when their last session dies.
+ */
+function socketName(): string {
+  const { testPath } = expect.getState();
+  if (!testPath) {
+    // No file context (shouldn't happen in a per-file setup) — fall back to the
+    // Worker id so concurrent workers still never share a server.
+    return `zaps-test-w${process.env.VITEST_POOL_ID ?? "0"}`;
+  }
+  const stem = path
+    .basename(testPath)
+    .replace(/\.test\.ts$/u, "")
+    .replace(/[^a-zA-Z0-9_-]/gu, "-");
+  const dir = path.basename(path.dirname(testPath));
+  return `zaps-test-${dir}-${stem}`;
+}
+
+const socket = socketName();
+process.env.ZAPS_TMUX_SOCKET = socket;
+
+afterAll(() => {
+  // The file owns this server outright, so a kill-server is safe (and reaps any
+  // Session a failed test left behind). Never touches the default server.
+  try {
+    execFileSync("tmux", ["-L", socket, "kill-server"], { stdio: "ignore" });
+  } catch {
+    /* Server already gone — nothing to reap */
+  }
+});

--- a/test/integration/tmux/apply-geometry.test.ts
+++ b/test/integration/tmux/apply-geometry.test.ts
@@ -15,12 +15,13 @@ import {
   paneIndexOrder,
   sendKeys,
   splitPane,
+  tmuxFor,
   windowLayout,
 } from "#src/lib/tmux.js";
 
 import { hasScriptPty, hasTmux, isCI } from "../helpers/skip.js";
 import type { AttachedClient, TestSession } from "../helpers/tmux.js";
-import { attachClient, createTestSession } from "../helpers/tmux.js";
+import { attachClient, createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 import { waitFor } from "../helpers/wait.js";
 
 const execFileAsync = promisify(execFile);
@@ -135,6 +136,7 @@ async function probeSttyUntil(
 
 function makeReflow(layout: LayoutNode, paneMap: PaneMap, sessionName: string): LayoutReflow {
   return new LayoutReflow({
+    tmux: tmuxFor(testTmuxSocket()),
     getLayout: () => layout,
     getPaneMap: () => paneMap,
     getWindowTarget: () => sessionName,

--- a/test/integration/tmux/apply-geometry.test.ts
+++ b/test/integration/tmux/apply-geometry.test.ts
@@ -142,7 +142,7 @@ function makeReflow(layout: LayoutNode, paneMap: PaneMap, sessionName: string): 
     tmux: tmuxFor(testTmuxSocket()),
     getLayout: () => layout,
     getPaneMap: () => paneMap,
-    getWindowTarget: () => sessionName,
+    getWindowTarget: () => `=${sessionName}:`,
   });
 }
 

--- a/test/integration/tmux/apply-geometry.test.ts
+++ b/test/integration/tmux/apply-geometry.test.ts
@@ -117,7 +117,10 @@ async function probeSttyOnce(paneId: string): Promise<{ rows: number; cols: numb
 async function probeSttyUntil(
   paneId: string,
   expected: { rows: number; cols: number },
-  timeoutMs = 10_000,
+  // Generous deadline: on a loaded machine the shell can take many seconds to
+  // Process the SIGWINCH, and this polls for the condition rather than sleeping
+  // — a correct resize still returns on the first matching poll.
+  timeoutMs = 30_000,
   pollMs = 100,
 ): Promise<{ rows: number; cols: number }> {
   const start = Date.now();

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -17,7 +17,7 @@ import { capturePane, getWindowSize, paneIndexOrder, sendKeys, splitPane } from 
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -169,6 +169,8 @@ function makeSession(
     paneMap,
     tmuxSession,
     originPane: initialPaneId,
+    tmuxSocket: testTmuxSocket(),
+    managedTmux: false,
     deps: {
       capturePane,
       sendKeys: vi.fn().mockResolvedValue(undefined),

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -13,7 +13,14 @@ import type { Rect } from "#src/lib/tmux-layout.js";
 import { computeRects } from "#src/lib/tmux-layout.js";
 import type { LayoutReflowDeps, PaneMap } from "#src/lib/tmux-reflow.js";
 import { LayoutReflow, TmuxFailedError } from "#src/lib/tmux-reflow.js";
-import { capturePane, getWindowSize, paneIndexOrder, sendKeys, splitPane } from "#src/lib/tmux.js";
+import {
+  capturePane,
+  getWindowSize,
+  paneIndexOrder,
+  sendKeys,
+  splitPane,
+  tmuxFor,
+} from "#src/lib/tmux.js";
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
@@ -106,6 +113,7 @@ function makeReflow(
   overrides: Partial<LayoutReflowDeps> = {},
 ): LayoutReflow {
   return new LayoutReflow({
+    tmux: tmuxFor(testTmuxSocket()),
     getLayout: () => layout,
     getPaneMap: () => paneMap,
     getWindowTarget: () => sessionName,
@@ -648,6 +656,7 @@ describe.skipIf(!hasTmux())("LayoutReflow rollback — real tmux fault injection
     let calls = 0;
     let observedPaneId: string | undefined;
     const faultyReflow = new LayoutReflow({
+      tmux: tmuxFor(testTmuxSocket()),
       getLayout: () => layout,
       getPaneMap: () => zapsSession.paneMap,
       getWindowTarget: () => session.name,

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -116,7 +116,7 @@ function makeReflow(
     tmux: tmuxFor(testTmuxSocket()),
     getLayout: () => layout,
     getPaneMap: () => paneMap,
-    getWindowTarget: () => sessionName,
+    getWindowTarget: () => `=${sessionName}:`,
     ...overrides,
   });
 }
@@ -659,7 +659,7 @@ describe.skipIf(!hasTmux())("LayoutReflow rollback — real tmux fault injection
       tmux: tmuxFor(testTmuxSocket()),
       getLayout: () => layout,
       getPaneMap: () => zapsSession.paneMap,
-      getWindowTarget: () => session.name,
+      getWindowTarget: () => `=${session.name}:`,
       selectLayout: async (target, layoutStr) => {
         calls += 1;
         if (calls === 1) {

--- a/test/integration/tmux/layout.test.ts
+++ b/test/integration/tmux/layout.test.ts
@@ -2,12 +2,12 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { LayoutNode, ServiceConfig } from "#src/config/types.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
-import { listPanes } from "#src/lib/tmux.js";
+import { listPanes, tmuxFor } from "#src/lib/tmux.js";
 import type { PaneInfo } from "#src/lib/tmux.js";
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 /** Poll listPanes until expected count or timeout — tmux may lag behind splitPane. */
 async function waitForPaneCount(
@@ -41,7 +41,9 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       worker: { start: "echo worker" },
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, undefined, services);
+    const { paneMap } = await createLayout(session.initialPaneId, undefined, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
     const panes = await waitForPaneCount(session.name, 3);
 
     expect(panes).toHaveLength(3);
@@ -57,7 +59,9 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       bg: { start: "echo bg", detached: true },
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, undefined, services);
+    const { paneMap } = await createLayout(session.initialPaneId, undefined, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
     const panes = await waitForPaneCount(session.name, 2);
 
     expect(panes).toHaveLength(2);
@@ -79,7 +83,9 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       ],
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, layout, services);
+    const { paneMap } = await createLayout(session.initialPaneId, layout, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
     const panes = await waitForPaneCount(session.name, 2);
 
     expect(panes).toHaveLength(2);
@@ -108,7 +114,9 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       ],
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, layout, services);
+    const { paneMap } = await createLayout(session.initialPaneId, layout, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
     const panes = await waitForPaneCount(session.name, 3);
 
     expect(panes).toHaveLength(3);
@@ -131,7 +139,9 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       ],
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, layout, services);
+    const { paneMap } = await createLayout(session.initialPaneId, layout, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
     const panes = await waitForPaneCount(session.name, 3);
 
     // @tui + api from layout + worker auto-split
@@ -154,7 +164,13 @@ describe.skipIf(!hasTmux())("tmux layout integration", () => {
       ],
     };
 
-    const { paneMap, focusPane } = await createLayout(session.initialPaneId, layout, services);
+    const { paneMap, focusPane } = await createLayout(
+      session.initialPaneId,
+      layout,
+      services,
+      undefined,
+      { tmux: tmuxFor(testTmuxSocket()) },
+    );
 
     expect(focusPane).toBe(paneMap.api);
   });

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -40,6 +40,7 @@ import {
   panePid,
   sendCtrlC,
   sendKeys,
+  tmuxFor,
 } from "#src/lib/tmux.js";
 
 import { hasTmux } from "../helpers/skip.js";
@@ -202,7 +203,7 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     config.project.layout,
     config.project.services,
     config.groups,
-    { skip },
+    { skip, tmux: tmuxFor(testTmuxSocket()) },
   );
 
   const ref: { session: Session | null } = { session: null };
@@ -212,7 +213,7 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     sendKeys,
     sendCtrlC,
     panePid,
-    detectPorts,
+    detectPorts: async (paneTarget: string) => detectPorts(paneTarget, tmuxFor(testTmuxSocket())),
     capturePane,
     // Real PID walker — required for crash detection (Flow D) and the
     // ManagerLoop's "process still alive" probe. Stubbing it (e.g. always
@@ -820,7 +821,7 @@ describe.skipIf(!hasTmux())("Phase 4 lifecycle integration", () => {
       config.project.layout,
       config.project.services,
       config.groups,
-      { skip, reserveTuiPane: true },
+      { skip, reserveTuiPane: true, tmux: tmuxFor(testTmuxSocket()) },
     );
 
     try {

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -44,7 +44,7 @@ import {
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 // --- Helpers ---------------------------------------------------------------
 
@@ -276,6 +276,8 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     paneMap,
     tmuxSession: testSession.name,
     originPane: testSession.initialPaneId,
+    tmuxSocket: testTmuxSocket(),
+    managedTmux: false,
     deps,
   };
   const session = new Session(params, manager);

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -228,6 +228,9 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     setWindowOption: async () => {
       /* No-op */
     },
+    displayPopup: async () => {
+      /* No-op */
+    },
     exec: async () => {
       /* No-op */
     },

--- a/test/integration/tmux/managed-create.test.ts
+++ b/test/integration/tmux/managed-create.test.ts
@@ -1,0 +1,238 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { sessionId } from "#src/daemon/session.js";
+import { MANAGED_SOCKET, managedSessionName } from "#src/lib/managed-tmux.js";
+
+import { reservePort } from "../helpers/port.js";
+import { hasBinary, hasTmux } from "../helpers/skip.js";
+
+const execFileAsync = promisify(execFile);
+const binaryPath = path.resolve("dist/zaps");
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** `tmux -L zaps …` — the real managed server, never the per-file test socket. */
+async function managed(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("tmux", ["-L", MANAGED_SOCKET, ...args]);
+  return stdout.trim();
+}
+
+async function managedSessionExists(name: string): Promise<boolean> {
+  try {
+    await managed(["has-session", "-t", name]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run zaps as a user would from a plain terminal: no `$TMUX`, no inherited tmux
+ * socket, and a private `XDG_RUNTIME_DIR` so this test drives its own daemon
+ * instead of the developer's.
+ */
+async function runZaps(
+  args: string[],
+  cwd: string,
+  runtimeDir: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    XDG_RUNTIME_DIR: runtimeDir,
+    ZAPS_COMMAND: binaryPath,
+    ...extraEnv,
+  };
+  delete env.TMUX;
+  delete env.TMUX_PANE;
+  delete env.ZAPS_TMUX_SOCKET;
+  try {
+    const { stdout, stderr } = await execFileAsync(binaryPath, args, { cwd, env });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: failure.code ?? 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
+  }
+}
+
+async function pollUntil(check: () => Promise<boolean>, timeoutMs = 30_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  /* eslint-disable no-await-in-loop -- poll a real condition, never sleep-and-hope */
+  while (Date.now() < deadline) {
+    if (await check()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  /* eslint-enable no-await-in-loop */
+  return false;
+}
+
+/** A project dir with a config, plus everything needed to address it later. */
+interface Project {
+  dir: string;
+  runtimeDir: string;
+  sessionName: string;
+}
+
+async function createProject(configBody: string): Promise<Project> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "zaps-managed-"));
+  // Real path: macOS tmpdir is a symlink, and zaps resolves cwd before hashing.
+  const realDir = fs.realpathSync(dir);
+  const configPath = path.join(realDir, ".zaps.mts");
+  await writeFile(configPath, configBody, "utf8");
+  const runtimeDir = path.join(realDir, "run");
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  return {
+    dir: realDir,
+    runtimeDir,
+    sessionName: managedSessionName(path.basename(realDir), sessionId(configPath)),
+  };
+}
+
+function serviceConfig(port: number): string {
+  const start = `node -e \\"require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port},()=>console.log('ready on port ${port}'))\\"`;
+  return `export function config({ define }) {
+  return define({
+    name: "managed-create",
+    services: {
+      web: {
+        start: "${start}",
+        ready: { port: ${port} },
+      },
+    },
+  });
+}
+`;
+}
+
+describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 120_000 }, () => {
+  let project: Project | undefined = undefined;
+
+  afterEach(async () => {
+    if (project) {
+      // Stop the daemon this test started, then reap its tmux session.
+      await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
+      try {
+        await managed(["kill-session", "-t", project.sessionName]);
+      } catch {
+        // Already gone — the failure paths kill it themselves.
+      }
+      await rm(project.dir, { recursive: true, force: true });
+      project = undefined;
+    }
+  });
+
+  it("creates a managed session, starts services, and reports success (F4)", async () => {
+    const { port, release } = await reservePort();
+    project = await createProject(serviceConfig(port));
+    await release();
+
+    const result = await runZaps(["up", "-d"], project.dir, project.runtimeDir);
+
+    expect(result.stderr + result.stdout).toContain("started (detached, managed tmux)");
+    expect(result.code).toBe(0);
+    await expect(managedSessionExists(project.sessionName)).resolves.toBe(true);
+
+    // The markers the inner zaps reads: socket routing + managed reporting.
+    await expect(
+      managed(["show-environment", "-t", project.sessionName, "ZAPS_TMUX_SOCKET"]),
+    ).resolves.toBe(`ZAPS_TMUX_SOCKET=${MANAGED_SOCKET}`);
+    await expect(
+      managed(["show-environment", "-t", project.sessionName, "ZAPS_MANAGED_TMUX"]),
+    ).resolves.toBe("ZAPS_MANAGED_TMUX=1");
+
+    // Options that keep the session (and its services) alive while unattached.
+    await expect(
+      managed(["show-options", "-t", project.sessionName, "destroy-unattached"]),
+    ).resolves.toBe("destroy-unattached off");
+    const paneId = await managed([
+      "list-panes",
+      "-t",
+      project.sessionName,
+      "-F",
+      "#{pane_id}",
+    ]).then((out) => out.split("\n")[0]);
+    await expect(managed(["show-options", "-p", "-t", paneId, "remain-on-exit"])).resolves.toBe(
+      "remain-on-exit on",
+    );
+
+    // Services really run inside the managed session.
+    const ready = await pollUntil(async () => {
+      try {
+        const response = await fetch(`http://localhost:${port}`, {
+          signal: AbortSignal.timeout(1000),
+        });
+        return response.status === 200;
+      } catch {
+        return false;
+      }
+    });
+    expect(ready).toBe(true);
+
+    // The daemon reports it as managed, hosted by the managed tmux session.
+    const listed = await runZaps(["ls", "--json"], project.dir, project.runtimeDir);
+    const sessions = JSON.parse(listed.stdout) as {
+      managed: boolean;
+      tmuxSession: string;
+    }[];
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ managed: true, tmuxSession: project.sessionName });
+  });
+
+  it("propagates an inner failure and leaves no session behind (F4)", async () => {
+    project = await createProject(`export function config() {
+  throw new Error("boom-managed-config");
+}
+`);
+
+    const result = await runZaps(["up", "-d"], project.dir, project.runtimeDir);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr + result.stdout).toContain("boom-managed-config");
+    await expect(managedSessionExists(project.sessionName)).resolves.toBe(false);
+  });
+
+  it("reaps a stale managed session the daemon knows nothing about (F9)", async () => {
+    const { port, release } = await reservePort();
+    project = await createProject(serviceConfig(port));
+    await release();
+
+    // Leftover from a crashed daemon: right name, no daemon session, no markers.
+    await managed(["new-session", "-d", "-s", project.sessionName, "--", "sleep", "600"]);
+    await expect(managedSessionExists(project.sessionName)).resolves.toBe(true);
+
+    const result = await runZaps(["up", "-d"], project.dir, project.runtimeDir);
+    expect(result.code).toBe(0);
+
+    // Same name, but a fresh session: the markers only exist on the new one.
+    await expect(
+      managed(["show-environment", "-t", project.sessionName, "ZAPS_MANAGED_TMUX"]),
+    ).resolves.toBe("ZAPS_MANAGED_TMUX=1");
+  });
+
+  it("restores the legacy error under ZAPS_AUTO_TMUX=0", async () => {
+    const { port, release } = await reservePort();
+    project = await createProject(serviceConfig(port));
+    await release();
+
+    const result = await runZaps(["up"], project.dir, project.runtimeDir, {
+      ZAPS_AUTO_TMUX: "0",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("zaps must be run from inside a tmux session.");
+    await expect(managedSessionExists(project.sessionName)).resolves.toBe(false);
+  });
+});

--- a/test/integration/tmux/managed-create.test.ts
+++ b/test/integration/tmux/managed-create.test.ts
@@ -44,20 +44,20 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 12
 
     // The markers the inner zaps reads: socket routing + managed reporting.
     await expect(
-      managed(["show-environment", "-t", project.sessionName, "ZAPS_TMUX_SOCKET"]),
+      managed(["show-environment", "-t", `=${project.sessionName}`, "ZAPS_TMUX_SOCKET"]),
     ).resolves.toBe(`ZAPS_TMUX_SOCKET=${MANAGED_SOCKET}`);
     await expect(
-      managed(["show-environment", "-t", project.sessionName, "ZAPS_MANAGED_TMUX"]),
+      managed(["show-environment", "-t", `=${project.sessionName}`, "ZAPS_MANAGED_TMUX"]),
     ).resolves.toBe("ZAPS_MANAGED_TMUX=1");
 
     // Options that keep the session (and its services) alive while unattached.
     await expect(
-      managed(["show-options", "-t", project.sessionName, "destroy-unattached"]),
+      managed(["show-options", "-t", `=${project.sessionName}:`, "destroy-unattached"]),
     ).resolves.toBe("destroy-unattached off");
     const paneId = await managed([
       "list-panes",
       "-t",
-      project.sessionName,
+      `=${project.sessionName}`,
       "-F",
       "#{pane_id}",
     ]).then((out) => out.split("\n")[0]);
@@ -105,7 +105,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 12
 
     // Same name, but a fresh session: the markers only exist on the new one.
     await expect(
-      managed(["show-environment", "-t", project.sessionName, "ZAPS_MANAGED_TMUX"]),
+      managed(["show-environment", "-t", `=${project.sessionName}`, "ZAPS_MANAGED_TMUX"]),
     ).resolves.toBe("ZAPS_MANAGED_TMUX=1");
   });
 

--- a/test/integration/tmux/managed-create.test.ts
+++ b/test/integration/tmux/managed-create.test.ts
@@ -1,121 +1,19 @@
-import { execFile } from "node:child_process";
-import fs from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { promisify } from "node:util";
-
 import { afterEach, describe, expect, it } from "vitest";
 
-import { sessionId } from "#src/daemon/session.js";
-import { MANAGED_SOCKET, managedSessionName } from "#src/lib/managed-tmux.js";
+import { MANAGED_SOCKET } from "#src/lib/managed-tmux.js";
 
+import type { Project } from "../helpers/managed.js";
+import {
+  createProject,
+  managed,
+  managedSessionExists,
+  pollUntil,
+  runZaps,
+  serviceAnswers,
+  serviceConfig,
+} from "../helpers/managed.js";
 import { reservePort } from "../helpers/port.js";
 import { hasBinary, hasTmux } from "../helpers/skip.js";
-
-const execFileAsync = promisify(execFile);
-const binaryPath = path.resolve("dist/zaps");
-
-interface RunResult {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
-
-/** `tmux -L zaps …` — the real managed server, never the per-file test socket. */
-async function managed(args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("tmux", ["-L", MANAGED_SOCKET, ...args]);
-  return stdout.trim();
-}
-
-async function managedSessionExists(name: string): Promise<boolean> {
-  try {
-    await managed(["has-session", "-t", name]);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Run zaps as a user would from a plain terminal: no `$TMUX`, no inherited tmux
- * socket, and a private `XDG_RUNTIME_DIR` so this test drives its own daemon
- * instead of the developer's.
- */
-async function runZaps(
-  args: string[],
-  cwd: string,
-  runtimeDir: string,
-  extraEnv: NodeJS.ProcessEnv = {},
-): Promise<RunResult> {
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    XDG_RUNTIME_DIR: runtimeDir,
-    ZAPS_COMMAND: binaryPath,
-    ...extraEnv,
-  };
-  delete env.TMUX;
-  delete env.TMUX_PANE;
-  delete env.ZAPS_TMUX_SOCKET;
-  try {
-    const { stdout, stderr } = await execFileAsync(binaryPath, args, { cwd, env });
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const failure = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: failure.code ?? 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
-  }
-}
-
-async function pollUntil(check: () => Promise<boolean>, timeoutMs = 30_000): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  /* eslint-disable no-await-in-loop -- poll a real condition, never sleep-and-hope */
-  while (Date.now() < deadline) {
-    if (await check()) {
-      return true;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  /* eslint-enable no-await-in-loop */
-  return false;
-}
-
-/** A project dir with a config, plus everything needed to address it later. */
-interface Project {
-  dir: string;
-  runtimeDir: string;
-  sessionName: string;
-}
-
-async function createProject(configBody: string): Promise<Project> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "zaps-managed-"));
-  // Real path: macOS tmpdir is a symlink, and zaps resolves cwd before hashing.
-  const realDir = fs.realpathSync(dir);
-  const configPath = path.join(realDir, ".zaps.mts");
-  await writeFile(configPath, configBody, "utf8");
-  const runtimeDir = path.join(realDir, "run");
-  fs.mkdirSync(runtimeDir, { recursive: true });
-  return {
-    dir: realDir,
-    runtimeDir,
-    sessionName: managedSessionName(path.basename(realDir), sessionId(configPath)),
-  };
-}
-
-function serviceConfig(port: number): string {
-  const start = `node -e \\"require('http').createServer((_,r)=>{r.writeHead(200);r.end('ok')}).listen(${port},()=>console.log('ready on port ${port}'))\\"`;
-  return `export function config({ define }) {
-  return define({
-    name: "managed-create",
-    services: {
-      web: {
-        start: "${start}",
-        ready: { port: ${port} },
-      },
-    },
-  });
-}
-`;
-}
 
 describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 120_000 }, () => {
   let project: Project | undefined = undefined;
@@ -129,7 +27,6 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 12
       } catch {
         // Already gone — the failure paths kill it themselves.
       }
-      await rm(project.dir, { recursive: true, force: true });
       project = undefined;
     }
   });
@@ -169,17 +66,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 12
     );
 
     // Services really run inside the managed session.
-    const ready = await pollUntil(async () => {
-      try {
-        const response = await fetch(`http://localhost:${port}`, {
-          signal: AbortSignal.timeout(1000),
-        });
-        return response.status === 200;
-      } catch {
-        return false;
-      }
-    });
-    expect(ready).toBe(true);
+    expect(await pollUntil(async () => serviceAnswers(port))).toBe(true);
 
     // The daemon reports it as managed, hosted by the managed tmux session.
     const listed = await runZaps(["ls", "--json"], project.dir, project.runtimeDir);

--- a/test/integration/tmux/managed-create.test.ts
+++ b/test/integration/tmux/managed-create.test.ts
@@ -23,7 +23,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed tmux create", { timeout: 12
       // Stop the daemon this test started, then reap its tmux session.
       await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
       try {
-        await managed(["kill-session", "-t", project.sessionName]);
+        await managed(["kill-session", "-t", `=${project.sessionName}`]);
       } catch {
         // Already gone — the failure paths kill it themselves.
       }

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -1,7 +1,11 @@
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { Project } from "../helpers/managed.js";
 import {
+  clients,
   createProject,
   managed,
   managedSessionExists,
@@ -12,7 +16,7 @@ import {
   serviceConfig,
 } from "../helpers/managed.js";
 import { reservePort } from "../helpers/port.js";
-import { hasBinary, hasTmux } from "../helpers/skip.js";
+import { hasBinary, hasScriptPty, hasTmux } from "../helpers/skip.js";
 
 /**
  * CI has no TTY, so `attach-session` itself cannot succeed here — the exit code
@@ -128,6 +132,72 @@ describe.skipIf(!hasTmux() || !hasBinary())(
       expect(windows.split("\n").length).toBeGreaterThanOrEqual(1);
       expect(await serviceAnswers(port)).toBe(true);
     });
+
+    // The one case that needs a real client: `q` only detaches something when
+    // Something is attached, and the bug this pins (`detach-client -t <pane>`)
+    // Fails silently — every pane-level assertion still passed.
+    it.skipIf(!hasScriptPty())(
+      "quitting with q detaches the real client and holds the pane (F2)",
+      async () => {
+        const { port, tuiPane } = await startDetached();
+        if (!project) {
+          throw new Error("no project");
+        }
+        const session = project.sessionName;
+
+        // Revive the TUI so there is a live process to press `q` in.
+        await runZaps(["attach"], project.dir, project.runtimeDir);
+        expect(
+          await pollUntil(async () => {
+            const live = await panes(session);
+            return live.find((p) => p.id === tuiPane)?.dead === false;
+          }, 15_000),
+        ).toBe(true);
+
+        // A real tmux client over a pty — `script` is the only way to get one
+        // In a headless run.
+        const client: ChildProcess = spawn(
+          "script",
+          ["-qec", `tmux -L zaps attach -t ${session}`, "/dev/null"],
+          { stdio: "ignore" },
+        );
+        try {
+          const attached = await pollUntil(async () => {
+            const live = await clients(session);
+            return live.length > 0;
+          }, 15_000);
+          expect(attached).toBe(true);
+
+          // Wait for the dashboard to actually paint: Ink only starts reading
+          // Keys once it has mounted, and a `q` sent before that is dropped.
+          expect(
+            await pollUntil(async () => {
+              const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
+              return frame.includes("web");
+            }, 30_000),
+          ).toBe(true);
+          await managed(["send-keys", "-t", tuiPane, "q"]);
+
+          // The MUST-HAVE of F2: the real client is gone, not just the process.
+          const detached = await pollUntil(async () => {
+            const live = await clients(session);
+            return live.length === 0;
+          }, 20_000);
+          expect(detached).toBe(true);
+          expect(
+            await pollUntil(async () => {
+              const live = await panes(session);
+              return live.find((p) => p.id === tuiPane)?.dead === true;
+            }, 20_000),
+          ).toBe(true);
+          // Detach, not teardown: the session and its services live on.
+          expect(await managedSessionExists(session)).toBe(true);
+          expect(await serviceAnswers(port)).toBe(true);
+        } finally {
+          client.kill("SIGKILL");
+        }
+      },
+    );
 
     it("routes the bare `zaps` smart default through the same re-attach path", async () => {
       const { tuiPane } = await startDetached();

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -133,6 +133,64 @@ describe.skipIf(!hasTmux() || !hasBinary())(
       expect(await serviceAnswers(port)).toBe(true);
     });
 
+    // A tmux client whose own stdin is at EOF (`script … < /dev/null`, CI, an
+    // Agent shell) makes the pty emit `VEOF` (0x04) the moment it attaches, and
+    // Tmux delivers that to the pane as a plain Ctrl-D. With shutdown bound to a
+    // Single key, merely running the documented escape-hatch attach destroyed the
+    // Session and stopped every service before the user typed anything.
+    it.skipIf(!hasScriptPty())(
+      "survives a raw client attaching onto a live, unattached TUI",
+      async () => {
+        const { port, tuiPane } = await startDetached();
+        if (!project) {
+          throw new Error("no project");
+        }
+        const session = project.sessionName;
+
+        // Revive the TUI and let it fully mount: a live TUI with NO client
+        // Attached is exactly the state the stray byte lands in.
+        await runZaps(["attach"], project.dir, project.runtimeDir);
+        expect(
+          await pollUntil(async () => {
+            const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
+            return frame.includes("web");
+          }, 30_000),
+        ).toBe(true);
+        expect(await clients(session)).toEqual([]);
+
+        // The README/F7 escape hatch, run the way a script or agent would.
+        const raw: ChildProcess = spawn(
+          "script",
+          ["-qec", `tmux -L zaps attach -t =${session}`, "/dev/null"],
+          { stdio: "ignore" },
+        );
+        try {
+          // Either the client shows up, or the session died under it — the
+          // Regression is the latter, so wait for whichever happens first.
+          await pollUntil(async () => {
+            const live = await clients(session);
+            return live.length > 0 || !(await managedSessionExists(session));
+          }, 15_000);
+          expect(await managedSessionExists(session)).toBe(true);
+          expect(await clients(session)).not.toEqual([]);
+
+          // Give the byte every chance to be processed before asserting: poll for
+          // The FAILURE condition instead of assuming it can't happen.
+          const died = await pollUntil(async () => !(await managedSessionExists(session)), 8000);
+          expect(died).toBe(false);
+
+          const listed = await runZaps(["ls", "--json"], project.dir, project.runtimeDir);
+          expect(JSON.parse(listed.stdout || "[]")).toHaveLength(1);
+          expect(await serviceAnswers(port)).toBe(true);
+          const live = await panes(session);
+          expect(live.find((p) => p.id === tuiPane)?.dead).toBe(false);
+          expect(await managed(["capture-pane", "-t", tuiPane, "-p"])).toContain("web");
+        } finally {
+          raw.kill("SIGKILL");
+        }
+      },
+    );
+
     // The one case that needs a real client: `q` only detaches something when
     // Something is attached, and the bug this pins (`detach-client -t <pane>`)
     // Fails silently — every pane-level assertion still passed.

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -97,7 +97,11 @@ describe.skipIf(!hasTmux() || !hasBinary())(
         // A detach: `remain-on-exit` holds the pane dead at its position.
         // eslint-disable-next-line no-await-in-loop
         await managed(["send-keys", "-t", tuiPane, "C-c"]);
-        process.kill(revived?.pid ?? 0, "SIGKILL");
+        try {
+          process.kill(revived?.pid ?? 0, "SIGKILL");
+        } catch {
+          // ESRCH: the C-c already took the TUI down — which is the goal.
+        }
         // eslint-disable-next-line no-await-in-loop
         const held = await pollUntil(async () => {
           const current = await panes(project?.sessionName ?? "");

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -7,6 +7,7 @@ import type { Project } from "../helpers/managed.js";
 import {
   clients,
   createProject,
+  dumpManagedState,
   managed,
   managedSessionExists,
   panes,
@@ -154,12 +155,14 @@ describe.skipIf(!hasTmux() || !hasBinary())(
         // Revive the TUI and let it fully mount: a live TUI with NO client
         // Attached is exactly the state the stray byte lands in.
         await runZaps(["attach"], project.dir, project.runtimeDir);
-        expect(
-          await pollUntil(async () => {
-            const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
-            return frame.includes("web");
-          }, 30_000),
-        ).toBe(true);
+        const painted = await pollUntil(async () => {
+          const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
+          return frame.includes("web");
+        }, 30_000);
+        if (!painted) {
+          await dumpManagedState(session, project.runtimeDir);
+        }
+        expect(painted).toBe(true);
         expect(await clients(session)).toEqual([]);
 
         // The README/F7 escape hatch, run the way a script or agent would.
@@ -232,12 +235,14 @@ describe.skipIf(!hasTmux() || !hasBinary())(
 
           // Wait for the dashboard to actually paint: Ink only starts reading
           // Keys once it has mounted, and a `q` sent before that is dropped.
-          expect(
-            await pollUntil(async () => {
-              const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
-              return frame.includes("web");
-            }, 30_000),
-          ).toBe(true);
+          const qPainted = await pollUntil(async () => {
+            const frame = await managed(["capture-pane", "-t", tuiPane, "-p"]);
+            return frame.includes("web");
+          }, 30_000);
+          if (!qPainted) {
+            await dumpManagedState(session, project.runtimeDir);
+          }
+          expect(qPainted).toBe(true);
           await managed(["send-keys", "-t", tuiPane, "q"]);
 
           // The MUST-HAVE of F2: the real client is gone, not just the process.

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Project } from "../helpers/managed.js";
+import {
+  createProject,
+  managed,
+  managedSessionExists,
+  panes,
+  pollUntil,
+  runZaps,
+  serviceAnswers,
+  serviceConfig,
+} from "../helpers/managed.js";
+import { reservePort } from "../helpers/port.js";
+import { hasBinary, hasTmux } from "../helpers/skip.js";
+
+/**
+ * CI has no TTY, so `attach-session` itself cannot succeed here — the exit code
+ * is therefore never the assertion. What IS observable (and is what the feature
+ * actually promises) is the tmux state the re-attach path leaves behind: the TUI
+ * pane alive again at its original position, with the services untouched.
+ *
+ * `zaps up -d` leaves exactly the post-detach state: the bootstrap pane is the
+ * `@tui` pane, and it is dead-but-held once the inner run exits.
+ */
+describe.skipIf(!hasTmux() || !hasBinary())(
+  "managed detach + re-attach",
+  { timeout: 180_000 },
+  () => {
+    let project: Project | undefined = undefined;
+
+    afterEach(async () => {
+      if (project) {
+        await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
+        try {
+          await managed(["kill-session", "-t", project.sessionName]);
+        } catch {
+          // Already gone.
+        }
+        project = undefined;
+      }
+    });
+
+    async function startDetached(): Promise<{ port: number; tuiPane: string }> {
+      const { port, release } = await reservePort();
+      project = await createProject(serviceConfig(port));
+      await release();
+      const result = await runZaps(["up", "-d"], project.dir, project.runtimeDir);
+      expect(result.code).toBe(0);
+      expect(await serviceAnswers(port)).toBe(true);
+
+      const [tui] = await panes(project.sessionName);
+      // Held by `remain-on-exit`: the layout position survives the process.
+      expect(tui.dead).toBe(true);
+      return { port, tuiPane: tui.id };
+    }
+
+    it("revives the held TUI pane in place and keeps services running (F3)", async () => {
+      const { port, tuiPane } = await startDetached();
+      if (!project) {
+        throw new Error("no project");
+      }
+
+      const attach = await runZaps(["attach"], project.dir, project.runtimeDir);
+
+      const after = await panes(project.sessionName);
+      const tui = after.find((p) => p.id === tuiPane);
+      expect(tui).toBeDefined();
+      // Same pane id — revived in place, not recreated somewhere else.
+      expect(tui?.dead).toBe(false);
+      // The service pane is untouched by the revival.
+      expect(after.filter((p) => p.id !== tuiPane).every((p) => !p.dead)).toBe(true);
+      expect(await serviceAnswers(port)).toBe(true);
+      // F2 line, printed because the session outlived the (failed) client.
+      expect(attach.stdout).toContain("detached — services still running");
+    });
+
+    it("survives repeated detach/re-attach cycles", async () => {
+      const { port, tuiPane } = await startDetached();
+      if (!project) {
+        throw new Error("no project");
+      }
+
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        // eslint-disable-next-line no-await-in-loop -- cycles are sequential by nature
+        await runZaps(["attach"], project.dir, project.runtimeDir);
+        // eslint-disable-next-line no-await-in-loop
+        const livePanes = await panes(project.sessionName);
+        const revived = livePanes.find((p) => p.id === tuiPane);
+        expect(revived?.dead).toBe(false);
+
+        // A hard kill of the pane's process is the crash case, and behaves like
+        // A detach: `remain-on-exit` holds the pane dead at its position.
+        // eslint-disable-next-line no-await-in-loop
+        await managed(["send-keys", "-t", tuiPane, "C-c"]);
+        process.kill(revived?.pid ?? 0, "SIGKILL");
+        // eslint-disable-next-line no-await-in-loop
+        const held = await pollUntil(async () => {
+          const current = await panes(project?.sessionName ?? "");
+          return current.find((p) => p.id === tuiPane)?.dead === true;
+        }, 10_000);
+        expect(held).toBe(true);
+      }
+
+      expect(await serviceAnswers(port)).toBe(true);
+      expect(await managedSessionExists(project.sessionName)).toBe(true);
+    });
+
+    it("opens a new window when the TUI pane was killed outright", async () => {
+      const { port, tuiPane } = await startDetached();
+      if (!project) {
+        throw new Error("no project");
+      }
+
+      // The user killed the pane by hand — nothing left to revive.
+      await managed(["kill-pane", "-t", tuiPane]);
+
+      const attach = await runZaps(["attach"], project.dir, project.runtimeDir);
+      expect(attach.stderr).toContain("opening a new window instead");
+
+      const windows = await managed([
+        "list-windows",
+        "-t",
+        project.sessionName,
+        "-F",
+        "#{window_id}",
+      ]);
+      expect(windows.split("\n").length).toBeGreaterThanOrEqual(1);
+      expect(await serviceAnswers(port)).toBe(true);
+    });
+
+    it("routes the bare `zaps` smart default through the same re-attach path", async () => {
+      const { tuiPane } = await startDetached();
+      if (!project) {
+        throw new Error("no project");
+      }
+
+      await runZaps(["up"], project.dir, project.runtimeDir);
+
+      const after = await panes(project.sessionName);
+      expect(after.find((p) => p.id === tuiPane)?.dead).toBe(false);
+    });
+  },
+);

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -160,7 +160,7 @@ describe.skipIf(!hasTmux() || !hasBinary())(
           return frame.includes("web");
         }, 30_000);
         if (!painted) {
-          await dumpManagedState(session, project.runtimeDir);
+          await dumpManagedState(session, project.runtimeDir, tuiPane);
         }
         expect(painted).toBe(true);
         expect(await clients(session)).toEqual([]);
@@ -240,7 +240,7 @@ describe.skipIf(!hasTmux() || !hasBinary())(
             return frame.includes("web");
           }, 30_000);
           if (!qPainted) {
-            await dumpManagedState(session, project.runtimeDir);
+            await dumpManagedState(session, project.runtimeDir, tuiPane);
           }
           expect(qPainted).toBe(true);
           await managed(["send-keys", "-t", tuiPane, "q"]);

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -125,7 +125,7 @@ describe.skipIf(!hasTmux() || !hasBinary())(
       const windows = await managed([
         "list-windows",
         "-t",
-        project.sessionName,
+        `=${project.sessionName}`,
         "-F",
         "#{window_id}",
       ]);

--- a/test/integration/tmux/managed-detach-attach.test.ts
+++ b/test/integration/tmux/managed-detach-attach.test.ts
@@ -37,7 +37,7 @@ describe.skipIf(!hasTmux() || !hasBinary())(
       if (project) {
         await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
         try {
-          await managed(["kill-session", "-t", project.sessionName]);
+          await managed(["kill-session", "-t", `=${project.sessionName}`]);
         } catch {
           // Already gone.
         }

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -1,0 +1,298 @@
+import type { ChildProcess } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getEnv } from "#src/lib/env.js";
+
+import type { Project } from "../helpers/managed.js";
+import {
+  binaryPath,
+  clients,
+  createProject,
+  managed,
+  managedSessionExists,
+  pollUntil,
+  runZaps,
+  serviceAnswers,
+  serviceConfig,
+} from "../helpers/managed.js";
+import { reservePort } from "../helpers/port.js";
+import { hasBinary, hasScriptPty, hasTmux } from "../helpers/skip.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Started projects, torn down after each test whatever the test did to them. */
+const started: { project: Project; port: number }[] = [];
+
+async function startManaged(): Promise<{ project: Project; port: number }> {
+  const { port, release } = await reservePort();
+  const project = await createProject(serviceConfig(port));
+  await release();
+  const entry = { project, port };
+  started.push(entry);
+  const result = await runZaps(["up", "-d"], project.dir, project.runtimeDir);
+  expect(result.code).toBe(0);
+  expect(await serviceAnswers(port)).toBe(true);
+  return entry;
+}
+
+describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_000 }, () => {
+  afterEach(async () => {
+    for (const { project } of started) {
+      // eslint-disable-next-line no-await-in-loop -- teardown is sequential
+      await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await managed(["kill-session", "-t", project.sessionName]);
+      } catch {
+        // Already gone — which is the point of most of these tests.
+      }
+    }
+    started.length = 0;
+  });
+
+  it("kills the tmux session it owns and reports it (F5)", async () => {
+    const { project, port } = await startManaged();
+
+    const down = await runZaps(["down"], project.dir, project.runtimeDir);
+
+    expect(down.code).toBe(0);
+    expect(down.stdout).toContain("Session destroyed.");
+    expect(down.stdout).toContain(`Killed managed tmux session ${project.sessionName}.`);
+    expect(await managedSessionExists(project.sessionName)).toBe(false);
+    expect(await pollUntil(async () => !(await serviceAnswers(port)), 20_000)).toBe(true);
+  });
+
+  it("leaves a sibling managed project completely alone", async () => {
+    const first = await startManaged();
+    const second = await startManaged();
+
+    await runZaps(["down"], first.project.dir, first.project.runtimeDir);
+
+    expect(await managedSessionExists(first.project.sessionName)).toBe(false);
+    // Same socket, same tmux server: the sibling must not even notice.
+    expect(await managedSessionExists(second.project.sessionName)).toBe(true);
+    expect(await serviceAnswers(second.port)).toBe(true);
+
+    await runZaps(["down"], second.project.dir, second.project.runtimeDir);
+    expect(await managedSessionExists(second.project.sessionName)).toBe(false);
+  });
+
+  it("kills every managed session on `zaps daemon stop`", async () => {
+    // One daemon, two projects: the stop path destroys each session, and each
+    // Destroy takes its own tmux session with it.
+    const first = await startManaged();
+    const second = await createProject(
+      serviceConfig(
+        await reservePort().then(async (r) => {
+          await r.release();
+          return r.port;
+        }),
+      ),
+    );
+    started.push({ project: second, port: 0 });
+    await runZaps(["up", "-d"], second.dir, first.project.runtimeDir);
+
+    const stop = await runZaps(["daemon", "stop"], first.project.dir, first.project.runtimeDir);
+    expect(stop.code).toBe(0);
+
+    expect(await managedSessionExists(first.project.sessionName)).toBe(false);
+    expect(await managedSessionExists(second.sessionName)).toBe(false);
+  });
+
+  // Guards the P03-T01 detach hint: teardown must NOT look like a detach. The
+  // Daemon kills the tmux session as part of `session.destroy`, so by the time
+  // The attached client dies there is no session left for the hint's probe to
+  // Find — this pins that ordering instead of trusting it.
+  it.skipIf(!hasScriptPty())(
+    "says nothing about detaching when the session is torn down under an attached client",
+    async () => {
+      const { project } = await startManaged();
+      const transcript = path.join(project.dir, "outer.log");
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        XDG_RUNTIME_DIR: project.runtimeDir,
+        ZAPS_COMMAND: binaryPath,
+      };
+      delete env.TMUX;
+      delete env.TMUX_PANE;
+      delete env.ZAPS_TMUX_SOCKET;
+
+      // A real outer `zaps attach` over a pty: it revives the pane, attaches,
+      // And is the process that would print the detach hint on its way out.
+      const outer: ChildProcess = spawn("script", ["-qec", `${binaryPath} attach`, transcript], {
+        cwd: project.dir,
+        env,
+        stdio: "ignore",
+      });
+      const exited = new Promise<void>((resolve) => outer.on("close", () => resolve()));
+      try {
+        const attached = await pollUntil(async () => {
+          const live = await clients(project.sessionName);
+          return live.length > 0;
+        }, 30_000);
+        expect(attached).toBe(true);
+
+        const down = await runZaps(["down"], project.dir, project.runtimeDir);
+        expect(down.stdout).toContain(`Killed managed tmux session ${project.sessionName}.`);
+
+        await exited;
+        const printed = fs.readFileSync(transcript, "utf8");
+        expect(printed).not.toContain("detached — services still running");
+        expect(await managedSessionExists(project.sessionName)).toBe(false);
+      } finally {
+        outer.kill("SIGKILL");
+      }
+    },
+  );
+
+  it.skipIf(!hasScriptPty())(
+    "tears down the same way on Ctrl-D from inside the TUI, hint-free",
+    async () => {
+      const { project, port } = await startManaged();
+      const transcript = path.join(project.dir, "outer-ctrl-d.log");
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        XDG_RUNTIME_DIR: project.runtimeDir,
+        ZAPS_COMMAND: binaryPath,
+      };
+      delete env.TMUX;
+      delete env.TMUX_PANE;
+      delete env.ZAPS_TMUX_SOCKET;
+
+      const outer: ChildProcess = spawn("script", ["-qec", `${binaryPath} attach`, transcript], {
+        cwd: project.dir,
+        env,
+        stdio: "ignore",
+      });
+      const exited = new Promise<void>((resolve) => outer.on("close", () => resolve()));
+      try {
+        expect(
+          await pollUntil(async () => {
+            const live = await clients(project.sessionName);
+            return live.length > 0;
+          }, 30_000),
+        ).toBe(true);
+        // Ink only reads keys once mounted — wait for the dashboard to paint.
+        const tui = await managed([
+          "list-panes",
+          "-t",
+          project.sessionName,
+          "-F",
+          "#{pane_id}",
+        ]).then((out) => out.split("\n")[0]);
+        expect(
+          await pollUntil(async () => {
+            const frame = await managed(["capture-pane", "-t", tui, "-p"]);
+            return frame.includes("web");
+          }, 30_000),
+        ).toBe(true);
+
+        await managed(["send-keys", "-t", tui, "C-d"]);
+
+        await exited;
+        const printed = fs.readFileSync(transcript, "utf8");
+        expect(printed).not.toContain("detached — services still running");
+        expect(await managedSessionExists(project.sessionName)).toBe(false);
+        expect(await pollUntil(async () => !(await serviceAnswers(port)), 20_000)).toBe(true);
+      } finally {
+        outer.kill("SIGKILL");
+      }
+    },
+  );
+
+  it("shows the tmux location in `zaps ls`", async () => {
+    const { project } = await startManaged();
+
+    const text = await runZaps(["ls"], project.dir, project.runtimeDir);
+    expect(text.stdout).toContain(`${project.sessionName} (managed)`);
+
+    const json = await runZaps(["ls", "--json"], project.dir, project.runtimeDir);
+    const sessions = JSON.parse(json.stdout) as { managed: boolean; tmuxSession: string }[];
+    expect(sessions[0]).toMatchObject({ managed: true, tmuxSession: project.sessionName });
+  });
+
+  it("refuses to drive a managed session from inside another tmux (F7)", async () => {
+    const { project } = await startManaged();
+
+    // Simulate the user's own tmux: `$TMUX` set, and a different server, which
+    // Is exactly the situation where pane ops would hit the wrong tmux.
+    const foreignSocket = getEnv("ZAPS_TMUX_SOCKET") ?? "zaps-test";
+    const inside = { TMUX: `/tmp/tmux-1000/${foreignSocket},1,0` };
+    const result = await runZaps(["up"], project.dir, project.runtimeDir, inside);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("is running in a zaps-managed tmux");
+    // The copy-pasteable escape hatch (Q5).
+    expect(result.stderr).toContain(`tmux -L zaps attach -t ${project.sessionName}`);
+
+    const attach = await runZaps(["attach"], project.dir, project.runtimeDir, inside);
+    expect(attach.code).toBe(1);
+    expect(attach.stderr).toContain(`tmux -L zaps attach -t ${project.sessionName}`);
+  });
+
+  it("refuses a session hosted in the user's own tmux from a plain terminal (F6)", async () => {
+    const { port, release } = await reservePort();
+    const project = await createProject(serviceConfig(port));
+    await release();
+    started.push({ project, port });
+
+    // A session created the pre-auto-tmux way: inside a personal tmux server.
+    const personalSocket = getEnv("ZAPS_TMUX_SOCKET") ?? "zaps-test";
+    const personalSession = `personal-${project.sessionName.slice(-8)}`;
+    // The command IS the pane's process: `send-keys` right after `new-session`
+    // Races the shell's startup and silently goes nowhere.
+    // `ZAPS_TMUX_SOCKET` is what makes this a session hosted on the personal
+    // Server — exactly what the pre-auto-tmux flow does via the inherited env.
+    const bootCommand = `cd ${project.dir} && XDG_RUNTIME_DIR=${project.runtimeDir} ZAPS_COMMAND=${binaryPath} ZAPS_TMUX_SOCKET=${personalSocket} ${binaryPath} up -d; exec sh`;
+    await execFileAsync("tmux", [
+      "-L",
+      personalSocket,
+      "new-session",
+      "-d",
+      "-s",
+      personalSession,
+      "-x",
+      "200",
+      "-y",
+      "50",
+      "--",
+      "sh",
+      "-c",
+      bootCommand,
+    ]);
+    try {
+      // F6 only needs the daemon to KNOW the session; waiting for the
+      // Service to be ready would test the pre-existing in-tmux flow instead.
+      const registered = await pollUntil(async () => {
+        const listed = await runZaps(["ls", "--json"], project.dir, project.runtimeDir);
+        const sessions = JSON.parse(listed.stdout || "[]") as { managed: boolean }[];
+        return sessions.length > 0;
+      }, 90_000);
+      expect(registered).toBe(true);
+
+      const result = await runZaps(["up"], project.dir, project.runtimeDir);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain(
+        `is running inside tmux session '${personalSession}'. Attach from within tmux, or run zaps down first.`,
+      );
+      // Nothing was spawned on the managed socket for it.
+      expect(await managedSessionExists(project.sessionName)).toBe(false);
+    } finally {
+      await execFileAsync("tmux", [
+        "-L",
+        personalSocket,
+        "kill-session",
+        "-t",
+        personalSession,
+      ]).then(
+        () => undefined,
+        () => undefined,
+      );
+    }
+  });
+});

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -13,6 +13,7 @@ import {
   binaryPath,
   clients,
   createProject,
+  dumpManagedState,
   managed,
   managedSessionExists,
   pollUntil,
@@ -185,12 +186,14 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
           "-F",
           "#{pane_id}",
         ]).then((out) => out.split("\n")[0]);
-        expect(
-          await pollUntil(async () => {
-            const frame = await managed(["capture-pane", "-t", tui, "-p"]);
-            return frame.includes("web");
-          }, 30_000),
-        ).toBe(true);
+        const painted = await pollUntil(async () => {
+          const frame = await managed(["capture-pane", "-t", tui, "-p"]);
+          return frame.includes("web");
+        }, 30_000);
+        if (!painted) {
+          await dumpManagedState(project.sessionName, project.runtimeDir);
+        }
+        expect(painted).toBe(true);
 
         // Ctrl-D asks first — a single stray byte must never tear a session down.
         await managed(["send-keys", "-t", tui, "C-d"]);

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -192,7 +192,15 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
           }, 30_000),
         ).toBe(true);
 
+        // Ctrl-D asks first — a single stray byte must never tear a session down.
         await managed(["send-keys", "-t", tui, "C-d"]);
+        expect(
+          await pollUntil(async () => {
+            const frame = await managed(["capture-pane", "-t", tui, "-p"]);
+            return frame.includes("Shut down session?");
+          }, 15_000),
+        ).toBe(true);
+        await managed(["send-keys", "-t", tui, "y"]);
 
         await exited;
         const printed = fs.readFileSync(transcript, "utf8");

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -191,7 +191,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
           return frame.includes("web");
         }, 30_000);
         if (!painted) {
-          await dumpManagedState(project.sessionName, project.runtimeDir);
+          await dumpManagedState(project.sessionName, project.runtimeDir, tui);
         }
         expect(painted).toBe(true);
 

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -47,7 +47,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
       await runZaps(["daemon", "stop"], project.dir, project.runtimeDir);
       try {
         // eslint-disable-next-line no-await-in-loop
-        await managed(["kill-session", "-t", project.sessionName]);
+        await managed(["kill-session", "-t", `=${project.sessionName}`]);
       } catch {
         // Already gone — which is the point of most of these tests.
       }
@@ -205,6 +205,30 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
     },
   );
 
+  // The safety invariant behind every managed kill: tmux resolves session
+  // Targets exact → prefix → fnmatch, so without `=` a teardown or stale-reap
+  // Aimed at an already-gone session silently hits a longer-named neighbour —
+  // E.g. a user's own `zaps-<project>-<id>-notes` window on the same server.
+  it("never touches a session whose name merely starts with the target", async () => {
+    const { project } = await startManaged();
+    const neighbour = `${project.sessionName}-notes`;
+    await managed(["new-session", "-d", "-s", neighbour, "--", "sleep", "600"]);
+
+    try {
+      await runZaps(["down"], project.dir, project.runtimeDir);
+      expect(await managedSessionExists(project.sessionName)).toBe(false);
+      // The neighbour is still there — and the short name must not "exist"
+      // Just because the neighbour does.
+      expect(await managedSessionExists(neighbour)).toBe(true);
+
+      // A second teardown of the (now gone) short name must be a no-op too.
+      await runZaps(["down"], project.dir, project.runtimeDir);
+      expect(await managedSessionExists(neighbour)).toBe(true);
+    } finally {
+      await managed(["kill-session", "-t", `=${neighbour}`]).catch(() => undefined);
+    }
+  });
+
   it("shows the tmux location in `zaps ls`", async () => {
     const { project } = await startManaged();
 
@@ -228,11 +252,11 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("is running in a zaps-managed tmux");
     // The copy-pasteable escape hatch (Q5).
-    expect(result.stderr).toContain(`tmux -L zaps attach -t ${project.sessionName}`);
+    expect(result.stderr).toContain(`tmux -L zaps attach -t =${project.sessionName}`);
 
     const attach = await runZaps(["attach"], project.dir, project.runtimeDir, inside);
     expect(attach.code).toBe(1);
-    expect(attach.stderr).toContain(`tmux -L zaps attach -t ${project.sessionName}`);
+    expect(attach.stderr).toContain(`tmux -L zaps attach -t =${project.sessionName}`);
   });
 
   it("refuses a session hosted in the user's own tmux from a plain terminal (F6)", async () => {
@@ -288,7 +312,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
         personalSocket,
         "kill-session",
         "-t",
-        personalSession,
+        `=${personalSession}`,
       ]).then(
         () => undefined,
         () => undefined,

--- a/test/integration/tmux/managed-teardown.test.ts
+++ b/test/integration/tmux/managed-teardown.test.ts
@@ -181,7 +181,7 @@ describe.skipIf(!hasTmux() || !hasBinary())("managed teardown", { timeout: 180_0
         const tui = await managed([
           "list-panes",
           "-t",
-          project.sessionName,
+          `=${project.sessionName}`,
           "-F",
           "#{pane_id}",
         ]).then((out) => out.split("\n")[0]);

--- a/test/integration/tmux/pane-env.test.ts
+++ b/test/integration/tmux/pane-env.test.ts
@@ -2,11 +2,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { ServiceConfig } from "#src/config/types.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
-import { removeEnv, setEnv, showEnv } from "#src/lib/tmux.js";
+import { removeEnv, setEnv, showEnv, tmuxFor } from "#src/lib/tmux.js";
 
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { createTestSession } from "../helpers/tmux.js";
+import { createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 
 describe.skipIf(!hasTmux())("tmux pane-env integration", () => {
   let session: TestSession;
@@ -45,7 +45,9 @@ describe.skipIf(!hasTmux())("tmux pane-env integration", () => {
       worker: { start: "echo worker" },
     };
 
-    const { paneMap } = await createLayout(session.initialPaneId, undefined, services);
+    const { paneMap } = await createLayout(session.initialPaneId, undefined, services, undefined, {
+      tmux: tmuxFor(testTmuxSocket()),
+    });
 
     // Serialize and store like cli.tsx does
     const serialized = JSON.stringify(paneMap);

--- a/test/integration/tmux/window-title.test.ts
+++ b/test/integration/tmux/window-title.test.ts
@@ -4,6 +4,7 @@ import { detectPorts, getDescendantPids } from "#src/lib/port.js";
 import { ServiceManager } from "#src/lib/service/manager.js";
 import {
   capturePane,
+  displayPopup,
   getWindowName,
   getWindowOption,
   panePid,
@@ -33,6 +34,7 @@ const deps = {
   getWindowName,
   getWindowOption,
   setWindowOption,
+  displayPopup,
   exec: async () => {
     /* No-op */
   },

--- a/test/integration/tmux/window-title.test.ts
+++ b/test/integration/tmux/window-title.test.ts
@@ -11,6 +11,7 @@ import {
   sendCtrlC,
   sendKeys,
   setWindowOption,
+  tmuxFor,
 } from "#src/lib/tmux.js";
 
 import { makeConfig } from "../helpers/config.js";
@@ -18,14 +19,14 @@ import { httpServerCmd } from "../helpers/fixtures.js";
 import { getFreePort } from "../helpers/port.js";
 import { hasTmux } from "../helpers/skip.js";
 import type { TestSession } from "../helpers/tmux.js";
-import { buildTestPaneMap, createTestSession } from "../helpers/tmux.js";
+import { buildTestPaneMap, createTestSession, testTmuxSocket } from "../helpers/tmux.js";
 import { waitFor } from "../helpers/wait.js";
 
 const deps = {
   sendKeys,
   sendCtrlC,
   panePid,
-  detectPorts,
+  detectPorts: async (paneTarget: string) => detectPorts(paneTarget, tmuxFor(testTmuxSocket())),
   capturePane,
   getDescendantPids,
   renameWindow,

--- a/test/integration/vitest.config.ts
+++ b/test/integration/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     hookTimeout: 30_000,
     pool: "forks",
     fileParallelism: false,
+    // Fallback only — `setup-tmux-socket.ts` overrides this with a per-file
+    // Socket. Kept so a stray tmux call can never hit the user's default server.
     env: { ZAPS_TMUX_SOCKET: "zaps-test" },
+    setupFiles: ["./test/integration/setup-tmux-socket.ts"],
     globalSetup: "./test/integration/global-setup.ts",
     coverage: {
       provider: "v8",

--- a/test/lib/managed-detach.test.ts
+++ b/test/lib/managed-detach.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { detachManagedClient } from "../../src/lib/managed-detach.js";
+
+describe("detachManagedClient", () => {
+  it("detaches the client attached to this pane in managed mode", async () => {
+    const detach = vi.fn().mockResolvedValue(undefined);
+    await expect(detachManagedClient({ managedEnv: "1", paneTarget: "%7", detach })).resolves.toBe(
+      true,
+    );
+    // Targeting the PANE, not the session: only this client goes away.
+    expect(detach).toHaveBeenCalledWith("%7");
+  });
+
+  it("does nothing in a personal tmux session", async () => {
+    const detach = vi.fn();
+    await expect(
+      detachManagedClient({ managedEnv: undefined, paneTarget: "%7", detach }),
+    ).resolves.toBe(false);
+    expect(detach).not.toHaveBeenCalled();
+  });
+
+  it("only honors an exact ZAPS_MANAGED_TMUX=1", async () => {
+    const detach = vi.fn();
+    await expect(detachManagedClient({ managedEnv: "0", paneTarget: "%7", detach })).resolves.toBe(
+      false,
+    );
+    expect(detach).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a pane to target", async () => {
+    const detach = vi.fn();
+    await expect(
+      detachManagedClient({ managedEnv: "1", paneTarget: undefined, detach }),
+    ).resolves.toBe(false);
+    expect(detach).not.toHaveBeenCalled();
+  });
+
+  it("never lets a tmux failure block quitting", async () => {
+    const detach = vi.fn().mockRejectedValue(new Error("no client found"));
+    await expect(detachManagedClient({ managedEnv: "1", paneTarget: "%7", detach })).resolves.toBe(
+      false,
+    );
+  });
+});

--- a/test/lib/managed-detach.test.ts
+++ b/test/lib/managed-detach.test.ts
@@ -5,41 +5,42 @@ import { detachManagedClient } from "../../src/lib/managed-detach.js";
 describe("detachManagedClient", () => {
   it("detaches the client attached to this pane in managed mode", async () => {
     const detach = vi.fn().mockResolvedValue(undefined);
-    await expect(detachManagedClient({ managedEnv: "1", paneTarget: "%7", detach })).resolves.toBe(
-      true,
-    );
-    // Targeting the PANE, not the session: only this client goes away.
-    expect(detach).toHaveBeenCalledWith("%7");
+    await expect(
+      detachManagedClient({ managedEnv: "1", tmuxEnv: "/tmp/tmux-1000/zaps,42,0", detach }),
+    ).resolves.toBe(true);
+    // No target: `-t` on detach-client means a client TTY, never a pane, so the
+    // Current client is resolved from `$TMUX` instead.
+    expect(detach).toHaveBeenCalledWith();
   });
 
   it("does nothing in a personal tmux session", async () => {
     const detach = vi.fn();
     await expect(
-      detachManagedClient({ managedEnv: undefined, paneTarget: "%7", detach }),
+      detachManagedClient({ managedEnv: undefined, tmuxEnv: "/tmp/tmux-1000/zaps,42,0", detach }),
     ).resolves.toBe(false);
     expect(detach).not.toHaveBeenCalled();
   });
 
   it("only honors an exact ZAPS_MANAGED_TMUX=1", async () => {
     const detach = vi.fn();
-    await expect(detachManagedClient({ managedEnv: "0", paneTarget: "%7", detach })).resolves.toBe(
-      false,
-    );
+    await expect(
+      detachManagedClient({ managedEnv: "0", tmuxEnv: "/tmp/tmux-1000/zaps,42,0", detach }),
+    ).resolves.toBe(false);
     expect(detach).not.toHaveBeenCalled();
   });
 
-  it("does nothing without a pane to target", async () => {
+  it("does nothing outside tmux (no client to resolve)", async () => {
     const detach = vi.fn();
     await expect(
-      detachManagedClient({ managedEnv: "1", paneTarget: undefined, detach }),
+      detachManagedClient({ managedEnv: "1", tmuxEnv: undefined, detach }),
     ).resolves.toBe(false);
     expect(detach).not.toHaveBeenCalled();
   });
 
   it("never lets a tmux failure block quitting", async () => {
     const detach = vi.fn().mockRejectedValue(new Error("no client found"));
-    await expect(detachManagedClient({ managedEnv: "1", paneTarget: "%7", detach })).resolves.toBe(
-      false,
-    );
+    await expect(
+      detachManagedClient({ managedEnv: "1", tmuxEnv: "/tmp/tmux-1000/zaps,42,0", detach }),
+    ).resolves.toBe(false);
   });
 });

--- a/test/lib/managed-tmux.test.ts
+++ b/test/lib/managed-tmux.test.ts
@@ -327,6 +327,17 @@ describe("waitForPaneSettled", () => {
     });
   });
 
+  it("rides out the tmux 3.5a race where pane_dead flips before the status lands", async () => {
+    const displayMessage = vi
+      .fn()
+      .mockResolvedValueOnce("1||")
+      .mockResolvedValueOnce("1||")
+      .mockResolvedValue("1|3|");
+    await expect(
+      waitForPaneSettled("%0", { tmux: fakeTmux({ displayMessage }), pollMs: 1 }),
+    ).resolves.toEqual({ settled: true, exitCode: 3 });
+  });
+
   it("never reports success when a dead pane has no readable status", async () => {
     const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1||") });
     await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({

--- a/test/lib/managed-tmux.test.ts
+++ b/test/lib/managed-tmux.test.ts
@@ -4,6 +4,7 @@ import {
   MANAGED_SOCKET,
   buildAttachArgs,
   buildCreateArgs,
+  buildNewWindowArgs,
   buildRespawnArgs,
   buildSetPaneOptionArgs,
   buildSetSessionOptionArgs,
@@ -188,6 +189,19 @@ describe("argv builders", () => {
     ]);
   });
 
+  it("builds the new-window fallback for a vanished TUI pane", () => {
+    expect(buildNewWindowArgs("zaps-app-abc123", ["zaps", "attach"])).toEqual([
+      "-L",
+      "zaps",
+      "new-window",
+      "-t",
+      "zaps-app-abc123",
+      "--",
+      "zaps",
+      "attach",
+    ]);
+  });
+
   it("builds the session + pane option invocations", () => {
     expect(buildSetSessionOptionArgs("zaps-app-abc123", "destroy-unattached", "off")).toEqual([
       "-L",
@@ -216,6 +230,7 @@ describe("argv builders", () => {
       buildCreateArgs({ name: "n", zapsArgv: ["zaps"] }),
       buildAttachArgs("n"),
       buildRespawnArgs("%0", ["zaps"]),
+      buildNewWindowArgs("n", ["zaps"]),
       buildSetSessionOptionArgs("n", "o", "v"),
       buildSetPaneOptionArgs("%0", "o", "v"),
     ]) {

--- a/test/lib/managed-tmux.test.ts
+++ b/test/lib/managed-tmux.test.ts
@@ -21,7 +21,7 @@ function fakeTmux(overrides: Partial<Parameters<typeof hasManagedSession>[1]> = 
     hasSession: vi.fn().mockResolvedValue(false),
     killSession: vi.fn().mockResolvedValue(undefined),
     tmuxVersion: vi.fn().mockResolvedValue({ major: 3, minor: 5 }),
-    displayMessage: vi.fn().mockResolvedValue("0 "),
+    displayMessage: vi.fn().mockResolvedValue("0||"),
     ...overrides,
   };
 }
@@ -124,6 +124,33 @@ describe("argv builders", () => {
     expect(args.some((arg) => arg.includes("zaps up"))).toBe(false);
   });
 
+  it("starts the plain shell when no zaps argv is given", () => {
+    // The detached path creates the session bare, sets `remain-on-exit`, and
+    // Only then respawns the pane with zaps — so no `--` and no command here.
+    const args = buildCreateArgs({ name: "zaps-app-abc123", detach: true });
+    expect(args).not.toContain("--");
+    expect(args.at(-1)).toBe("ZAPS_MANAGED_TMUX=1");
+  });
+
+  it("passes an initial size so panes are laid out at terminal size", () => {
+    const args = buildCreateArgs({ name: "n", detach: true, width: 203, height: 51 });
+    expect(args.slice(0, 8)).toEqual(["-L", "zaps", "new-session", "-d", "-x", "203", "-y", "51"]);
+  });
+
+  it("omits the size unless both dimensions are known", () => {
+    expect(buildCreateArgs({ name: "n", width: 100 })).not.toContain("-x");
+    expect(buildCreateArgs({ name: "n", height: 40 })).not.toContain("-y");
+  });
+
+  it("forwards extra session env after the markers", () => {
+    const args = buildCreateArgs({
+      name: "n",
+      zapsArgv: ["zaps", "up"],
+      env: { XDG_RUNTIME_DIR: "/run/user/1000" },
+    });
+    expect(args.join(" ")).toContain("-e ZAPS_MANAGED_TMUX=1 -e XDG_RUNTIME_DIR=/run/user/1000 --");
+  });
+
   it("builds the attach invocation", () => {
     expect(buildAttachArgs("zaps-app-abc123")).toEqual([
       "-L",
@@ -131,6 +158,20 @@ describe("argv builders", () => {
       "attach-session",
       "-t",
       "zaps-app-abc123",
+    ]);
+  });
+
+  it("kills a live pane when asked (tmux refuses to respawn one otherwise)", () => {
+    expect(buildRespawnArgs("%7", ["zaps", "up"], { kill: true })).toEqual([
+      "-L",
+      "zaps",
+      "respawn-pane",
+      "-k",
+      "-t",
+      "%7",
+      "--",
+      "zaps",
+      "up",
     ]);
   });
 
@@ -235,42 +276,62 @@ describe("tmuxAvailable", () => {
 
 describe("waitForPaneSettled", () => {
   it("returns the inner exit code once the pane is dead", async () => {
-    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1 42") });
+    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1|42|") });
     await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
       settled: true,
       exitCode: 42,
     });
-    expect(tmux.displayMessage).toHaveBeenCalledWith("%0", "#{pane_dead} #{pane_dead_status}");
+    expect(tmux.displayMessage).toHaveBeenCalledWith(
+      "%0",
+      "#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}",
+    );
   });
 
   it("polls until the pane dies rather than sleeping a fixed time", async () => {
     const displayMessage = vi
       .fn()
-      .mockResolvedValueOnce("0 ")
-      .mockResolvedValueOnce("0 ")
-      .mockResolvedValue("1 0");
+      .mockResolvedValueOnce("0||")
+      .mockResolvedValueOnce("0||")
+      .mockResolvedValue("1|0|");
     await expect(
       waitForPaneSettled("%0", { tmux: fakeTmux({ displayMessage }), pollMs: 1 }),
     ).resolves.toEqual({ settled: true, exitCode: 0 });
     expect(displayMessage).toHaveBeenCalledTimes(3);
   });
 
-  it("treats a dead pane with no readable status as exit 0", async () => {
-    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1 ") });
+  it("maps a signal death to 128 + signal instead of success", async () => {
+    // SIGKILLed inner zaps: no exit status, only a signal.
+    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1||9") });
     await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
       settled: true,
-      exitCode: 0,
+      exitCode: 137,
     });
   });
 
-  it("reports 'gone' when the pane or its session disappeared", async () => {
-    const tmux = fakeTmux({
-      displayMessage: vi.fn().mockRejectedValue(new Error("can't find pane")),
-    });
+  it("never reports success when a dead pane has no readable status", async () => {
+    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1||") });
     await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
       settled: false,
-      reason: "gone",
+      reason: "unknown-status",
     });
+  });
+
+  it("rides out a transient probe failure", async () => {
+    const displayMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("tmux hiccup"))
+      .mockResolvedValue("1|7|");
+    await expect(
+      waitForPaneSettled("%0", { tmux: fakeTmux({ displayMessage }), pollMs: 1 }),
+    ).resolves.toEqual({ settled: true, exitCode: 7 });
+  });
+
+  it("reports 'gone' only after consecutive probe failures", async () => {
+    const displayMessage = vi.fn().mockRejectedValue(new Error("can't find pane"));
+    await expect(
+      waitForPaneSettled("%0", { tmux: fakeTmux({ displayMessage }), pollMs: 1 }),
+    ).resolves.toEqual({ settled: false, reason: "gone" });
+    expect(displayMessage).toHaveBeenCalledTimes(3);
   });
 
   it("gives up at the deadline while the pane is still alive", async () => {

--- a/test/lib/managed-tmux.test.ts
+++ b/test/lib/managed-tmux.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MANAGED_SOCKET,
+  buildAttachArgs,
+  buildCreateArgs,
+  buildRespawnArgs,
+  buildSetPaneOptionArgs,
+  buildSetSessionOptionArgs,
+  hasManagedSession,
+  killStaleSession,
+  managedSessionName,
+  sanitizeProjectName,
+  tmuxAvailable,
+  waitForPaneSettled,
+} from "../../src/lib/managed-tmux.js";
+
+/** Minimal stand-in for the managed-socket handle; every probe takes one. */
+function fakeTmux(overrides: Partial<Parameters<typeof hasManagedSession>[1]> = {}) {
+  return {
+    hasSession: vi.fn().mockResolvedValue(false),
+    killSession: vi.fn().mockResolvedValue(undefined),
+    tmuxVersion: vi.fn().mockResolvedValue({ major: 3, minor: 5 }),
+    displayMessage: vi.fn().mockResolvedValue("0 "),
+    ...overrides,
+  };
+}
+
+describe("sanitizeProjectName", () => {
+  it.each([
+    ["my-app", "my-app"],
+    ["My App", "my-app"],
+    ["app.v2", "app-v2"],
+    ["host:1234", "host-1234"],
+    ["Bücher", "b-cher"],
+    [String.raw`a//b\c`, "a-b-c"],
+    ["snake_case-2", "snake_case-2"],
+  ])("sanitizes %j to %j", (input, expected) => {
+    expect(sanitizeProjectName(input)).toBe(expected);
+  });
+
+  it("never emits a character tmux rejects in a session name", () => {
+    const sanitized = sanitizeProjectName("weird.name:with/slashes and spaces");
+    expect(sanitized).not.toMatch(/[.:]/u);
+    expect(sanitized).toMatch(/^[a-z0-9_-]+$/u);
+  });
+
+  it("collapses runs and trims leading/trailing separators", () => {
+    expect(sanitizeProjectName("  ...weird---name...  ")).toBe("weird-name");
+  });
+
+  it("truncates to 30 chars without leaving a trailing separator", () => {
+    const sanitized = sanitizeProjectName(`${"a".repeat(30)} tail`);
+    expect(sanitized).toHaveLength(30);
+    expect(sanitized.endsWith("-")).toBe(false);
+  });
+
+  it("falls back to 'project' when nothing survives", () => {
+    expect(sanitizeProjectName("....")).toBe("project");
+    expect(sanitizeProjectName("")).toBe("project");
+  });
+});
+
+describe("managedSessionName", () => {
+  it("builds zaps-<sanitized>-<sessionId>", () => {
+    expect(managedSessionName("My App", "a1b2c3d4e5f6")).toBe("zaps-my-app-a1b2c3d4e5f6");
+  });
+
+  it("is deterministic for the same inputs", () => {
+    expect(managedSessionName("app", "abc123abc123")).toBe(
+      managedSessionName("app", "abc123abc123"),
+    );
+  });
+
+  it("separates projects that share a display name via the session id", () => {
+    expect(managedSessionName("app", "aaaaaaaaaaaa")).not.toBe(
+      managedSessionName("app", "bbbbbbbbbbbb"),
+    );
+  });
+
+  it("stays a valid tmux session name for hostile input", () => {
+    expect(managedSessionName("v1.2:beta build", "abc123abc123")).toBe(
+      "zaps-v1-2-beta-build-abc123abc123",
+    );
+  });
+});
+
+describe("argv builders", () => {
+  it("builds the create invocation from 50_api", () => {
+    expect(buildCreateArgs({ name: "zaps-app-abc123", zapsArgv: ["/usr/bin/zaps", "up"] })).toEqual(
+      [
+        "-L",
+        "zaps",
+        "new-session",
+        "-s",
+        "zaps-app-abc123",
+        "-e",
+        "ZAPS_TMUX_SOCKET=zaps",
+        "-e",
+        "ZAPS_MANAGED_TMUX=1",
+        "--",
+        "/usr/bin/zaps",
+        "up",
+      ],
+    );
+  });
+
+  it("inserts -d before -s for the detached create path", () => {
+    const args = buildCreateArgs({
+      name: "zaps-app-abc123",
+      detach: true,
+      zapsArgv: ["zaps", "up", "-d"],
+    });
+    expect(args.slice(0, 6)).toEqual(["-L", "zaps", "new-session", "-d", "-s", "zaps-app-abc123"]);
+    expect(args.slice(-4)).toEqual(["--", "zaps", "up", "-d"]);
+  });
+
+  it("passes the zaps argv as separate elements, never a joined string", () => {
+    const args = buildCreateArgs({
+      name: "n",
+      zapsArgv: ["/path with spaces/zaps", "up"],
+    });
+    expect(args).toContain("/path with spaces/zaps");
+    expect(args.some((arg) => arg.includes("zaps up"))).toBe(false);
+  });
+
+  it("builds the attach invocation", () => {
+    expect(buildAttachArgs("zaps-app-abc123")).toEqual([
+      "-L",
+      "zaps",
+      "attach-session",
+      "-t",
+      "zaps-app-abc123",
+    ]);
+  });
+
+  it("builds respawn in argv form targeting a pane id", () => {
+    expect(buildRespawnArgs("%7", ["zaps", "attach"])).toEqual([
+      "-L",
+      "zaps",
+      "respawn-pane",
+      "-t",
+      "%7",
+      "--",
+      "zaps",
+      "attach",
+    ]);
+  });
+
+  it("builds the session + pane option invocations", () => {
+    expect(buildSetSessionOptionArgs("zaps-app-abc123", "destroy-unattached", "off")).toEqual([
+      "-L",
+      "zaps",
+      "set-option",
+      "-t",
+      "zaps-app-abc123",
+      "destroy-unattached",
+      "off",
+    ]);
+    // `-p` makes it pane-level so it beats any global user setting.
+    expect(buildSetPaneOptionArgs("%0", "remain-on-exit", "on")).toEqual([
+      "-L",
+      "zaps",
+      "set-option",
+      "-p",
+      "-t",
+      "%0",
+      "remain-on-exit",
+      "on",
+    ]);
+  });
+
+  it("targets the managed socket in every builder", () => {
+    for (const args of [
+      buildCreateArgs({ name: "n", zapsArgv: ["zaps"] }),
+      buildAttachArgs("n"),
+      buildRespawnArgs("%0", ["zaps"]),
+      buildSetSessionOptionArgs("n", "o", "v"),
+      buildSetPaneOptionArgs("%0", "o", "v"),
+    ]) {
+      expect(args.slice(0, 2)).toEqual(["-L", MANAGED_SOCKET]);
+    }
+  });
+});
+
+describe("hasManagedSession", () => {
+  it("reports what the managed server says", async () => {
+    const tmux = fakeTmux({ hasSession: vi.fn().mockResolvedValue(true) });
+    await expect(hasManagedSession("zaps-app-abc123", tmux)).resolves.toBe(true);
+    expect(tmux.hasSession).toHaveBeenCalledWith("zaps-app-abc123");
+  });
+});
+
+describe("killStaleSession", () => {
+  it("kills the named session and reports it", async () => {
+    const tmux = fakeTmux();
+    await expect(killStaleSession("zaps-app-abc123", tmux)).resolves.toBe(true);
+    expect(tmux.killSession).toHaveBeenCalledWith("zaps-app-abc123");
+  });
+
+  it("treats an already-gone session as a no-op, not an error", async () => {
+    const tmux = fakeTmux({
+      killSession: vi.fn().mockRejectedValue(new Error("session not found")),
+    });
+    await expect(killStaleSession("zaps-app-abc123", tmux)).resolves.toBe(false);
+  });
+});
+
+describe("tmuxAvailable", () => {
+  it("accepts the minimum supported version", async () => {
+    await expect(tmuxAvailable(fakeTmux())).resolves.toEqual({ ok: true, version: "3.5" });
+  });
+
+  it("accepts newer majors and minors", async () => {
+    const newer = fakeTmux({ tmuxVersion: vi.fn().mockResolvedValue({ major: 4, minor: 0 }) });
+    await expect(tmuxAvailable(newer)).resolves.toEqual({ ok: true, version: "4.0" });
+  });
+
+  it("reports 'missing' when tmux is absent or unparsable", async () => {
+    const absent = fakeTmux({ tmuxVersion: vi.fn().mockResolvedValue(null) });
+    await expect(tmuxAvailable(absent)).resolves.toEqual({ ok: false, reason: "missing" });
+  });
+
+  it("reports 'too-old' with the version for the F8 message", async () => {
+    const old = fakeTmux({ tmuxVersion: vi.fn().mockResolvedValue({ major: 3, minor: 2 }) });
+    await expect(tmuxAvailable(old)).resolves.toEqual({
+      ok: false,
+      reason: "too-old",
+      version: "3.2",
+    });
+    const olderMajor = fakeTmux({ tmuxVersion: vi.fn().mockResolvedValue({ major: 2, minor: 9 }) });
+    await expect(tmuxAvailable(olderMajor)).resolves.toMatchObject({ reason: "too-old" });
+  });
+});
+
+describe("waitForPaneSettled", () => {
+  it("returns the inner exit code once the pane is dead", async () => {
+    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1 42") });
+    await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
+      settled: true,
+      exitCode: 42,
+    });
+    expect(tmux.displayMessage).toHaveBeenCalledWith("%0", "#{pane_dead} #{pane_dead_status}");
+  });
+
+  it("polls until the pane dies rather than sleeping a fixed time", async () => {
+    const displayMessage = vi
+      .fn()
+      .mockResolvedValueOnce("0 ")
+      .mockResolvedValueOnce("0 ")
+      .mockResolvedValue("1 0");
+    await expect(
+      waitForPaneSettled("%0", { tmux: fakeTmux({ displayMessage }), pollMs: 1 }),
+    ).resolves.toEqual({ settled: true, exitCode: 0 });
+    expect(displayMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it("treats a dead pane with no readable status as exit 0", async () => {
+    const tmux = fakeTmux({ displayMessage: vi.fn().mockResolvedValue("1 ") });
+    await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
+      settled: true,
+      exitCode: 0,
+    });
+  });
+
+  it("reports 'gone' when the pane or its session disappeared", async () => {
+    const tmux = fakeTmux({
+      displayMessage: vi.fn().mockRejectedValue(new Error("can't find pane")),
+    });
+    await expect(waitForPaneSettled("%0", { tmux, pollMs: 1 })).resolves.toEqual({
+      settled: false,
+      reason: "gone",
+    });
+  });
+
+  it("gives up at the deadline while the pane is still alive", async () => {
+    const tmux = fakeTmux();
+    await expect(waitForPaneSettled("%0", { tmux, pollMs: 1, timeoutMs: 30 })).resolves.toEqual({
+      settled: false,
+      reason: "timeout",
+    });
+    expect(tmux.displayMessage).toHaveBeenCalled();
+  });
+});

--- a/test/lib/managed-tmux.test.ts
+++ b/test/lib/managed-tmux.test.ts
@@ -152,13 +152,15 @@ describe("argv builders", () => {
     expect(args.join(" ")).toContain("-e ZAPS_MANAGED_TMUX=1 -e XDG_RUNTIME_DIR=/run/user/1000 --");
   });
 
-  it("builds the attach invocation", () => {
+  it("builds the attach invocation with an exact-match target", () => {
     expect(buildAttachArgs("zaps-app-abc123")).toEqual([
       "-L",
       "zaps",
       "attach-session",
       "-t",
-      "zaps-app-abc123",
+      // `=`: tmux prefix-matches session targets, so a bare name could attach to
+      // `zaps-app-abc123-notes` once the exact session is gone.
+      "=zaps-app-abc123",
     ]);
   });
 
@@ -195,7 +197,7 @@ describe("argv builders", () => {
       "zaps",
       "new-window",
       "-t",
-      "zaps-app-abc123",
+      "=zaps-app-abc123",
       "--",
       "zaps",
       "attach",
@@ -207,8 +209,10 @@ describe("argv builders", () => {
       "-L",
       "zaps",
       "set-option",
+      // `=name:` — `set-option` rejects a bare `=name` and prefix-matches a
+      // Bare name; the trailing colon makes it an exact session target.
       "-t",
-      "zaps-app-abc123",
+      "=zaps-app-abc123:",
       "destroy-unattached",
       "off",
     ]);

--- a/test/lib/port.test.ts
+++ b/test/lib/port.test.ts
@@ -292,7 +292,7 @@ describe("detectPorts", () => {
       };
     });
 
-    const result = await detectPorts("%0");
+    const result = await detectPorts("%0", { panePid: mockPanePid });
     expect(result).toEqual([3000, 5432]);
   });
 });

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -33,6 +33,7 @@ function createMockDeps(): ServiceManagerDeps {
     setWindowOption: vi.fn<ServiceManagerDeps["setWindowOption"]>().mockResolvedValue(),
     exec: vi.fn<ServiceManagerDeps["exec"]>().mockResolvedValue(),
     preflightPorts: vi.fn<ServiceManagerDeps["preflightPorts"]>().mockResolvedValue(null),
+    displayPopup: vi.fn<ServiceManagerDeps["displayPopup"]>().mockResolvedValue(),
     storeExecInfo: vi.fn(),
     sessionId: "test-session-id",
     zapsCommand: "zaps",

--- a/test/lib/service/manager.test.ts
+++ b/test/lib/service/manager.test.ts
@@ -2117,6 +2117,31 @@ describe("bindActions", () => {
     ]);
   });
 
+  it("runs popup tasks on the injected (session-bound) tmux socket", async () => {
+    let capturedActions: LibraryActions | undefined;
+    const config = makeConfig({ db: { start: "start-db" } });
+    config.project.tasks = {
+      seed: { name: "Seed", popup: true, commands: "echo seed" },
+    };
+    config.bindActions = (actions) => {
+      capturedActions = actions;
+    };
+
+    const displayPopup = vi.fn().mockResolvedValue(undefined);
+    const deps = { ...createMockDeps(), displayPopup };
+    const mgr = new ServiceManager(config, makePaneMap(["db"]), deps, "test-session");
+    expect(mgr).toBeDefined();
+
+    if (!capturedActions) {
+      throw new Error("bindActions was not called");
+    }
+    await capturedActions.runTask("seed");
+
+    expect(displayPopup).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Seed", command: expect.stringContaining("echo seed") }),
+    );
+  });
+
   it("emits taskComplete with error when runTask fails", async () => {
     let capturedActions: LibraryActions | undefined;
     const config = makeConfig({

--- a/test/lib/tmux-layout.test.ts
+++ b/test/lib/tmux-layout.test.ts
@@ -25,6 +25,9 @@ import { killPane, splitPane } from "../../src/lib/tmux.js";
 const mockSplitPane = vi.mocked(splitPane);
 const mockKillPane = vi.mocked(killPane);
 
+/** Layout builds take an explicit socket-bound handle; here it is the mocked module. */
+const tmuxStub = { splitPane: mockSplitPane, killPane: mockKillPane };
+
 let paneCounter = 0;
 
 beforeEach(() => {
@@ -45,7 +48,9 @@ describe("createLayout", () => {
       api: { start: "npm start" },
     };
 
-    const { paneMap } = await createLayout("%0", undefined, services);
+    const { paneMap } = await createLayout("%0", undefined, services, undefined, {
+      tmux: tmuxStub,
+    });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.db).toBe("%1");
@@ -59,7 +64,9 @@ describe("createLayout", () => {
       api: { start: "npm start" },
     };
 
-    const { paneMap } = await createLayout("%0", undefined, services);
+    const { paneMap } = await createLayout("%0", undefined, services, undefined, {
+      tmux: tmuxStub,
+    });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.api).toBe("%1");
@@ -80,7 +87,7 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.api).toBe("%1");
@@ -110,7 +117,7 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     expect(paneMap["@tui"]).toBe("%0");
     // First split creates %1 for the right column
@@ -135,7 +142,7 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.api).toBe("%1");
@@ -161,7 +168,7 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.api).toBe("%1");
@@ -179,7 +186,7 @@ describe("createLayout", () => {
       children: [{ pane: "@tui", size: "60%" }, { pane: "api" }],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     expect(paneMap["@tui"]).toBe("%0");
     expect(paneMap.api).toBe("%1");
@@ -202,7 +209,9 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap, focusPane } = await createLayout("%0", layout, services);
+    const { paneMap, focusPane } = await createLayout("%0", layout, services, undefined, {
+      tmux: tmuxStub,
+    });
 
     expect(paneMap.api).toBe("%1");
     expect(focusPane).toBe("%1");
@@ -221,7 +230,9 @@ describe("createLayout", () => {
       ],
     };
 
-    const { paneMap, focusPane } = await createLayout("%0", layout, services);
+    const { paneMap, focusPane } = await createLayout("%0", layout, services, undefined, {
+      tmux: tmuxStub,
+    });
 
     expect(focusPane).toBe(paneMap["@tui"]);
   });
@@ -231,7 +242,9 @@ describe("createLayout", () => {
       api: { start: "npm start" },
     };
 
-    const { paneMap, focusPane } = await createLayout("%0", undefined, services);
+    const { paneMap, focusPane } = await createLayout("%0", undefined, services, undefined, {
+      tmux: tmuxStub,
+    });
 
     expect(focusPane).toBe(paneMap["@tui"]);
   });
@@ -243,7 +256,7 @@ describe("createLayout", () => {
       children: [{ pane: "api" }, { pane: "@tui" }],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services);
+    const { paneMap } = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
 
     // Free mode keeps today's behavior: first leaf inherits the start pane.
     expect(paneMap.api).toBe("%0");
@@ -259,6 +272,7 @@ describe("createLayout", () => {
 
     const { paneMap } = await createLayout("%0", layout, services, undefined, {
       reserveTuiPane: true,
+      tmux: tmuxStub,
     });
 
     // The TUI pane (start pane) is never handed to a service on reload (A2).
@@ -275,6 +289,7 @@ describe("createLayout", () => {
 
     const { paneMap } = await createLayout("%0", layout, services, undefined, {
       reserveTuiPane: true,
+      tmux: tmuxStub,
     });
 
     expect(paneMap["@tui"]).toBe("%0");
@@ -297,7 +312,9 @@ describe("createLayout", () => {
       throw new Error("tmux split failed");
     });
 
-    await expect(createLayout("%0", undefined, services)).rejects.toThrow("tmux split failed");
+    await expect(
+      createLayout("%0", undefined, services, undefined, { tmux: tmuxStub }),
+    ).rejects.toThrow("tmux split failed");
 
     // The one pane created before the failure is cleaned up (best-effort).
     expect(mockKillPane).toHaveBeenCalledTimes(1);
@@ -312,7 +329,7 @@ describe("createLayout", () => {
       children: [{ pane: "@tui" }, { pane: "api" }],
     };
 
-    const { paneMap } = await createLayout("%0", layout, services, groups);
+    const { paneMap } = await createLayout("%0", layout, services, groups, { tmux: tmuxStub });
 
     // One shared pane for the whole group; every member maps to it.
     expect(paneMap.dbgroup).toBe("%2");
@@ -335,6 +352,7 @@ describe("createLayout", () => {
 
       const { paneMap } = await createLayout("%0", layout, services, undefined, {
         skip: new Set(["worker"]),
+        tmux: tmuxStub,
       });
 
       expect(paneMap["@tui"]).toBeDefined();
@@ -350,6 +368,7 @@ describe("createLayout", () => {
 
       const { paneMap } = await createLayout("%0", undefined, services, undefined, {
         skip: new Set(["worker"]),
+        tmux: tmuxStub,
       });
 
       expect(paneMap["@tui"]).toBe("%0");
@@ -376,6 +395,7 @@ describe("createLayout", () => {
       const { paneMap } = await createLayout("%0", layout, services, undefined, {
         skip: new Set(["worker"]),
         reserveTuiPane: true,
+        tmux: tmuxStub,
       });
 
       // @tui maps to the start pane (the SURVIVING first leaf in the filtered
@@ -398,13 +418,14 @@ describe("createLayout", () => {
         children: [{ pane: "@tui" }, { pane: "api" }, { pane: "worker" }],
       };
 
-      const ref = await createLayout("%0", layout, services);
+      const ref = await createLayout("%0", layout, services, undefined, { tmux: tmuxStub });
       paneCounter = 0;
       vi.clearAllMocks();
       mockSplitPane.mockImplementation(async () => `%${(paneCounter += 1)}`);
       mockKillPane.mockResolvedValue(undefined);
       const withEmptySkip = await createLayout("%0", layout, services, undefined, {
         skip: new Set<string>(),
+        tmux: tmuxStub,
       });
 
       expect(withEmptySkip.paneMap).toEqual(ref.paneMap);
@@ -423,6 +444,7 @@ describe("createLayout", () => {
 
       const { paneMap, focusPane } = await createLayout("%0", layout, services, undefined, {
         skip: new Set(["worker"]),
+        tmux: tmuxStub,
       });
 
       // Worker was the declared focus target but it's skipped → fallback @tui.
@@ -456,6 +478,7 @@ describe("createLayout", () => {
 
       const { paneMap } = await createLayout("%0", layout, services, undefined, {
         skip: new Set(["rainfrog", "mailtrap"]),
+        tmux: tmuxStub,
       });
 
       expect(paneMap["@tui"]).toBe("%0");
@@ -484,9 +507,7 @@ describe("createLayout", () => {
       };
 
       await expect(
-        createLayout("%0", layout, services, undefined, {
-          skip: new Set(["api"]),
-        }),
+        createLayout("%0", layout, services, undefined, { skip: new Set(["api"]), tmux: tmuxStub }),
       ).rejects.toThrow(/every layout leaf is skipped/);
     });
   });

--- a/test/lib/tmux-missing.test.ts
+++ b/test/lib/tmux-missing.test.ts
@@ -1,0 +1,77 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+
+import { spawn } from "node:child_process";
+
+import { decideTmuxContext } from "../../src/cli/tmux-context.js";
+import { tmuxAvailable } from "../../src/lib/managed-tmux.js";
+import { tmuxFor } from "../../src/lib/tmux.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+/**
+ * A spawn that fails the way a missing binary does: no `close`, just an `error`
+ * event. Node kills the process over an unhandled one, which is exactly how the
+ * "tmux not installed" path used to crash instead of printing its message.
+ */
+function createEnoentProc(): ChildProcess {
+  const proc = new EventEmitter() as unknown as ChildProcess;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  setTimeout(() => {
+    const error = Object.assign(new Error("spawn tmux ENOENT"), { code: "ENOENT" });
+    proc.emit("error", error);
+  }, 0);
+  return proc;
+}
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  mockSpawn.mockImplementation(() => createEnoentProc());
+});
+
+describe("tmux binary missing", () => {
+  it("rejects the command instead of crashing the process", async () => {
+    await expect(tmuxFor("zaps").currentPaneId()).rejects.toThrow("ENOENT");
+  });
+
+  it("rejects display-popup too (it spawns without a pipe)", async () => {
+    await expect(tmuxFor("zaps").displayPopup({ command: "echo hi" })).rejects.toThrow("ENOENT");
+  });
+
+  it("lets callers that swallow tmux errors keep working", async () => {
+    await expect(tmuxFor("zaps").hasSession("whatever")).resolves.toBe(false);
+    await expect(tmuxFor("zaps").tmuxVersion()).resolves.toBeNull();
+  });
+
+  it("reports the tmux gate as 'missing' rather than throwing (F8)", async () => {
+    await expect(tmuxAvailable(tmuxFor("zaps"))).resolves.toEqual({
+      ok: false,
+      reason: "missing",
+    });
+  });
+
+  it("ends in the friendly install message, not a stack trace (F8)", async () => {
+    // The whole user-visible chain: no tmux on PATH → gate → decision → text.
+    const availability = await tmuxAvailable(tmuxFor("zaps"));
+    const decision = decideTmuxContext({
+      tmuxEnv: undefined,
+      autoTmuxEnv: undefined,
+      detach: false,
+      tmuxAvailability: availability,
+      daemonSession: undefined,
+      managedName: "zaps-app-abc123abc123",
+      managedSessionExists: false,
+    });
+    expect(decision.kind).toBe("error-no-tmux");
+    const { message } = decision as { message: string };
+    expect(message).toContain("zaps requires tmux (>= 3.5a) — install it and re-run.");
+    expect(message).toContain("https://github.com/tmux/tmux/wiki/Installing");
+    expect(message).not.toContain("ENOENT");
+  });
+});

--- a/test/lib/tmux-missing.test.ts
+++ b/test/lib/tmux-missing.test.ts
@@ -65,6 +65,7 @@ describe("tmux binary missing", () => {
       detach: false,
       tmuxAvailability: availability,
       daemonSession: undefined,
+      currentTmuxSession: undefined,
       managedName: "zaps-app-abc123abc123",
       managedSessionExists: false,
     });

--- a/test/lib/tmux-missing.test.ts
+++ b/test/lib/tmux-missing.test.ts
@@ -71,7 +71,7 @@ describe("tmux binary missing", () => {
     });
     expect(decision.kind).toBe("error-no-tmux");
     const { message } = decision as { message: string };
-    expect(message).toContain("zaps requires tmux (>= 3.5a) — install it and re-run.");
+    expect(message).toContain("zaps requires tmux (>= 3.5) — install it and re-run.");
     expect(message).toContain("https://github.com/tmux/tmux/wiki/Installing");
     expect(message).not.toContain("ENOENT");
   });

--- a/test/lib/tmux-reflow.test.ts
+++ b/test/lib/tmux-reflow.test.ts
@@ -44,6 +44,7 @@ function makeReflow(
   extra: Partial<LayoutReflowDeps> = {},
 ): { reflow: LayoutReflow; deps: LayoutReflowDeps } {
   const deps: LayoutReflowDeps = {
+    tmux,
     getLayout: () => layout,
     getPaneMap: () => paneMap,
     getWindowTarget: () => "@0",
@@ -210,6 +211,7 @@ describe("LayoutReflow — live getters survive Session._reload's paneMap reassi
 
     const tmux = makeFakeTmux(["%1", "%2"]); // First call.
     const reflow = new LayoutReflow({
+      tmux,
       getLayout: () => layout,
       getPaneMap: () => live, // Live getter — survives reassignment.
       getWindowTarget: () => "@0",
@@ -254,6 +256,7 @@ describe("LayoutReflow — live getters survive Session._reload's paneMap reassi
     let live = oldLayout;
     const tmux = makeFakeTmux(["%1", "%2"]);
     const reflow = new LayoutReflow({
+      tmux,
       getLayout: () => live,
       getPaneMap: () => ({ "@tui": "%1", api: "%2" }),
       getWindowTarget: () => "@0",

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -82,7 +82,8 @@ describe("hasSession", () => {
   it("returns true when session exists", async () => {
     mockSpawn.mockReturnValue(createMockProc(""));
     expect(await hasSession("my-sess")).toBe(true);
-    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["has-session", "-t", "my-sess"], {
+    // `=` forces exact matching; a bare name would prefix-match a neighbour.
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["has-session", "-t", "=my-sess"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
   });
@@ -132,7 +133,7 @@ describe("newWindow", () => {
     expect(paneId).toBe("%3");
     expect(mockSpawn).toHaveBeenCalledWith(
       "tmux",
-      ["new-window", "-t", "my-project", "-d", "-P", "-F", "#{pane_id}"],
+      ["new-window", "-t", "=my-project", "-d", "-P", "-F", "#{pane_id}"],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
   });
@@ -142,7 +143,7 @@ describe("killSession", () => {
   it("kills session by name", async () => {
     mockSpawn.mockReturnValue(createMockProc(""));
     await killSession("my-project");
-    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["kill-session", "-t", "my-project"], {
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["kill-session", "-t", "=my-project"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
   });
@@ -325,7 +326,7 @@ describe("setEnv", () => {
     await setEnv("my-project", "FOO", "bar");
     expect(mockSpawn).toHaveBeenCalledWith(
       "tmux",
-      ["set-environment", "-t", "my-project", "FOO", "bar"],
+      ["set-environment", "-t", "=my-project", "FOO", "bar"],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
   });
@@ -337,7 +338,7 @@ describe("removeEnv", () => {
     await removeEnv("my-project", "FOO");
     expect(mockSpawn).toHaveBeenCalledWith(
       "tmux",
-      ["set-environment", "-u", "-t", "my-project", "FOO"],
+      ["set-environment", "-u", "-t", "=my-project", "FOO"],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
   });
@@ -467,7 +468,7 @@ describe("listPanes", () => {
       [
         "list-panes",
         "-t",
-        "my-project",
+        "=my-project",
         "-F",
         "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}:#{pane_dead}",
       ],

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock child_process.spawn before importing tmux
 vi.mock("node:child_process", () => ({
@@ -43,6 +43,7 @@ import {
   selectLayout,
   windowLayout,
   paneIndexOrder,
+  tmuxFor,
 } from "../../src/lib/tmux.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -618,5 +619,73 @@ describe("resyncPaneSizes", () => {
   it("swallows errors so startup is never blocked", async () => {
     mockSpawn.mockImplementation(() => createMockProc("", 1, "boom"));
     await expect(resyncPaneSizes("%7", 0)).resolves.toBeUndefined();
+  });
+});
+
+describe("tmuxFor", () => {
+  const originalSocket = process.env.ZAPS_TMUX_SOCKET;
+
+  afterEach(() => {
+    if (originalSocket === undefined) {
+      delete process.env.ZAPS_TMUX_SOCKET;
+    } else {
+      process.env.ZAPS_TMUX_SOCKET = originalSocket;
+    }
+  });
+
+  it("prefixes every command with -L <socket>", async () => {
+    mockSpawn.mockReturnValue(createMockProc("%3"));
+    const tmux = tmuxFor("foo");
+    await tmux.splitPane("%0", "v");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["-L", "foo", "split-window", "-v", "-t", "%0", "-P", "-F", "#{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("targets the default server (no -L) for a null socket", async () => {
+    process.env.ZAPS_TMUX_SOCKET = "ignored";
+    mockSpawn.mockReturnValue(createMockProc("%0"));
+    await tmuxFor(null).currentPaneId();
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["display-message", "-p", "#{pane_id}"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  });
+
+  it("ignores ZAPS_TMUX_SOCKET — the bound socket wins", async () => {
+    process.env.ZAPS_TMUX_SOCKET = "env-socket";
+    mockSpawn.mockReturnValue(createMockProc(""));
+    await tmuxFor("bound").killPane("%1");
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["-L", "bound", "kill-pane", "-t", "%1"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  });
+
+  it("binds the socket for display-popup too", async () => {
+    mockSpawn.mockReturnValue(createSilentMockProc());
+    await tmuxFor("zaps").displayPopup({ command: "echo hi" });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["-L", "zaps", "display-popup", "-EE", "--", "echo hi"],
+      { stdio: "ignore" },
+    );
+  });
+
+  it("module-level exports read ZAPS_TMUX_SOCKET per call", async () => {
+    process.env.ZAPS_TMUX_SOCKET = "first";
+    mockSpawn.mockImplementation(() => createMockProc(""));
+    await killPane("%1");
+    process.env.ZAPS_TMUX_SOCKET = "second";
+    await killPane("%2");
+    delete process.env.ZAPS_TMUX_SOCKET;
+    await killPane("%3");
+
+    const calls = mockSpawn.mock.calls.map((c) => (c[1] as string[]).join(" "));
+    expect(calls).toEqual([
+      "-L first kill-pane -t %1",
+      "-L second kill-pane -t %2",
+      "kill-pane -t %3",
+    ]);
   });
 });

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -12,6 +12,7 @@ vi.mock("node:child_process", () => ({
 import { spawn } from "node:child_process";
 
 import {
+  exactWindowTarget,
   hasSession,
   sendKeys,
   newSession,
@@ -76,6 +77,17 @@ function createSilentMockProc(exitCode = 0): ChildProcess {
 
 beforeEach(() => {
   mockSpawn.mockReset();
+});
+
+describe("exactWindowTarget", () => {
+  // Window-scoped commands (`display-message`, `select-layout`, `resize-window`,
+  // `set-option`/`show-options`) need `=name:`. Verified against live tmux: a
+  // Bare `=name` makes `display-message` return an empty string, `select-layout`
+  // Fail, and `show-options` error with "no such session: =name" — while a bare
+  // `name` prefix-matches a longer-named neighbour.
+  it("marks the session exact and scopes to its current window", () => {
+    expect(exactWindowTarget("zaps-app-a1")).toBe("=zaps-app-a1:");
+  });
 });
 
 describe("hasSession", () => {

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -625,10 +625,12 @@ describe("resyncPaneSizes", () => {
 });
 
 describe("detachClient", () => {
-  it("detaches the client owning the target pane", async () => {
+  it("detaches the current client, resolved by tmux from $TMUX", async () => {
     mockSpawn.mockReturnValue(createMockProc(""));
-    await detachClient("%7");
-    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["detach-client", "-t", "%7"], {
+    await detachClient();
+    // Never `-t <pane>`: detach-client's target is a client tty, and a pane id
+    // Fails outright (`can't find client: %N`), silently skipping the detach.
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["detach-client"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
   });

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -44,6 +44,7 @@ import {
   windowLayout,
   paneIndexOrder,
   tmuxFor,
+  detachClient,
 } from "../../src/lib/tmux.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -454,11 +455,12 @@ describe("selectPane", () => {
 
 describe("listPanes", () => {
   it("parses pane info from output", async () => {
-    mockSpawn.mockReturnValue(createMockProc("%0:1234:120:40\n%1:5678:60:20"));
+    mockSpawn.mockReturnValue(createMockProc("%0:1234:120:40:0\n%1:5678:60:20:1"));
     const panes = await listPanes("my-project");
     expect(panes).toEqual([
-      { id: "%0", pid: 1234, width: 120, height: 40 },
-      { id: "%1", pid: 5678, width: 60, height: 20 },
+      { id: "%0", pid: 1234, width: 120, height: 40, dead: false },
+      // `dead` is what the re-attach path reads to decide whether to respawn.
+      { id: "%1", pid: 5678, width: 60, height: 20, dead: true },
     ]);
     expect(mockSpawn).toHaveBeenCalledWith(
       "tmux",
@@ -467,7 +469,7 @@ describe("listPanes", () => {
         "-t",
         "my-project",
         "-F",
-        "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}",
+        "#{pane_id}:#{pane_pid}:#{pane_width}:#{pane_height}:#{pane_dead}",
       ],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
@@ -619,6 +621,16 @@ describe("resyncPaneSizes", () => {
   it("swallows errors so startup is never blocked", async () => {
     mockSpawn.mockImplementation(() => createMockProc("", 1, "boom"));
     await expect(resyncPaneSizes("%7", 0)).resolves.toBeUndefined();
+  });
+});
+
+describe("detachClient", () => {
+  it("detaches the client owning the target pane", async () => {
+    mockSpawn.mockReturnValue(createMockProc(""));
+    await detachClient("%7");
+    expect(mockSpawn).toHaveBeenCalledWith("tmux", ["detach-client", "-t", "%7"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
   });
 });
 


### PR DESCRIPTION
## What

Running `zaps`, `zaps up`, or `zaps up -d` outside tmux no longer fails with "zaps must be run from inside a tmux session". Instead zaps starts a managed tmux session on its own server socket (`tmux -L zaps`), runs itself inside it, and attaches your terminal. You never have to know tmux exists:

- `q` detaches back to your plain shell, services keep running. `zaps` re-attaches, reviving the TUI pane in place.
- `Ctrl-D` or `d` in the dashboard asks `Shut down session?`; `y` stops the services and removes the tmux session. `zaps down` from the shell does the same. The tmux server exits on its own once its last session is gone.
- `zaps ls` shows where each session lives (LOCATION column, `(managed)` suffix).
- Cross-context conflicts refuse with a copy-pasteable resolution instead of doing something surprising, for example `tmux -L zaps attach -t =<name>` when the session lives in a managed tmux you are not in.
- `ZAPS_AUTO_TMUX=0` restores the old error.

Sessions run inside tmux the way they always did, and a personal tmux setup is untouched: the managed server is a separate socket, teardown targets sessions by exact name (`=<name>`, since tmux otherwise prefix-matches and can hit a sibling), and `kill-server` is never issued.

## Why

People who don't use tmux couldn't use zaps at all; the old error told them to learn tmux first. This makes the tmux layer an implementation detail while keeping the full detach/re-attach workflow for everyone else.

Two defects found on the way are fixed here because this feature made them reachable: a missing error listener crashed zaps with a raw ENOENT stack when tmux wasn't installed, and a client attaching with stdin at EOF (CI, agent shells, `script </dev/null`) delivered a VEOF byte into the pane that Ink read as Ctrl-D, silently destroying the session and every service in it. The shutdown confirmation exists because of that second one: no single stray byte may be able to stop everything.
