### PR TITLE
fix(tmux): pin sessions to launch window

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -331,7 +331,7 @@ async function upFlow(detach?: boolean): Promise<void> {
   // Outside tmux we never get here: `upCommand` bootstraps a managed session
   // First and only falls through once `$TMUX` is set.
   const originPane = await currentPaneId();
-  const tmuxSession = await currentSession();
+  const tmuxSession = await currentSession(originPane);
 
   const zapsCommand = resolveCommand();
   const sock = await ensureDaemon(resolveCommandArgv());

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -197,6 +197,7 @@ class DaemonServer implements SessionStore {
 
     // Load config
     const config = await loadConfig(params.configPath, params.projectDir);
+    const tmuxWindow = await tmux.displayMessage(params.originPane, "#{window_id}");
 
     // Build pane layout. Boot-skip the pane for any service that is lazy
     // (P04-T02 resolved `lazyPaneByService`) AND won't autostart
@@ -278,6 +279,7 @@ class DaemonServer implements SessionStore {
       config,
       paneMap,
       tmuxSession: params.tmuxSession,
+      tmuxWindow,
       originPane: params.originPane,
       deps,
       tmuxSocket,

--- a/src/daemon/session.ts
+++ b/src/daemon/session.ts
@@ -12,7 +12,7 @@ import type { PaneRunInfo } from "#src/lib/task/run-in-pane.js";
 import { getTaskShortcuts } from "#src/lib/taskShortcuts.js";
 import { createLayout } from "#src/lib/tmux-layout.js";
 import { LayoutReflow } from "#src/lib/tmux-reflow.js";
-import { exactWindowTarget, tmuxFor } from "#src/lib/tmux.js";
+import { tmuxFor } from "#src/lib/tmux.js";
 import type { TmuxHandle } from "#src/lib/tmux.js";
 
 import { LogBuffer } from "./log-buffer.js";
@@ -93,6 +93,7 @@ export interface SessionCreateParams {
   config: ResolvedConfig;
   paneMap: PaneMap;
   tmuxSession: string;
+  tmuxWindow: string;
   originPane: string;
   deps: ServiceManagerDeps;
   /** Tmux server socket hosting this session (`null` = the user's default server). */
@@ -110,6 +111,7 @@ export class Session {
   public readonly configPath: string;
   public readonly projectDir: string;
   public readonly tmuxSession: string;
+  public readonly tmuxWindow: string;
   public readonly originPane: string;
   public readonly subscribers = new Set<net.Socket>();
   public readonly createdAt = Date.now();
@@ -183,6 +185,7 @@ export class Session {
     this.config = params.config;
     this.paneMap = params.paneMap;
     this.tmuxSession = params.tmuxSession;
+    this.tmuxWindow = params.tmuxWindow;
     this.originPane = params.originPane;
     this.deps = params.deps;
     this.tmuxSocket = params.tmuxSocket;
@@ -207,10 +210,7 @@ export class Session {
       tmux: this.tmux,
       getLayout: () => this.config.project.layout,
       getPaneMap: () => this.paneMap,
-      // `=name:` — exact session, its current window: every geometry command
-      // The reflow issues is window-scoped, and a bare name would prefix-match
-      // A longer-named session on the same server.
-      getWindowTarget: () => exactWindowTarget(this.tmuxSession),
+      getWindowTarget: () => this.tmuxWindow,
       onPaneInserted: (name, paneId) => {
         this.allocatePaneLog(name, paneId);
         // Lazy panes are created/destroyed after the TUI captured its startup

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -99,7 +99,13 @@ function createTmux(resolveSocket: () => string | null) {
   }
 
   async function currentPaneId(): Promise<string> {
-    return run(["display-message", "-p", "#{pane_id}"]);
+    const args = ["display-message", "-p"];
+    const inheritedPane = getEnv("TMUX_PANE");
+    if (inheritedPane) {
+      args.push("-t", inheritedPane);
+    }
+    args.push("#{pane_id}");
+    return run(args);
   }
 
   /**
@@ -110,8 +116,13 @@ function createTmux(resolveSocket: () => string | null) {
     return run(["display-message", "-p", "-t", target, format]);
   }
 
-  async function currentSession(): Promise<string> {
-    return run(["display-message", "-p", "#{session_name}"]);
+  async function currentSession(target?: string): Promise<string> {
+    const args = ["display-message", "-p"];
+    if (target) {
+      args.push("-t", target);
+    }
+    args.push("#{session_name}");
+    return run(args);
   }
 
   async function showEnv(session: string, key: string): Promise<string | null> {

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -76,6 +76,7 @@ vi.mock("#src/lib/tmux.js", () => {
     getWindowName: vi.fn(),
     getWindowOption: vi.fn(),
     setWindowOption: vi.fn(),
+    displayMessage: vi.fn(),
     displayPopup: vi.fn(),
     resyncPaneSizes: vi.fn(),
     // LayoutReflow (constructed by Session) uses these too.
@@ -142,6 +143,7 @@ describe("DaemonServer", () => {
     tmux.getWindowName.mockResolvedValue("bash");
     tmux.getWindowOption.mockResolvedValue("on");
     tmux.setWindowOption.mockResolvedValue(undefined);
+    tmux.displayMessage.mockResolvedValue("@1");
     server = new DaemonServer();
   });
 
@@ -192,6 +194,8 @@ describe("DaemonServer", () => {
       originPane: "%0",
     });
     expect(session.id).toBeDefined();
+    expect(session.tmuxWindow).toBe("@1");
+    expect(tmux.displayMessage).toHaveBeenCalledWith("%0", "#{window_id}");
     expect(server.sessionCount).toBe(1);
     expect(server.get(session.id)).toBe(session);
   });
@@ -343,7 +347,10 @@ describe("DaemonServer", () => {
     };
     const s1 = await server.create(params);
     tmux.paneExists.mockResolvedValue(true);
-    await expect(server.create(params)).resolves.toBe(s1);
+    await expect(server.create({ ...params, originPane: "%9" })).resolves.toBe(s1);
+    expect(s1.originPane).toBe("%0");
+    expect(s1.tmuxWindow).toBe("@1");
+    expect(tmux.displayMessage).toHaveBeenCalledTimes(1);
   });
 
   it("destroys and rebuilds when the cached @tui pane is dead (A4)", async () => {
@@ -358,10 +365,13 @@ describe("DaemonServer", () => {
 
     // The window was closed externally — next create rebuilds with the new pane.
     tmux.paneExists.mockResolvedValue(false);
+    tmux.displayMessage.mockResolvedValueOnce("@9");
     const s2 = await server.create({ ...params, originPane: "%9" });
 
     expect(s2).not.toBe(s1);
     expect(s1.destroyed).toBe(true);
+    expect(s2.originPane).toBe("%9");
+    expect(s2.tmuxWindow).toBe("@9");
     expect(server.sessionCount).toBe(1);
     expect(mockCreateLayout).toHaveBeenCalledTimes(2);
   });

--- a/test/daemon/session.test.ts
+++ b/test/daemon/session.test.ts
@@ -86,6 +86,7 @@ function createSessionParams(overrides?: Partial<SessionCreateParams>): SessionC
     } as SessionCreateParams["config"],
     paneMap: { "@tui": "%0", api: "%1" },
     tmuxSession: "main",
+    tmuxWindow: "@1",
     originPane: "%0",
     deps: {
       capturePane: vi.fn().mockResolvedValue(""),
@@ -846,15 +847,11 @@ describe("Session.reflow — wired with live-getter deps", () => {
     expect(session.reflow).toBe(beforeReflow);
   });
 
-  // Every geometry command the reflow issues is WINDOW-scoped, and tmux matches
-  // Targets exact → prefix → fnmatch: a bare `main` would drive `main-notes`'s
-  // Window on the same server. `=main:` is the only form all four commands
-  // Accept — a bare `=main` makes `display-message` return empty and
-  // `select-layout` fail outright (verified against live tmux).
-  it("targets the session's own window exactly (`=name:`)", async () => {
+  it("targets the stored tmux window", async () => {
     const session = new Session(
       createSessionParams({
         tmuxSession: "zaps-app-a1",
+        tmuxWindow: "@7",
         paneMap: { "@tui": "%0", api: "%1" },
         config: {
           project: {
@@ -882,9 +879,9 @@ describe("Session.reflow — wired with live-getter deps", () => {
 
     // One getter feeds every window-scoped call site (incl. insert/remove's
     // `windowLayout` snapshot), so pinning the geometry path pins them all.
-    expect(tmux.getWindowSize).toHaveBeenCalledWith("=zaps-app-a1:");
-    expect(tmux.paneIndexOrder).toHaveBeenCalledWith("=zaps-app-a1:");
-    expect(tmux.selectLayout).toHaveBeenCalledWith("=zaps-app-a1:", expect.any(String));
+    expect(tmux.getWindowSize).toHaveBeenCalledWith("@7");
+    expect(tmux.paneIndexOrder).toHaveBeenCalledWith("@7");
+    expect(tmux.selectLayout).toHaveBeenCalledWith("@7", expect.any(String));
   });
 });
 

--- a/test/integration/daemon/log-fanout.test.ts
+++ b/test/integration/daemon/log-fanout.test.ts
@@ -77,6 +77,7 @@ describe.skipIf(!hasTmux())("combined-pane log fan-out (D2)", () => {
       config,
       paneMap,
       tmuxSession: tmux.name,
+      tmuxWindow: tmux.initialPaneId,
       originPane: tmux.initialPaneId,
       tmuxSocket: testTmuxSocket(),
       managedTmux: false,

--- a/test/integration/tmux/context.test.ts
+++ b/test/integration/tmux/context.test.ts
@@ -1,0 +1,42 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getEnv } from "#src/lib/env.js";
+import { currentPaneId, currentSession, newWindow } from "#src/lib/tmux.js";
+
+import { hasTmux } from "../helpers/skip.js";
+import type { TestSession } from "../helpers/tmux.js";
+import { createTestSession } from "../helpers/tmux.js";
+
+const execFileAsync = promisify(execFile);
+
+function tmuxSocketArgs(): string[] {
+  const socket = getEnv("ZAPS_TMUX_SOCKET");
+  return socket ? ["-L", socket] : [];
+}
+
+describe.skipIf(!hasTmux())("tmux launch context", () => {
+  let session: TestSession;
+
+  beforeEach(async () => {
+    session = await createTestSession();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await session.cleanup();
+  });
+
+  it("keeps the launching pane after the current window changes", async () => {
+    const otherPane = await newWindow(session.name);
+    vi.stubEnv("TMUX_PANE", session.initialPaneId);
+
+    await execFileAsync("tmux", [...tmuxSocketArgs(), "select-window", "-t", otherPane]);
+
+    const originPane = await currentPaneId();
+    expect(originPane).toBe(session.initialPaneId);
+    expect(await currentSession(originPane)).toBe(session.name);
+  });
+});

--- a/test/integration/tmux/insert-remove.test.ts
+++ b/test/integration/tmux/insert-remove.test.ts
@@ -15,7 +15,9 @@ import type { LayoutReflowDeps, PaneMap } from "#src/lib/tmux-reflow.js";
 import { LayoutReflow, TmuxFailedError } from "#src/lib/tmux-reflow.js";
 import {
   capturePane,
+  displayMessage,
   getWindowSize,
+  newWindow,
   paneIndexOrder,
   sendKeys,
   splitPane,
@@ -169,6 +171,7 @@ function makeSession(
   initialPaneId: string,
   config: ResolvedConfig,
   paneMap: PaneMap,
+  tmuxWindow = initialPaneId,
 ): Session {
   const params: SessionCreateParams = {
     configPath: config.configPath,
@@ -176,6 +179,7 @@ function makeSession(
     config,
     paneMap,
     tmuxSession,
+    tmuxWindow,
     originPane: initialPaneId,
     tmuxSocket: testTmuxSocket(),
     managedTmux: false,
@@ -433,6 +437,26 @@ describe.skipIf(!hasTmux())("Session.reflow log lifecycle — real tmux", () => 
 
   afterEach(async () => {
     await session.cleanup();
+  });
+
+  it("inserts a lazy pane in the stored window after another window becomes current", async () => {
+    const layout: LayoutNode = {
+      direction: "columns",
+      children: [{ pane: "@tui" }, { pane: "api" }],
+    };
+    const config = makeConfig(["api"], layout);
+    const paneMap: PaneMap = { "@tui": session.initialPaneId };
+    const tmuxWindow = await displayMessage(session.initialPaneId, "#{window_id}");
+    const otherPane = await newWindow(session.name);
+    zapsSession = makeSession(session.name, session.initialPaneId, config, paneMap, tmuxWindow);
+
+    await execFileAsync("tmux", [...tmuxSocketArgs(), "select-window", "-t", otherPane]);
+    await zapsSession.reflow.insertPane("api");
+
+    const originalWindowPanes = await listPaneGeoms(tmuxWindow);
+    const otherWindowPanes = await listPaneGeoms(otherPane);
+    expect(originalWindowPanes.map(({ id }) => id)).toContain(zapsSession.paneMap.api);
+    expect(otherWindowPanes.map(({ id }) => id)).toEqual([otherPane]);
   });
 
   it("printed line in a lazily-inserted pane reaches its LogBuffer + broadcast", async () => {

--- a/test/integration/tmux/lifecycle.test.ts
+++ b/test/integration/tmux/lifecycle.test.ts
@@ -279,6 +279,7 @@ async function buildLiveSession(config: ResolvedConfig): Promise<LiveSession> {
     config,
     paneMap,
     tmuxSession: testSession.name,
+    tmuxWindow: testSession.initialPaneId,
     originPane: testSession.initialPaneId,
     tmuxSocket: testTmuxSocket(),
     managedTmux: false,

--- a/test/lib/tmux.test.ts
+++ b/test/lib/tmux.test.ts
@@ -79,6 +79,10 @@ beforeEach(() => {
   mockSpawn.mockReset();
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("exactWindowTarget", () => {
   // Window-scoped commands (`display-message`, `select-layout`, `resize-window`,
   // `set-option`/`show-options`) need `=name:`. Verified against live tmux: a
@@ -371,10 +375,22 @@ describe("showEnv", () => {
 });
 
 describe("currentPaneId", () => {
-  it("returns the pane id", async () => {
+  it("targets the process pane from TMUX_PANE", async () => {
+    vi.stubEnv("TMUX_PANE", "%5");
     mockSpawn.mockReturnValue(createMockProc("%5"));
     const id = await currentPaneId();
     expect(id).toBe("%5");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["display-message", "-p", "-t", "%5", "#{pane_id}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  });
+
+  it("falls back to the active pane without TMUX_PANE", async () => {
+    vi.stubEnv("TMUX_PANE", "");
+    mockSpawn.mockReturnValue(createMockProc("%7"));
+    expect(await currentPaneId()).toBe("%7");
     expect(mockSpawn).toHaveBeenCalledWith("tmux", ["display-message", "-p", "#{pane_id}"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -389,6 +405,16 @@ describe("currentSession", () => {
     expect(mockSpawn).toHaveBeenCalledWith("tmux", ["display-message", "-p", "#{session_name}"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
+  });
+
+  it("resolves the session from a stable pane target", async () => {
+    mockSpawn.mockReturnValue(createMockProc("my-session"));
+    expect(await currentSession("%5")).toBe("my-session");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "tmux",
+      ["display-message", "-p", "-t", "%5", "#{session_name}"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
   });
 });
 
@@ -673,6 +699,7 @@ describe("tmuxFor", () => {
 
   it("targets the default server (no -L) for a null socket", async () => {
     process.env.ZAPS_TMUX_SOCKET = "ignored";
+    vi.stubEnv("TMUX_PANE", "");
     mockSpawn.mockReturnValue(createMockProc("%0"));
     await tmuxFor(null).currentPaneId();
     expect(mockSpawn).toHaveBeenCalledWith("tmux", ["display-message", "-p", "#{pane_id}"], {


### PR DESCRIPTION
## Summary

- Resolve startup from the launching pane instead of the active tmux window.
- Store the original tmux window in the daemon session.
- Keep lazy pane insertion in that window after detach, reattach, or window changes.
- Rebuild against a new window only when the original TUI pane is gone.

## Test plan

- pnpm exec vitest run: 2053 passed
- affected tmux integration tests: 31 passed
- pnpm typecheck
- pnpm lint
- manual Fish test with an immediate tmux window switch